### PR TITLE
feat: add support for parse errors

### DIFF
--- a/apidom/packages/apidom-parser-adapter-openapi3/src/parser/visitors/DocumentVisitor.js
+++ b/apidom/packages/apidom-parser-adapter-openapi3/src/parser/visitors/DocumentVisitor.js
@@ -8,7 +8,6 @@ const CommentVisitor = require('./CommentVisitor');
 const DocumentVisitor = stampit(SpecificationVisitor, {
   methods: {
     document(documentNode) {
-      this.element = new this.namespace.elements.ParseResult();
       const openApiVisitor = this.retrieveVisitorInstance(['document', 'openApi']);
       const commentVisitor = this.retrieveVisitorInstance(['document', 'comment']);
 


### PR DESCRIPTION
If the underlying json-ast parser fails to parse the document, it will throw an error.
This error is translated into ApiDOM Annotation and embedded into ParserResult.

Special case of failure is when there is no parsing error but the shape of the data
is unexpected for the parser. So this case is more an unexpected failure. This case
will be handled in future by validator, that runs before the mapping visitors kics in.

Closes #4