### PR TITLE
feat(apidom): embed AST nodes into parsed structures

### DIFF
--- a/apidom/package-lock.json
+++ b/apidom/package-lock.json
@@ -4182,9 +4182,9 @@
       "dev": true
     },
     "minim": {
-      "version": "0.23.6",
-      "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.6.tgz",
-      "integrity": "sha512-DblDp/6TZWAUtVAkzZwWz6SFamq9huwA/jzI1NCFYhBFddAdflUa1+9HBtHcr7jqkqnLvJ4FOeH7s2nmQrzarg==",
+      "version": "0.23.7",
+      "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.7.tgz",
+      "integrity": "sha512-XAp54ttzelevD/iN0U+N7I0clxrFw9n01Ou0ZGS3tuweXpzjfnFq2rDrqFeHqBoYUtpt/3vt1JFvBtPMc5KW/Q==",
       "requires": {
         "lodash": "^4.15.0"
       }

--- a/apidom/packages/apidom-parser-adapter-openapi3/src/parser/visitors/ApiDOM.js
+++ b/apidom/packages/apidom-parser-adapter-openapi3/src/parser/visitors/ApiDOM.js
@@ -1,4 +1,5 @@
 const { Visitor } = require('json-ast');
+
 const LiteralVisitor = require('./Literal');
 
 class ApiDOMVisitor extends Visitor {
@@ -8,14 +9,10 @@ class ApiDOMVisitor extends Visitor {
         this.result = null;
     }
 
-    toLiteral(node) {
-        const literalVisitor = new LiteralVisitor();
+    toElement(node) {
+        const literalVisitor = new LiteralVisitor(this.namespace);
         node.accept(literalVisitor);
-        const element = this.namespace.toElement(literalVisitor.result);
-        const sourceMap = new this.namespace.elements.SourceMap();
-        sourceMap.position = node.position;
-        element.meta.set('sourceMap', sourceMap);
-        return element;
+        return literalVisitor.result;
     }
 }
 

--- a/apidom/packages/apidom-parser-adapter-openapi3/src/parser/visitors/Info.js
+++ b/apidom/packages/apidom-parser-adapter-openapi3/src/parser/visitors/Info.js
@@ -23,8 +23,8 @@ class InfoVisitor extends ApiDOMVisitor {
 
     property(propertyNode) {
         if (propertyNode.value instanceof JsonString) {
-            const keyElement = this.toLiteral(propertyNode.key);
-            const valueElement = this.toLiteral(propertyNode.value);
+            const keyElement = this.toElement(propertyNode.key);
+            const valueElement = this.toElement(propertyNode.value);
             const { MemberElement } = this.namespace.elements.Element.prototype;
 
             this.result.push(new MemberElement(keyElement, valueElement));

--- a/apidom/packages/apidom-parser-adapter-openapi3/src/parser/visitors/Literal.js
+++ b/apidom/packages/apidom-parser-adapter-openapi3/src/parser/visitors/Literal.js
@@ -3,25 +3,49 @@
 const { Visitor } = require('json-ast');
 
 class LiteralVisitor extends Visitor {
-    constructor(...args) {
-        super(...args);
+    constructor(namespace) {
+        super();
+        this.namespace = namespace;
         this.result = null;
     }
 
+    key(keyNode) {
+        return this.string(keyNode);
+    }
+
     string(stringNode) {
-        this.result = String(stringNode.value);
+        const element = new this.namespace.elements.String(String(stringNode.value));
+        this.result = this._decorateWithSourcemap(element, stringNode);
+        this.stop = true;
     }
 
     number(numberNode) {
-        this.result = Number(numberNode.value);
+        const element = new this.namespace.elements.Number(Number(numberNode.value));
+        this.result = this._decorateWithSourcemap(element, numberNode);
+        this.stop = true;
     }
 
     boolean(booleanNode){
-        this.result = booleanNode.value === 'true';
+        const element = new this.namespace.elements.Boolean(booleanNode.value === 'true');
+        this.result = this._decorateWithSourcemap(element, booleanNode);
+        this.stop = true;
     };
 
-    nil() {
-        this.result = null
+    nil(nullNode) {
+        const element = new this.namespace.elements.Null();
+        this.result = this._decorateWithSourcemap(element, nullNode);
+        this.stop = true;
+    }
+
+    _decorateWithSourcemap(element, node) {
+        const sourceMap = new this.namespace.elements.SourceMap();
+
+        sourceMap.position = node.position;
+        sourceMap.astNode = node;
+
+        element.meta.set('sourceMap', sourceMap);
+
+        return element;
     }
 }
 

--- a/apidom/packages/apidom-parser-adapter-openapi3/src/parser/visitors/Openapi.js
+++ b/apidom/packages/apidom-parser-adapter-openapi3/src/parser/visitors/Openapi.js
@@ -1,19 +1,13 @@
 'use strict';
 
 const ApiDOMVisitor = require('./ApiDOM');
-const LiteralVisitor = require('./Literal');
 
 class Openapi extends ApiDOMVisitor {
     value(valueNode) {
-        const valueVisitor = new LiteralVisitor();
-        const sourceMap = new this.namespace.elements.SourceMap();
-
-        valueNode.accept(valueVisitor);
-        sourceMap.position = valueNode.position;
-
         const openapi = new this.namespace.elements.Openapi();
-        openapi.set(valueVisitor.result);
-        openapi.meta.set('sourceMap', sourceMap);
+        const element = this.toElement(valueNode);
+        openapi.set(element.toValue());
+        openapi.meta.set('sourceMap', element.meta.get('sourceMap'));
 
         this.result = openapi;
         this.stop = true;

--- a/apidom/packages/apidom-parser-adapter-openapi3/test/index.js
+++ b/apidom/packages/apidom-parser-adapter-openapi3/test/index.js
@@ -13,4 +13,5 @@ console.log(adapter.detect(spec));
 console.log(adapter.mediaTypes);
 
 const parseResult = adapter.parse(spec);
-console.log(JSON.stringify(apiDOM.toJSON(namespace, parseResult), null, 2));
+console.dir(apiDOM.toValue(parseResult));
+console.log(JSON.stringify(apiDOM.toJSON(namespace, parseResult), null, null));

--- a/apidom/packages/apidom/src/elements/SourceMap.js
+++ b/apidom/packages/apidom/src/elements/SourceMap.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ArrayElement, ObjectElement } = require('minim');
+const { ArrayElement } = require('minim');
 
 /**
  * @class SourceMap
@@ -8,7 +8,7 @@ const { ArrayElement, ObjectElement } = require('minim');
  * @param {string} content
  * @param meta
  * @param attributes
- * @extends ObjectElement
+ * @extends ArrayElement
  */
 class SourceMap extends ArrayElement {
     constructor(...args) {


### PR DESCRIPTION
As AST nodes are of ephemeral nature, I did not make them
part of resulting ApiDOM, but rather they are attached to javascript
structures forming the actual ApiDOM structures. The reason is not to
serialize ephemeral AST nodes into Refract.

Closes #10