### PR TITLE
refactor(OpenApi3.1-Yaml): create surrogate pair value when empty

### DIFF
--- a/apidom/packages/apidom-ast/src/nodes/yaml/YamlKeyValuePair.ts
+++ b/apidom/packages/apidom-ast/src/nodes/yaml/YamlKeyValuePair.ts
@@ -1,16 +1,15 @@
 import stampit from 'stampit';
-import { filter, anyPass, pipe, nth, pathOr, identical, complement, both } from 'ramda';
+import { filter, anyPass, pipe, nth, identical, complement, both } from 'ramda';
 
 import Node from '../../Node';
 import YamlStyleModel from './YamlStyle';
 import { isScalar, isMapping, isSequence, isAlias } from './predicates';
 import YamlScalar from './YamlScalar';
-import YamlAlias from './YamlAlias';
 
 interface YamlKeyValuePair extends Node, YamlStyleModel {
   type: 'keyValuePair';
   readonly key: YamlScalar;
-  readonly value: YamlScalar | YamlAlias | null | any;
+  readonly value: any;
 }
 
 const YamlKeyValuePair: stampit.Stamp<YamlKeyValuePair> = stampit(Node, YamlStyleModel, {
@@ -28,8 +27,7 @@ const YamlKeyValuePair: stampit.Stamp<YamlKeyValuePair> = stampit(Node, YamlStyl
       const excludeKeyPredicate = complement(identical(this.key));
       const valuePredicate = anyPass([isScalar, isMapping, isSequence, isAlias]);
       // @ts-ignore
-      const filtered = filter(both(excludeKeyPredicate, valuePredicate), this.children);
-      return pathOr(null, [0], filtered);
+      return pipe(filter(both(excludeKeyPredicate, valuePredicate)), nth(0))(this.children);
     },
   },
 });

--- a/apidom/packages/apidom-ast/test/transformers/tree-sitter-yaml.ts
+++ b/apidom/packages/apidom-ast/test/transformers/tree-sitter-yaml.ts
@@ -15,7 +15,8 @@ describe('tree-sitter-yaml', function () {
       const parser = new Parser();
       parser.setLanguage(YAMLLanguage);
 
-      const jsonString = 'prop: value';
+      const jsonString = 'prop: &anchor !!str';
+
       cst = parser.parse(jsonString);
       ast = transform(cst);
       // const util = require('util');

--- a/apidom/packages/apidom-parser-adapter-openapi3-1-yaml/src/parser/visitors/generics/index.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi3-1-yaml/src/parser/visitors/generics/index.ts
@@ -1,12 +1,11 @@
 import stampit from 'stampit';
-import { last, propOr } from 'ramda';
+import { last } from 'ramda';
 import { isNotNull } from 'ramda-adjunct';
 import {
   YamlKeyValuePair,
   YamlMapping,
   YamlScalar,
   YamlSequence,
-  YamlAlias,
   isYamlMapping,
   isYamlSequence,
 } from 'apidom-ast';
@@ -78,10 +77,8 @@ export const MappingVisitor = stampit(SpecificationVisitor).init(function Mappin
     // @ts-ignore
     const objElement = last(stack);
     const { MemberElement } = this.namespace.elements.Element.prototype;
-    type YamlValue = YamlScalar | YamlMapping | YamlSequence | YamlAlias | null;
     const { key: keyNode } = keyValuePairNode;
-    const { value: valueNode }: { value: YamlValue } = keyValuePairNode;
-    const valueNodeContent = propOr(null, 'content', valueNode);
+    const { value: valueNode } = keyValuePairNode;
     const keyElement = new this.namespace.elements.String(keyNode.content);
     let valueElement;
 
@@ -92,11 +89,11 @@ export const MappingVisitor = stampit(SpecificationVisitor).init(function Mappin
     } else if (keyNode.content === '$ref') {
       // $ref property key special handling
       // @ts-ignore
-      valueElement = new this.namespace.elements.Ref(valueNodeContent);
-      valueElement.path = valueNodeContent;
+      valueElement = new this.namespace.elements.Ref(valueNode.content);
+      valueElement.path = valueNode.content;
     } else if (!isOpenApiExtension({}, keyValuePairNode)) {
       // @ts-ignore
-      valueElement = this.namespace.toElement(valueNodeContent);
+      valueElement = this.namespace.toElement(valueNode.content);
     }
 
     if (isOpenApiExtension({}, keyValuePairNode)) {


### PR DESCRIPTION
Even when value is explicitly ommited from key/value pair
we create an AST node to represent it.

Refs #1