### PR TITLE
fix(AST): compensate for inconsistent tree-sitter SyntaxNode API

### DIFF
--- a/apidom/package-lock.json
+++ b/apidom/package-lock.json
@@ -3588,7 +3588,7 @@
         "ramda": "=0.27.0",
         "ramda-adjunct": "=2.27.0",
         "stampit": "=4.3.1",
-        "tree-sitter": "=0.16.1",
+        "tree-sitter": "=0.16.2",
         "tree-sitter-json": "=0.16.0",
         "web-tree-sitter": "=0.16.4"
       }
@@ -3603,7 +3603,7 @@
         "ramda": "=0.27.0",
         "ramda-adjunct": "=2.27.0",
         "stampit": "=4.3.1",
-        "tree-sitter": "=0.16.1",
+        "tree-sitter": "=0.16.2",
         "tree-sitter-json": "=0.16.0",
         "web-tree-sitter": "=0.16.4"
       }
@@ -13325,9 +13325,9 @@
       }
     },
     "tree-sitter": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.16.1.tgz",
-      "integrity": "sha512-+vQBp4yefo+AQ2gv+b2PK+zglWS+9UqZGdzr05EYDSOcVb+tnr0Tj6hjknDTxUEGQagMe0JcDsIrr6peI7Yvyg==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.16.2.tgz",
+      "integrity": "sha512-1d9oNXVUWJGzpPyTwI7qBHoGZYLD4BU04bHSxj9PqRgR3URY8fXqk2LhFCu7AFBDQHifcinMxss5CqYXCTGcLQ==",
       "requires": {
         "nan": "^2.14.0",
         "prebuild-install": "^5.0.0"

--- a/apidom/packages/apidom-ast/package.json
+++ b/apidom/packages/apidom-ast/package.json
@@ -40,7 +40,7 @@
     "stampit": "=4.3.1"
   },
   "devDependencies": {
-    "tree-sitter": "=0.16.1",
+    "tree-sitter": "=0.16.2",
     "tree-sitter-json": "=0.16.0"
   }
 }

--- a/apidom/packages/apidom-ast/src/transformers/tree-sitter-json.ts
+++ b/apidom/packages/apidom-ast/src/transformers/tree-sitter-json.ts
@@ -1,6 +1,6 @@
 import stampit from 'stampit';
 import { tail } from 'ramda';
-import { isFalse } from 'ramda-adjunct';
+import { isFalse, isFunction } from 'ramda-adjunct';
 import { Tree, SyntaxNode } from 'tree-sitter';
 
 import JsonArray from '../nodes/json/JsonArray';
@@ -62,7 +62,11 @@ const Visitor = stampit({
 
     this.enter = function enter(node: SyntaxNode) {
       // missing anonymous literals from CST transformed into AST literal nodes
-      if (isFalse(node.isNamed)) {
+      // WARNING: be aware that web-tree-sitter and tree-sitter node bindings have inconsistency
+      // in `SyntaxNode.isNamed` property. web-tree-sitter has it defined as method
+      // whether tree-sitter node binding has it defined as a boolean property.
+      // @ts-ignore
+      if ((isFunction(node.isNamed) && !node.isNamed()) || isFalse(node.isNamed)) {
         const position = toPosition(node);
         const value = node.type || node.text;
         const isMissing = node.isMissing();

--- a/apidom/packages/apidom-parser-adapter-asyncapi2-0-json/package.json
+++ b/apidom/packages/apidom-parser-adapter-asyncapi2-0-json/package.json
@@ -31,7 +31,7 @@
     "ramda": "=0.27.0",
     "ramda-adjunct": "=2.27.0",
     "stampit": "=4.3.1",
-    "tree-sitter": "=0.16.1",
+    "tree-sitter": "=0.16.2",
     "tree-sitter-json": "=0.16.0",
     "web-tree-sitter": "=0.16.4"
   },

--- a/apidom/packages/apidom-parser-adapter-openapi3-1-json/package.json
+++ b/apidom/packages/apidom-parser-adapter-openapi3-1-json/package.json
@@ -31,7 +31,7 @@
     "ramda": "=0.27.0",
     "ramda-adjunct": "=2.27.0",
     "stampit": "=4.3.1",
-    "tree-sitter": "=0.16.1",
+    "tree-sitter": "=0.16.2",
     "tree-sitter-json": "=0.16.0",
     "web-tree-sitter": "=0.16.4"
   },

--- a/experiments/apidom-monaco/config/webpack/browser.config.js
+++ b/experiments/apidom-monaco/config/webpack/browser.config.js
@@ -68,8 +68,10 @@ const browser = {
     alias: {
       ...apidomPackage("apidom"),
       ...apidomPackage("apidom-ast"),
+      ...apidomPackage("apidom-ns-asyncapi2-0"),
       ...apidomPackage("apidom-ns-openapi3-1"),
       ...apidomPackage("apidom-parser"),
+      ...apidomPackage("apidom-parser-adapter-asyncapi2-0-json"),
       ...apidomPackage("apidom-parser-adapter-openapi3-1-json"),
     },
   },


### PR DESCRIPTION
web-tree-sitter and tree-sitter node bindings have inconsistency
in  property. web-tree-sitter has it defined as method
whether tree-sitter node binding has it defined as a boolean property.

Refs #69