### PR TITLE
refactor(reference): revert logic of sourceMap flag

### DIFF
--- a/apidom/packages/apidom-reference/src/parsers/apidom-reference-parser-json/index.ts
+++ b/apidom/packages/apidom-reference/src/parsers/apidom-reference-parser-json/index.ts
@@ -24,7 +24,7 @@ const JsonParser: stampit.Stamp<JsonParser> = stampit({
     /**
      * Whether to generate source map during parsing.
      */
-    sourceMap: true,
+    sourceMap: false,
   },
   init(this: JsonParser, { allowEmpty = this.allowEmpty, sourceMap = this.sourceMap } = {}) {
     this.allowEmpty = allowEmpty;

--- a/apidom/packages/apidom-reference/src/parsers/apidom-reference-parser-openapi-json-3-1/index.ts
+++ b/apidom/packages/apidom-reference/src/parsers/apidom-reference-parser-openapi-json-3-1/index.ts
@@ -28,7 +28,7 @@ const OpenApiJson3_1Parser: stampit.Stamp<OpenApiJson3_1Parser> = stampit({
     /**
      * Whether to generate source map during parsing.
      */
-    sourceMap: true,
+    sourceMap: false,
 
     /**
      * Path of the Specification object where visitor is located.

--- a/apidom/packages/apidom-reference/src/parsers/apidom-reference-parser-openapi-yaml-3-1/index.ts
+++ b/apidom/packages/apidom-reference/src/parsers/apidom-reference-parser-openapi-yaml-3-1/index.ts
@@ -28,7 +28,7 @@ const OpenApiYaml3_1Parser: stampit.Stamp<OpenApiYaml3_1Parser> = stampit({
     /**
      * Whether to generate source map during parsing.
      */
-    sourceMap: true,
+    sourceMap: false,
 
     /**
      * Path of the Specification object where visitor is located.

--- a/apidom/packages/apidom-reference/src/parsers/apidom-reference-parser-yaml/index.ts
+++ b/apidom/packages/apidom-reference/src/parsers/apidom-reference-parser-yaml/index.ts
@@ -24,7 +24,7 @@ const YamlParser: stampit.Stamp<YamlParser> = stampit({
     /**
      * Whether to generate source map during parsing.
      */
-    sourceMap: true,
+    sourceMap: false,
   },
   init(this: YamlParser, { allowEmpty = this.allowEmpty, sourceMap = this.sourceMap } = {}) {
     this.allowEmpty = allowEmpty;

--- a/apidom/packages/apidom-reference/test/parsers/apidom-reference-parser-openapi-json-3-1/index.ts
+++ b/apidom/packages/apidom-reference/test/parsers/apidom-reference-parser-openapi-json-3-1/index.ts
@@ -104,7 +104,7 @@ describe('parsers', function () {
             const data = fs.readFileSync(url).toString();
             const file = File({ url, data });
             const specPath = always(['document', 'objects', 'PathItem']);
-            const parser = OpenApiJson3_1Parser({ specPath });
+            const parser = OpenApiJson3_1Parser({ specPath, sourceMap: true });
             const result = await parser.parse(file);
             const pathItem: PathItemElement = result.get(0);
 

--- a/apidom/packages/apidom-reference/test/parsers/apidom-reference-parser-openapi-yaml-3-1/index.ts
+++ b/apidom/packages/apidom-reference/test/parsers/apidom-reference-parser-openapi-yaml-3-1/index.ts
@@ -114,7 +114,7 @@ describe('parsers', function () {
             const data = fs.readFileSync(url).toString();
             const file = File({ url, data });
             const specPath = always(['document', 'objects', 'PathItem']);
-            const parser = OpenApiYaml3_1Parser({ specPath });
+            const parser = OpenApiYaml3_1Parser({ specPath, sourceMap: true });
             const result = await parser.parse(file);
             const pathItem: PathItemElement = result.get(0);
 


### PR DESCRIPTION
This flag has now default value of false, which is
the same as flag for parser adapters.

Refs https://github.com/swagger-api/oss-planning/issues/133