### PR TITLE
refactor(OpenApi3.1-YAML): annotate Reference Object with meta

### DIFF
--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/SpecificationExtensionVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/SpecificationExtensionVisitor.ts
@@ -1,7 +1,7 @@
 import stampit from 'stampit';
 import { YamlAlias, YamlKeyValuePair, YamlMapping, YamlScalar, YamlSequence } from 'apidom-ast';
 // @ts-ignore
-import { SpecificationVisitor, BREAK, visit } from 'apidom-parser-adapter-yaml-1-2';
+import { appendMetadata, SpecificationVisitor, BREAK, visit } from 'apidom-parser-adapter-yaml-1-2';
 
 import { isOpenApiExtension } from '../predicates';
 
@@ -28,7 +28,7 @@ const SpecificationExtensionVisitor = stampit(SpecificationVisitor, {
       );
 
       if (isOpenApiExtension({}, keyValuePairNode)) {
-        memberElement.classes.push('specificationExtension');
+        appendMetadata(['specification-extension'], memberElement);
       }
 
       this.element = memberElement;

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/ParametersVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/ParametersVisitor.ts
@@ -1,7 +1,7 @@
 import stampit from 'stampit';
 import { YamlSequence } from 'apidom-ast';
 // @ts-ignore
-import { BREAK, SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
+import { appendMetadata, BREAK, SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
 
 import { isParameterObject, isReferenceObject } from '../../predicates';
 import { KindVisitor } from '../generics';
@@ -9,13 +9,14 @@ import { KindVisitor } from '../generics';
 const ParametersVisitor = stampit(KindVisitor, SpecificationVisitor, {
   init() {
     this.element = new this.namespace.elements.Array();
-    this.element.classes.push('parameters');
+    appendMetadata(['parameters'], this.element);
   },
   methods: {
     sequence(sequenceNode: YamlSequence) {
       sequenceNode.content.forEach((item): void => {
         if (isReferenceObject({}, item)) {
           const referenceElement = this.nodeToElement(['document', 'objects', 'Reference'], item);
+          appendMetadata(['openapi-reference-for-parameter'], referenceElement);
           this.element.push(referenceElement);
         } else if (isParameterObject({}, item)) {
           const parameterElement = this.nodeToElement(['document', 'objects', 'Parameter'], item);

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/SecurityVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/SecurityVisitor.ts
@@ -1,14 +1,14 @@
 import stampit from 'stampit';
 import { isYamlMapping, YamlSequence } from 'apidom-ast';
 // @ts-ignore
-import { BREAK, SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
+import { appendMetadata, BREAK, SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
 
 import { KindVisitor } from '../generics';
 
 const SecurityVisitor = stampit(KindVisitor, SpecificationVisitor, {
   init() {
     this.element = new this.namespace.elements.Array();
-    this.element.classes.push('security');
+    appendMetadata(['security'], this.element);
   },
   methods: {
     sequence(sequenceNode: YamlSequence) {

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/ServersVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/ServersVisitor.ts
@@ -1,7 +1,7 @@
 import stampit from 'stampit';
 import { YamlSequence } from 'apidom-ast';
 // @ts-ignore
-import { BREAK, SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
+import { appendMetadata, BREAK, SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
 
 import { isServerObject } from '../../predicates';
 import { KindVisitor } from '../generics';
@@ -9,7 +9,7 @@ import { KindVisitor } from '../generics';
 const ServersVisitor = stampit(KindVisitor, SpecificationVisitor, {
   init() {
     this.element = new this.namespace.elements.Array();
-    this.element.classes.push('servers');
+    appendMetadata(['servers'], this.element);
   },
   methods: {
     sequence(sequenceNode: YamlSequence) {

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/components/ParametersVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/components/ParametersVisitor.ts
@@ -1,5 +1,7 @@
 import stampit from 'stampit';
-import { YamlNode } from 'apidom-ast';
+import { YamlMapping, YamlNode } from 'apidom-ast';
+// @ts-ignore
+import { appendMetadata, isReferenceElement, ReferenceElement } from 'apidom-ns-openapi-3-1';
 
 import MapYamlMappingVisitor from '../../generics/MapYamlMappingVisitor';
 import { KindVisitor } from '../../generics';
@@ -19,6 +21,17 @@ const ParametersVisitor = stampit(KindVisitor, MapYamlMappingVisitor, {
   init() {
     this.element = new this.namespace.elements.Object();
     this.element.classes.push('parameters');
+  },
+  methods: {
+    mapping(mappingNode: YamlMapping) {
+      const result = MapYamlMappingVisitor.compose.methods.mapping.call(this, mappingNode);
+
+      this.element.filter(isReferenceElement).forEach((referenceElement: ReferenceElement) => {
+        appendMetadata(['openapi-reference-for-parameter'], referenceElement);
+      });
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/components/SchemasVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/components/SchemasVisitor.ts
@@ -1,5 +1,7 @@
 import stampit from 'stampit';
 import { always } from 'ramda';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-yaml-1-2';
 
 import MapYamlMappingVisitor from '../../generics/MapYamlMappingVisitor';
 import { KindVisitor } from '../../generics';
@@ -10,7 +12,7 @@ const SchemasVisitor = stampit(KindVisitor, MapYamlMappingVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('schemas');
+    appendMetadata(['schemas'], this.element);
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/operation/CallbacksVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/operation/CallbacksVisitor.ts
@@ -1,5 +1,8 @@
 import stampit from 'stampit';
-import { isYamlMapping } from 'apidom-ast';
+import { isYamlMapping, YamlMapping } from 'apidom-ast';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-yaml-1-2';
+import { isReferenceElement, ReferenceElement } from 'apidom-ns-openapi-3-1';
 
 import MapYamlMappingVisitor from '../../generics/MapYamlMappingVisitor';
 import { isReferenceObject } from '../../../predicates';
@@ -18,7 +21,18 @@ const CallbacksVisitor = stampit(KindVisitor, MapYamlMappingVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('callbacks');
+    appendMetadata(['callbacks'], this.element);
+  },
+  methods: {
+    mapping(mappingNode: YamlMapping) {
+      const result = MapYamlMappingVisitor.compose.methods.mapping.call(this, mappingNode);
+
+      this.element.filter(isReferenceElement).forEach((referenceElement: ReferenceElement) => {
+        appendMetadata(['openapi-reference-for-callback'], referenceElement);
+      });
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/operation/RequestBodyVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/operation/RequestBodyVisitor.ts
@@ -1,5 +1,9 @@
 import stampit from 'stampit';
 import { T as stubTrue } from 'ramda';
+import { YamlMapping } from 'apidom-ast';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-yaml-1-2';
+import { isReferenceElement } from 'apidom-ns-openapi-3-1';
 
 import { isRequestBodyObject, isReferenceObject } from '../../../predicates';
 import AlternatingVisitor from '../../generics/AlternatingVisitor';
@@ -11,6 +15,17 @@ const RequestBodyVisitor = stampit(AlternatingVisitor, {
       { predicate: isReferenceObject({}), specPath: ['document', 'objects', 'Reference'] },
       { predicate: stubTrue, specPath: ['kind'] },
     ],
+  },
+  methods: {
+    mapping(mappingNode: YamlMapping) {
+      const result = AlternatingVisitor.compose.methods.mapping.call(this, mappingNode);
+
+      if (isReferenceElement(this.element)) {
+        appendMetadata(['openapi-reference-for-requestBody'], this.element);
+      }
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/operation/TagsVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/operation/TagsVisitor.ts
@@ -1,17 +1,17 @@
 import stampit from 'stampit';
 import { YamlSequence } from 'apidom-ast';
 // @ts-ignore
-import { SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
+import { appendMetadata } from 'apidom-parser-adapter-yaml-1-2';
 
 import { KindVisitor } from '../../generics';
 
-const TagsVisitor = stampit(KindVisitor, SpecificationVisitor, {
+const TagsVisitor = stampit(KindVisitor, {
   methods: {
     sequence(sequenceNode: YamlSequence) {
       // @ts-ignore
       const result = KindVisitor.compose.methods.sequence.call(this, sequenceNode);
 
-      this.element.classes.push('tags');
+      appendMetadata(['tags'], this.element);
 
       return result;
     },

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/responses/DefaultVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/responses/DefaultVisitor.ts
@@ -1,5 +1,9 @@
 import stampit from 'stampit';
 import { T as stubTrue } from 'ramda';
+import { YamlMapping } from 'apidom-ast';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-yaml-1-2';
+import { isReferenceElement } from 'apidom-ns-openapi-3-1';
 
 import { isReferenceObject, isResponseObject } from '../../../predicates';
 import AlternatingVisitor from '../../generics/AlternatingVisitor';
@@ -11,6 +15,17 @@ const DefaultVisitor = stampit(AlternatingVisitor, {
       { predicate: isResponseObject({}), specPath: ['document', 'objects', 'Response'] },
       { predicate: stubTrue, specPath: ['kind'] },
     ],
+  },
+  methods: {
+    mapping(mappingNode: YamlMapping) {
+      const result = AlternatingVisitor.compose.methods.object.call(this, mappingNode);
+
+      if (isReferenceElement(this.element)) {
+        appendMetadata(['openapi-reference-for-response'], this.element);
+      }
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/responses/index.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/responses/index.ts
@@ -1,5 +1,9 @@
 import stampit from 'stampit';
 import { test, always } from 'ramda';
+import { YamlMapping } from 'apidom-ast';
+import { isReferenceElement, ReferenceElement } from 'apidom-ns-openapi-3-1';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-yaml-1-2';
 
 import { isReferenceObject, isResponseObject } from '../../../predicates';
 import MixedFieldsYamlMappingVisitor from '../../generics/MixedFieldsYamlMappingVisitor';
@@ -22,6 +26,18 @@ const ResponsesVisitor = stampit(KindVisitor, MixedFieldsYamlMappingVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Responses();
+  },
+  methods: {
+    mapping(mappingNode: YamlMapping) {
+      // @ts-ignore
+      const result = MixedFieldsYamlMappingVisitor.compose.methods.mapping.call(this, mappingNode);
+
+      this.element.filter(isReferenceElement).forEach((referenceElement: ReferenceElement) => {
+        appendMetadata(['openapi-reference-for-response'], referenceElement);
+      });
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/server/VariablesVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-openapi-yaml-3-1/src/parser/visitors/open-api-3-1/server/VariablesVisitor.ts
@@ -1,5 +1,7 @@
 import stampit from 'stampit';
 import { always } from 'ramda';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-yaml-1-2';
 
 import { KindVisitor } from '../../generics';
 import MapYamlMappingVisitor from '../../generics/MapYamlMappingVisitor';
@@ -10,7 +12,7 @@ const VariablesVisitor = stampit(KindVisitor, MapYamlMappingVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('variables');
+    appendMetadata(['variables'], this.element);
   },
 });
 


### PR DESCRIPTION
This new metdata will allow us to distinguish the type
of the value (Element) that the Reference Object is referencing.

Refs https://github.com/swagger-api/oss-planning/issues/133