### PR TITLE
refactor(OpenApi3.1-JSON): annotate Reference Object with meta

### DIFF
--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Reference.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Reference.ts
@@ -4,7 +4,7 @@ class Reference extends ObjectElement {
   constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'reference';
-    this.classes.push('json-schema-reference');
+    this.classes.push('openapi-reference');
   }
 
   get $ref(): StringElement {

--- a/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/ErrorVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/ErrorVisitor.ts
@@ -2,6 +2,7 @@ import stampit from 'stampit';
 
 import { BREAK } from './index';
 import SpecificationVisitor from './SpecificationVisitor';
+import { appendMetadata } from '../metadata';
 
 const ErrorVisitor = stampit(SpecificationVisitor, {
   methods: {
@@ -24,7 +25,7 @@ const ErrorVisitor = stampit(SpecificationVisitor, {
         : `(Error ${errorNode.value})`;
 
       this.element = new this.namespace.elements.Annotation(message);
-      this.element.classes.push('error');
+      appendMetadata(['error'], this.element);
 
       this.maybeAddSourceMap(errorNode, this.element);
 

--- a/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/generics/FixedFieldsJsonObjectVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/generics/FixedFieldsJsonObjectVisitor.ts
@@ -2,6 +2,7 @@ import stampit from 'stampit';
 import { F as stubFalse } from 'ramda';
 import { noop } from 'ramda-adjunct';
 
+import { appendMetadata } from '../../metadata';
 import SpecificationVisitor from '../SpecificationVisitor';
 import { visit, BREAK } from '../index';
 
@@ -53,7 +54,7 @@ const FixedFieldsJsonObjectVisitor = stampit(SpecificationVisitor, {
               visitor.element,
             ),
           );
-          memberElement.classes.push('fixedField');
+          appendMetadata(['fixed-field'], memberElement);
 
           this.element.content.push(memberElement);
         } else if (

--- a/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/generics/MixedFieldsJsonObjectVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/generics/MixedFieldsJsonObjectVisitor.ts
@@ -1,5 +1,6 @@
 import stampit from 'stampit';
 import { noop } from 'ramda-adjunct';
+import { JsonObject } from 'apidom-ast';
 
 import { BREAK } from '../index';
 import FixedFieldsJsonObjectVisitor from './FixedFieldsJsonObjectVisitor';
@@ -14,7 +15,7 @@ const MixedFieldsJsonObjectVisitor = stampit(
       specPathPatternedFields: noop,
     },
     methods: {
-      object(objectNode) {
+      object(objectNode: JsonObject) {
         const { specPath } = this;
 
         try {

--- a/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/generics/PatternedFieldsJsonObjectVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/generics/PatternedFieldsJsonObjectVisitor.ts
@@ -4,6 +4,7 @@ import { noop } from 'ramda-adjunct';
 
 import SpecificationVisitor from '../SpecificationVisitor';
 import { visit, BREAK } from '../index';
+import { appendMetadata } from '../../metadata';
 
 const PatternedFieldsJsonObjectVisitor = stampit(SpecificationVisitor, {
   props: {
@@ -55,7 +56,7 @@ const PatternedFieldsJsonObjectVisitor = stampit(SpecificationVisitor, {
               visitor.element,
             ),
           );
-          memberElement.classes.push('patternedField');
+          appendMetadata(['patterned-field'], memberElement);
 
           this.element.content.push(memberElement);
         } else if (!this.ignoredFields.includes(keyName)) {

--- a/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/generics/index.ts
+++ b/apidom/packages/apidom-parser-adapter-json/src/parser/visitors/generics/index.ts
@@ -16,6 +16,7 @@ import {
 } from 'apidom-ast';
 
 import { visit, BREAK } from '../index';
+import { appendMetadata } from '../../metadata';
 import SpecificationVisitor from '../SpecificationVisitor';
 
 export const ArrayVisitor = stampit(SpecificationVisitor).init(function ArrayVisitor() {
@@ -131,8 +132,7 @@ export const ObjectVisitor = stampit(SpecificationVisitor).init(function ObjectV
       // $ref property key special handling
       // @ts-ignore
       valueElement = new this.namespace.elements.String(propertyNode.value.value);
-      objElement.classes.push('json-reference');
-      objElement.classes.push('json-schema-reference');
+      appendMetadata(['json-reference', 'json-schema-reference'], valueElement);
     } else if (!this.specificationExtensionPredicate(propertyNode)) {
       // @ts-ignore
       valueElement = this.namespace.toElement(propertyNode.value.value);

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/SpecificationExtensionVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/SpecificationExtensionVisitor.ts
@@ -1,6 +1,6 @@
 import stampit from 'stampit';
 // @ts-ignore
-import { SpecificationVisitor, visit, BREAK } from 'apidom-parser-adapter-json';
+import { appendMetadata, SpecificationVisitor, visit, BREAK } from 'apidom-parser-adapter-json';
 
 import { isOpenApiExtension } from '../predicates';
 
@@ -24,7 +24,7 @@ const SpecificationExtensionVisitor = stampit(SpecificationVisitor, {
       );
 
       if (isOpenApiExtension({}, propertyNode)) {
-        memberElement.classes.push('specificationExtension');
+        appendMetadata(['specification-extension'], memberElement);
       }
 
       this.element = memberElement;

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/ParametersVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/ParametersVisitor.ts
@@ -1,7 +1,7 @@
 import stampit from 'stampit';
 import { JsonNode } from 'apidom-ast';
 // @ts-ignore
-import { SpecificationVisitor, BREAK } from 'apidom-parser-adapter-json';
+import { appendMetadata, SpecificationVisitor, BREAK } from 'apidom-parser-adapter-json';
 
 import { isParameterObject, isReferenceObject } from '../../predicates';
 import { ValueVisitor } from '../generics';
@@ -9,13 +9,14 @@ import { ValueVisitor } from '../generics';
 const ParametersVisitor = stampit(ValueVisitor, SpecificationVisitor, {
   init() {
     this.element = new this.namespace.elements.Array();
-    this.element.classes.push('parameters');
+    appendMetadata(['parameters'], this.element);
   },
   methods: {
     array(arrayNode) {
       arrayNode.items.forEach(<T extends JsonNode>(item: T): void => {
         if (isReferenceObject({}, item)) {
           const referenceElement = this.nodeToElement(['document', 'objects', 'Reference'], item);
+          appendMetadata(['openapi-reference-for-parameter'], referenceElement);
           this.element.push(referenceElement);
         } else if (isParameterObject({}, item)) {
           const parameterElement = this.nodeToElement(['document', 'objects', 'Parameter'], item);

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/SecurityVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/SecurityVisitor.ts
@@ -1,14 +1,14 @@
 import stampit from 'stampit';
 import { isJsonObject, JsonNode } from 'apidom-ast';
 // @ts-ignore
-import { SpecificationVisitor, BREAK } from 'apidom-parser-adapter-json';
+import { appendMetadata, SpecificationVisitor, BREAK } from 'apidom-parser-adapter-json';
 
 import { ValueVisitor } from '../generics';
 
 const SecurityVisitor = stampit(ValueVisitor, SpecificationVisitor, {
   init() {
     this.element = new this.namespace.elements.Array();
-    this.element.classes.push('security');
+    appendMetadata(['security'], this.element);
   },
   methods: {
     array(arrayNode) {

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/ServersVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/ServersVisitor.ts
@@ -1,7 +1,7 @@
 import stampit from 'stampit';
 import { JsonNode } from 'apidom-ast';
 // @ts-ignore
-import { SpecificationVisitor, BREAK } from 'apidom-parser-adapter-json';
+import { appendMetadata, SpecificationVisitor, BREAK } from 'apidom-parser-adapter-json';
 
 import { isServerObject } from '../../predicates';
 import { ValueVisitor } from '../generics';
@@ -9,7 +9,7 @@ import { ValueVisitor } from '../generics';
 const ServersVisitor = stampit(ValueVisitor, SpecificationVisitor, {
   init() {
     this.element = new this.namespace.elements.Array();
-    this.element.classes.push('servers');
+    appendMetadata(['servers'], this.element);
   },
   methods: {
     array(arrayNode) {

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/components/ParametersVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/components/ParametersVisitor.ts
@@ -1,5 +1,8 @@
 import stampit from 'stampit';
-import { JsonNode } from 'apidom-ast';
+import { JsonNode, JsonObject } from 'apidom-ast';
+import { isReferenceElement, ReferenceElement } from 'apidom-ns-openapi-3-1';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-json';
 
 import MapJsonObjectVisitor from '../../generics/MapJsonObjectVisitor';
 import { ValueVisitor } from '../../generics';
@@ -18,7 +21,18 @@ const ParametersVisitor = stampit(ValueVisitor, MapJsonObjectVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('parameters');
+    appendMetadata(['parameters'], this.element);
+  },
+  methods: {
+    object(objectNode: JsonObject) {
+      const result = MapJsonObjectVisitor.compose.methods.object.call(this, objectNode);
+
+      this.element.filter(isReferenceElement).forEach((referenceElement: ReferenceElement) => {
+        appendMetadata(['openapi-reference-for-parameter'], referenceElement);
+      });
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/components/SchemasVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/components/SchemasVisitor.ts
@@ -1,5 +1,7 @@
 import stampit from 'stampit';
 import { always } from 'ramda';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-json';
 
 import MapJsonObjectVisitor from '../../generics/MapJsonObjectVisitor';
 import { ValueVisitor } from '../../generics';
@@ -10,7 +12,7 @@ const SchemasVisitor = stampit(ValueVisitor, MapJsonObjectVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('schemas');
+    appendMetadata(['schemas'], this.element);
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/operation/CallbacksVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/operation/CallbacksVisitor.ts
@@ -1,5 +1,8 @@
 import stampit from 'stampit';
-import { isJsonObject, JsonNode } from 'apidom-ast';
+import { isJsonObject, JsonNode, JsonObject } from 'apidom-ast';
+import { isReferenceElement, ReferenceElement } from 'apidom-ns-openapi-3-1';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-json';
 
 import MapJsonObjectVisitor from '../../generics/MapJsonObjectVisitor';
 import { isReferenceObject } from '../../../predicates';
@@ -18,7 +21,18 @@ const CallbacksVisitor = stampit(ValueVisitor, MapJsonObjectVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('callbacks');
+    appendMetadata(['callbacks'], this.element);
+  },
+  methods: {
+    object(objectNode: JsonObject) {
+      const result = MapJsonObjectVisitor.compose.methods.object.call(this, objectNode);
+
+      this.element.filter(isReferenceElement).forEach((referenceElement: ReferenceElement) => {
+        appendMetadata(['openapi-reference-for-callback'], referenceElement);
+      });
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/operation/RequestBodyVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/operation/RequestBodyVisitor.ts
@@ -1,5 +1,9 @@
 import stampit from 'stampit';
 import { T as stubTrue } from 'ramda';
+import { JsonObject } from 'apidom-ast';
+import { isReferenceElement } from 'apidom-ns-openapi-3-1';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-json';
 
 import { isRequestBodyObject, isReferenceObject } from '../../../predicates';
 import AlternatingVisitor from '../../generics/AlternatingVisitor';
@@ -11,6 +15,17 @@ const RequestBodyVisitor = stampit(AlternatingVisitor, {
       { predicate: isReferenceObject({}), specPath: ['document', 'objects', 'Reference'] },
       { predicate: stubTrue, specPath: ['value'] },
     ],
+  },
+  methods: {
+    object(objectNode: JsonObject) {
+      const result = AlternatingVisitor.compose.methods.object.call(this, objectNode);
+
+      if (isReferenceElement(this.element)) {
+        appendMetadata(['openapi-reference-for-requestBody'], this.element);
+      }
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/operation/TagsVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/operation/TagsVisitor.ts
@@ -1,16 +1,16 @@
 import stampit from 'stampit';
 // @ts-ignore
-import { SpecificationVisitor } from 'apidom-parser-adapter-json';
+import { appendMetadata } from 'apidom-parser-adapter-json';
 
 import { ValueVisitor } from '../../generics';
 
-const TagsVisitor = stampit(ValueVisitor, SpecificationVisitor, {
+const TagsVisitor = stampit(ValueVisitor, {
   methods: {
     array(arrayNode) {
       // @ts-ignore
       const result = ValueVisitor.compose.methods.array.call(this, arrayNode);
 
-      this.element.classes.push('tags');
+      appendMetadata(['tags'], this.element);
 
       return result;
     },

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/responses/DefaultVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/responses/DefaultVisitor.ts
@@ -1,5 +1,9 @@
 import stampit from 'stampit';
 import { T as stubTrue } from 'ramda';
+import { JsonObject } from 'apidom-ast';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-json';
+import { isReferenceElement } from 'apidom-ns-openapi-3-1';
 
 import { isReferenceObject, isResponseObject } from '../../../predicates';
 import AlternatingVisitor from '../../generics/AlternatingVisitor';
@@ -11,6 +15,17 @@ const DefaultVisitor = stampit(AlternatingVisitor, {
       { predicate: isResponseObject({}), specPath: ['document', 'objects', 'Response'] },
       { predicate: stubTrue, specPath: ['value'] },
     ],
+  },
+  methods: {
+    object(objectNode: JsonObject) {
+      const result = AlternatingVisitor.compose.methods.object.call(this, objectNode);
+
+      if (isReferenceElement(this.element)) {
+        appendMetadata(['openapi-reference-for-response'], this.element);
+      }
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/responses/index.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/responses/index.ts
@@ -1,6 +1,9 @@
 import stampit from 'stampit';
 import { test, always } from 'ramda';
-import { JsonNode } from 'apidom-ast';
+import { JsonNode, JsonObject } from 'apidom-ast';
+import { isReferenceElement, ReferenceElement } from 'apidom-ns-openapi-3-1';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-json';
 
 import { isReferenceObject, isResponseObject } from '../../../predicates';
 import MixedFieldsJsonObjectVisitor from '../../generics/MixedFieldsJsonObjectVisitor';
@@ -23,6 +26,18 @@ const ResponsesVisitor = stampit(ValueVisitor, MixedFieldsJsonObjectVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Responses();
+  },
+  methods: {
+    object(objectNode: JsonObject) {
+      // @ts-ignore
+      const result = MixedFieldsJsonObjectVisitor.compose.methods.object.call(this, objectNode);
+
+      this.element.filter(isReferenceElement).forEach((referenceElement: ReferenceElement) => {
+        appendMetadata(['openapi-reference-for-response'], referenceElement);
+      });
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/server/VariablesVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-json-3-1/src/parser/visitors/open-api-3-1/server/VariablesVisitor.ts
@@ -1,5 +1,7 @@
 import stampit from 'stampit';
 import { always } from 'ramda';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-json';
 
 import MapJsonObjectVisitor from '../../generics/MapJsonObjectVisitor';
 import { ValueVisitor } from '../../generics';
@@ -10,7 +12,7 @@ const VariablesVisitor = stampit(ValueVisitor, MapJsonObjectVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('variables');
+    appendMetadata(['variables'], this.element);
   },
 });
 


### PR DESCRIPTION
This new metadata will allow us to distinguish the type
of the value (Element) that the Reference Object is referencing.

Refs https://github.com/swagger-api/oss-planning/issues/133