### PR TITLE
feat(reference): add HTTP resolver implementation

### DIFF
--- a/apidom/package-lock.json
+++ b/apidom/package-lock.json
@@ -3731,6 +3731,7 @@
       "version": "file:packages/apidom-reference",
       "requires": {
         "@types/ramda": "=0.27.6",
+        "axios": "=0.21.0",
         "ramda": "=0.27.0",
         "ramda-adjunct": "=2.27.0",
         "stampit": "=4.3.1"
@@ -3973,6 +3974,32 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
+    "axios-mock-adapter": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz",
+      "integrity": "sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.3"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+          "dev": true
+        }
+      }
     },
     "babel-loader": {
       "version": "8.1.0",
@@ -7250,6 +7277,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/apidom/package.json
+++ b/apidom/package.json
@@ -54,6 +54,7 @@
     "@types/mocha": "=7.0.2",
     "@typescript-eslint/eslint-plugin": "=3.0.2",
     "@typescript-eslint/parser": "=3.0.2",
+    "axios-mock-adapter": "=1.19.0",
     "babel-loader": "=8.1.0",
     "babel-plugin-native-error-extend": "=2.0.0",
     "chai": "=4.2.0",

--- a/apidom/packages/apidom-reference/package.json
+++ b/apidom/packages/apidom-reference/package.json
@@ -27,9 +27,13 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
+    "axios": "=0.21.0",
     "ramda": "=0.27.0",
     "@types/ramda": "=0.27.6",
     "ramda-adjunct": "=2.27.0",
     "stampit": "=4.3.1"
+  },
+  "devDependencies": {
+    "axios-mock-adapter": "=1.19.0"
   }
 }

--- a/apidom/packages/apidom-reference/src/resolvers/FileResolver.ts
+++ b/apidom/packages/apidom-reference/src/resolvers/FileResolver.ts
@@ -6,12 +6,7 @@ import Resolver from './Resolver';
 import { isFileSystemPath, toFileSystemPath } from '../util/url';
 import { ResolverError } from '../util/errors';
 
-interface FileResolver extends Resolver {
-  canRead(uri: string): boolean;
-  read(uri: string): Promise<Buffer>;
-}
-
-const FileResolver: stampit.Stamp<FileResolver> = stampit(Resolver, {
+const FileResolver: stampit.Stamp<Resolver> = stampit(Resolver, {
   methods: {
     canRead(uri: string): boolean {
       return isFileSystemPath(uri);

--- a/apidom/packages/apidom-reference/src/resolvers/HttpResolver.ts
+++ b/apidom/packages/apidom-reference/src/resolvers/HttpResolver.ts
@@ -1,0 +1,54 @@
+import stampit from 'stampit';
+
+import Resolver from './Resolver';
+import { isHttpUrl } from '../util/url';
+import NotImplementedError from '../util/errors/NotImplementedError';
+
+interface HttpResolverConstructorParameters {
+  timeout?: number;
+  redirects?: number;
+  withCredentials?: boolean;
+}
+
+interface HttpResolver extends Resolver {
+  timeout: number;
+  redirects: number;
+  withCredentials: boolean;
+
+  getHttpClient(): unknown;
+}
+
+const HttpResolver: stampit.Stamp<HttpResolver> = stampit(Resolver, {
+  props: {
+    timeout: 5000,
+    redirects: 5,
+    withCredentials: false,
+  },
+  init(
+    this: HttpResolver,
+    {
+      timeout = this.timeout,
+      redirects = this.redirects,
+      withCredentials = this.withCredentials,
+    }: HttpResolverConstructorParameters = {},
+  ) {
+    this.timeout = timeout;
+    this.redirects = redirects;
+    this.withCredentials = withCredentials;
+  },
+  methods: {
+    canRead(uri: string): boolean {
+      return isHttpUrl(uri);
+    },
+
+    async read(): Promise<never> {
+      throw new NotImplementedError();
+    },
+
+    getHttpClient(): unknown {
+      throw new NotImplementedError();
+    },
+  },
+});
+
+export default HttpResolver;

--- a/apidom/packages/apidom-reference/src/resolvers/HttpResolverAxios.ts
+++ b/apidom/packages/apidom-reference/src/resolvers/HttpResolverAxios.ts
@@ -1,0 +1,39 @@
+import stampit from 'stampit';
+import axios from 'axios';
+import { clone } from 'ramda';
+
+import HttpResolver from './HttpResolver';
+import ResolverError from '../util/errors/ResolverError';
+
+const HttpResolverAxios: stampit.Stamp<HttpResolver> = stampit(HttpResolver).init(
+  function HttpResolverAxios() {
+    /**
+     * Private Api.
+     */
+    const axiosInstance = axios.create({
+      timeout: this.timeout,
+      maxRedirects: this.redirects,
+      withCredentials: this.withCredentials,
+      responseType: 'arraybuffer',
+    });
+
+    /**
+     * Public Api.
+     */
+
+    this.getHttpClient = function getHttpClient() {
+      return clone(axiosInstance);
+    };
+
+    this.read = async function read(uri: string): Promise<Buffer> {
+      try {
+        const response = await axiosInstance.get(uri);
+        return response.data;
+      } catch (e) {
+        throw new ResolverError(`Error downloading "${uri}"`, e);
+      }
+    };
+  },
+);
+
+export default HttpResolverAxios;

--- a/apidom/packages/apidom-reference/src/resolvers/Resolver.ts
+++ b/apidom/packages/apidom-reference/src/resolvers/Resolver.ts
@@ -4,7 +4,7 @@ import { NotImplementedError } from '../util/errors';
 
 interface Resolver {
   canRead(uri: string): boolean;
-  read(uri: string): Promise<unknown>;
+  read(uri: string): Promise<Buffer>;
 }
 
 const Resolver: stampit.Stamp<Resolver> = stampit({
@@ -12,7 +12,7 @@ const Resolver: stampit.Stamp<Resolver> = stampit({
     canRead() {
       return false;
     },
-    async read() {
+    async read(): Promise<never> {
       throw new NotImplementedError();
     },
   },

--- a/apidom/packages/apidom-reference/src/util/url.ts
+++ b/apidom/packages/apidom-reference/src/util/url.ts
@@ -27,6 +27,14 @@ export const isFileSystemPath = (url: string): boolean => {
 };
 
 /**
+ * Determines whether the given path is an HTTP(S) URL.
+ */
+export const isHttpUrl = (url: string): boolean => {
+  const protocol = getProtocol(url);
+  return protocol === 'http' || protocol === 'https';
+};
+
+/**
  * Converts a URL to a local filesystem path.
  *
  * @param {boolean} [keepFileProtocol] - If true, then "file://" will NOT be stripped

--- a/apidom/packages/apidom-reference/test/resolvers/FileResolver.ts
+++ b/apidom/packages/apidom-reference/test/resolvers/FileResolver.ts
@@ -6,7 +6,7 @@ import { ResolverError } from '../../src/util/errors';
 
 describe('resolvers', function () {
   context('FileResolver', function () {
-    let resolver: FileResolver;
+    let resolver: any;
 
     beforeEach(function () {
       resolver = FileResolver();
@@ -34,7 +34,7 @@ describe('resolvers', function () {
         });
       });
 
-      context('given paths with known protocols', function () {
+      context('given paths with other known protocols', function () {
         specify('should not consider it a file system path', function () {
           assert.isFalse(resolver.canRead('https://swagger.io/'));
           assert.isFalse(resolver.canRead('http://swagger.io/'));

--- a/apidom/packages/apidom-reference/test/resolvers/HttpResolverAxios.ts
+++ b/apidom/packages/apidom-reference/test/resolvers/HttpResolverAxios.ts
@@ -1,0 +1,152 @@
+import http from 'http';
+import { assert } from 'chai';
+import { AxiosRequestConfig } from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+import HttpResolverAxios from '../../src/resolvers/HttpResolverAxios';
+import { ResolverError } from '../../src/util/errors';
+
+describe('resolvers', function () {
+  context('HttpResolverAxios', function () {
+    let resolver: any;
+
+    beforeEach(function () {
+      resolver = HttpResolverAxios();
+    });
+
+    context('canRead', function () {
+      context('given valid http URL', function () {
+        specify('should consider it a HTTP URL', function () {
+          assert.isTrue(resolver.canRead('http://swagger.io/file.txt'));
+        });
+      });
+
+      context('given valid https URL', function () {
+        specify('should consider it a https URL', function () {
+          assert.isTrue(resolver.canRead('https://swagger.io/file.txt'));
+        });
+      });
+
+      context('given URIs with no protocol', function () {
+        specify('should not consider it a http/https URL', function () {
+          assert.isFalse(resolver.canRead('/home/user/file.txt'));
+          assert.isFalse(resolver.canRead('C:\\home\\user\\file.txt'));
+        });
+      });
+
+      context('given URLs with other known protocols', function () {
+        specify('should not consider it a http/https URL', function () {
+          assert.isFalse(resolver.canRead('ftp://swagger.io/'));
+        });
+      });
+    });
+
+    context('read', function () {
+      let axiosInstance: any;
+      let axiosMock: any;
+
+      beforeEach(function () {
+        axiosInstance = resolver.getHttpClient();
+        axiosMock = new MockAdapter(axiosInstance);
+      });
+
+      context('given HTTP URL', function () {
+        specify('should fetch the URL', async function () {
+          const url = 'https://httpbin.org/anything';
+
+          axiosMock.onGet(url).reply(200, Buffer.from('data'));
+          const content = await resolver.read(url);
+
+          assert.instanceOf(content, Buffer);
+          assert.strictEqual(content.toString(), 'data');
+        });
+
+        specify('should throw on unexpected status codes', async function () {
+          const url = 'https://httpbin.org/anything';
+
+          axiosMock.onGet(url).reply(400, Buffer.from('data'));
+
+          try {
+            await resolver.read(url);
+            assert.fail('should throw ResolverError');
+          } catch (e) {
+            assert.instanceOf(e, ResolverError);
+            assert.propertyVal(e, 'message', 'Error downloading "https://httpbin.org/anything"');
+          }
+        });
+
+        specify('should throw on timeout', async function () {
+          resolver = HttpResolverAxios({ timeout: 1 });
+          const url = 'https://httpbin.org/anything';
+
+          axiosMock.onGet(url).timeout();
+
+          try {
+            await resolver.read(url);
+            assert.fail('should throw ResolverError');
+          } catch (e) {
+            assert.strictEqual(e.cause.message, 'timeout of 1ms exceeded');
+            assert.instanceOf(e, ResolverError);
+            assert.propertyVal(e, 'message', 'Error downloading "https://httpbin.org/anything"');
+          }
+        });
+
+        specify('should throw on network error', async function () {
+          const url = 'https://httpbin.org/anything';
+
+          axiosMock.onGet(url).networkError();
+
+          try {
+            await resolver.read(url);
+            assert.fail('should throw ResolverError');
+          } catch (e) {
+            assert.strictEqual(e.cause.message, 'Network Error');
+            assert.instanceOf(e, ResolverError);
+            assert.propertyVal(e, 'message', 'Error downloading "https://httpbin.org/anything"');
+          }
+        });
+
+        context('given withCredentials option', function () {
+          specify('should allow cross-site Access-Control requests', function (done) {
+            resolver = HttpResolverAxios({ withCredentials: true });
+            axiosInstance = resolver.getHttpClient();
+            axiosMock = new MockAdapter(axiosInstance);
+            const url = 'https://httpbin.org/anything';
+
+            axiosMock.onGet(url).reply((config: AxiosRequestConfig) => {
+              assert.isTrue(config.withCredentials);
+              done();
+              return [200];
+            });
+            resolver.read(url);
+          });
+        });
+
+        context('given redirects options', function () {
+          specify('should throw on exceeding redirects', function (done) {
+            resolver = HttpResolverAxios({ redirects: 0 });
+            axiosInstance = resolver.getHttpClient();
+            const server = http.createServer((req, res) => {
+              res.setHeader('Location', '/foo');
+              res.statusCode = 302;
+              res.end();
+            });
+
+            server.listen(4444, () => {
+              axiosInstance
+                .get('http://localhost:4444/')
+                .catch((error: any) => {
+                  assert.strictEqual(error.response.status, 302);
+                  assert.strictEqual(error.response.headers.location, '/foo');
+                })
+                .then(() => {
+                  server.close();
+                  done();
+                });
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This first default implementation is based on Axios.

Refs https://github.com/swagger-api/oss-planning/issues/133