### PR TITLE
refactor: discontinue using Ref Element

### DIFF
--- a/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/async-api-2-0/channel-item/$RefVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/async-api-2-0/channel-item/$RefVisitor.ts
@@ -1,19 +1,7 @@
 import stampit from 'stampit';
-// @ts-ignore
-import { SpecificationVisitor, BREAK } from 'apidom-parser-adapter-json';
 
 import { ValueVisitor } from '../../generics';
 
-const $RefVisitor = stampit(ValueVisitor, SpecificationVisitor, {
-  methods: {
-    string(stringNode) {
-      const refElement = new this.namespace.elements.Ref(stringNode.value);
-      refElement.path = stringNode.value;
-      this.element = this.maybeAddSourceMap(stringNode, refElement);
-
-      return BREAK;
-    },
-  },
-});
+const $RefVisitor = stampit(ValueVisitor);
 
 export default $RefVisitor;

--- a/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/async-api-2-0/channel-item/$RefVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/async-api-2-0/channel-item/$RefVisitor.ts
@@ -1,21 +1,7 @@
 import stampit from 'stampit';
-import { YamlScalar } from 'apidom-ast';
-// @ts-ignore
-import { BREAK, SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
 
 import { KindVisitor } from '../../generics';
 
-const $RefVisitor = stampit(KindVisitor, SpecificationVisitor, {
-  methods: {
-    scalar(scalarNode: YamlScalar) {
-      const { content } = scalarNode;
-      const refElement = new this.namespace.elements.Ref(content);
-      refElement.path = content;
-      this.element = this.maybeAddSourceMap(scalarNode, refElement);
-
-      return BREAK;
-    },
-  },
-});
+const $RefVisitor = stampit(KindVisitor);
 
 export default $RefVisitor;

--- a/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/generics/index.ts
+++ b/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/generics/index.ts
@@ -130,9 +130,7 @@ export const ObjectVisitor = stampit(SpecificationVisitor).init(function ObjectV
     } else if (propertyNode.key.value === '$ref' && isJsonString(propertyNode.value)) {
       // $ref property key special handling
       // @ts-ignore
-      valueElement = new this.namespace.elements.Ref(propertyNode.value.value);
-      // @ts-ignore
-      valueElement.path = propertyNode.value.value;
+      valueElement = new this.namespace.elements.String(propertyNode.value.value);
       objElement.classes.push('json-reference');
       objElement.classes.push('json-schema-reference');
     } else if (!this.specificationExtensionPredicate(propertyNode)) {

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/path-item/$RefVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/path-item/$RefVisitor.ts
@@ -1,19 +1,7 @@
 import stampit from 'stampit';
-// @ts-ignore
-import { SpecificationVisitor, BREAK } from 'apidom-parser-adapter-json';
 
 import { ValueVisitor } from '../../generics';
 
-const $RefVisitor = stampit(ValueVisitor, SpecificationVisitor, {
-  methods: {
-    string(stringNode) {
-      const refElement = new this.namespace.elements.Ref(stringNode.value);
-      refElement.path = stringNode.value;
-      this.element = this.maybeAddSourceMap(stringNode, refElement);
-
-      return BREAK;
-    },
-  },
-});
+const $RefVisitor = stampit(ValueVisitor);
 
 export default $RefVisitor;

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/path-item/$RefVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/path-item/$RefVisitor.ts
@@ -1,21 +1,7 @@
 import stampit from 'stampit';
-import { YamlScalar } from 'apidom-ast';
-// @ts-ignore
-import { BREAK, SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
 
 import { KindVisitor } from '../../generics';
 
-const $RefVisitor = stampit(KindVisitor, SpecificationVisitor, {
-  methods: {
-    scalar(scalarNode: YamlScalar) {
-      const { content } = scalarNode;
-      const refElement = new this.namespace.elements.Ref(content);
-      refElement.path = content;
-      this.element = this.maybeAddSourceMap(scalarNode, refElement);
-
-      return BREAK;
-    },
-  },
-});
+const $RefVisitor = stampit(KindVisitor);
 
 export default $RefVisitor;

--- a/apidom/packages/apidom-parser-adapter-yaml-1-2/src/parser/visitors/generics/index.ts
+++ b/apidom/packages/apidom-parser-adapter-yaml-1-2/src/parser/visitors/generics/index.ts
@@ -8,6 +8,7 @@ import {
   YamlSequence,
   isYamlMapping,
   isYamlSequence,
+  isYamlScalar,
 } from 'apidom-ast';
 
 import { BREAK } from '../index';
@@ -87,15 +88,12 @@ export const MappingVisitor = stampit(SpecificationVisitor).init(function Mappin
       valueElement = this.nodeToElement(['mapping'], valueNode);
     } else if (isYamlSequence(valueNode)) {
       valueElement = this.nodeToElement(['sequence'], valueNode);
-    } else if (keyNode.content === '$ref') {
+    } else if (keyNode.content === '$ref' && isYamlScalar(valueNode)) {
       // $ref property key special handling
-      // @ts-ignore
-      valueElement = new this.namespace.elements.Ref(valueNode.content);
-      valueElement.path = valueNode.content;
+      valueElement = this.namespace.toElement(valueNode.content);
       objElement.classes.push('json-reference');
       objElement.classes.push('json-schema-reference');
     } else if (!this.specificationExtensionPredicate(keyValuePairNode)) {
-      // @ts-ignore
       valueElement = this.namespace.toElement(valueNode.content);
     }
 

--- a/apidom/packages/apidom-parser-adapter-yaml-1-2/test/fixtures/sample-data.yaml
+++ b/apidom/packages/apidom-parser-adapter-yaml-1-2/test/fixtures/sample-data.yaml
@@ -1,4 +1,5 @@
 # stream comment
 ---
 prop: val
+$ref: #/prop
 ...


### PR DESCRIPTION
Ref Element is designed to be used as a special referencing
mechanism for Refract structure. It can be considered as
an alternative to JSON Reference. It's better not to mix
those two.

Refs https://github.com/swagger-api/oss-planning/issues/133