### PR TITLE
refactor(AsyncApi2.0): annotate Reference Object with meta

### DIFF
--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/index.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/index.ts
@@ -28,6 +28,7 @@ export {
   isServerElement,
   isServerVariableElement,
   isParameterElement,
+  isReferenceElement,
 } from './predicates';
 
 export { default as AsyncapiElement } from './elements/Asyncapi';

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/predicates.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/predicates.ts
@@ -15,6 +15,7 @@ import ServersElement from './elements/Servers';
 import ServerElement from './elements/Server';
 import ServerVariableElement from './elements/ServerVariable';
 import ParameterElement from './elements/Parameter';
+import ReferenceElement from './elements/Reference';
 
 export const isAsycApi2_0Element = createPredicate(
   ({ hasBasicElementProps, isElementType, primitiveEq, hasClass }) => {
@@ -181,6 +182,18 @@ export const isParameterElement = createPredicate(
     return either(
       is(ParameterElement),
       allPass([hasBasicElementProps, isElementTypeParameter, primitiveEqObject]),
+    );
+  },
+);
+
+export const isReferenceElement = createPredicate(
+  ({ hasBasicElementProps, isElementType, primitiveEq }) => {
+    const isElementTypeReference = isElementType('reference');
+    const primitiveEqObject = primitiveEq('object');
+
+    return either(
+      is(ReferenceElement),
+      allPass([hasBasicElementProps, isElementTypeReference, primitiveEqObject]),
     );
   },
 );

--- a/apidom/packages/apidom-ns-asyncapi-2-0/test/predicates.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/test/predicates.ts
@@ -16,6 +16,7 @@ import {
   isServerElement,
   isServerVariableElement,
   isParameterElement,
+  isReferenceElement,
   AsyncApi2_0Element,
   AsyncapiElement,
   SchemaElement,
@@ -30,6 +31,7 @@ import {
   ServerElement,
   ServerVariableElement,
   ParameterElement,
+  ReferenceElement,
 } from '../src';
 
 describe('predicates', function () {
@@ -773,6 +775,59 @@ describe('predicates', function () {
 
       assert.isTrue(isParameterElement(parameterElementDuck));
       assert.isFalse(isParameterElement(parameterItemElementSwan));
+    });
+  });
+
+  context('isReferenceElement', function () {
+    context('given ReferenceElement instance value', function () {
+      specify('should return true', function () {
+        const element = new ReferenceElement();
+
+        assert.isTrue(isReferenceElement(element));
+      });
+    });
+
+    context('given subtype instance value', function () {
+      specify('should return true', function () {
+        class ReferenceSubElement extends ReferenceElement {}
+
+        assert.isTrue(isReferenceElement(new ReferenceSubElement()));
+      });
+    });
+
+    context('given non ReferenceElement instance value', function () {
+      specify('should return false', function () {
+        assert.isFalse(isReferenceElement(1));
+        assert.isFalse(isReferenceElement(null));
+        assert.isFalse(isReferenceElement(undefined));
+        assert.isFalse(isReferenceElement({}));
+        assert.isFalse(isReferenceElement([]));
+        assert.isFalse(isReferenceElement('string'));
+      });
+    });
+
+    specify('should support duck-typing', function () {
+      const referenceElementDuck = {
+        _storedElement: 'reference',
+        _content: [],
+        primitive() {
+          return 'object';
+        },
+        get element() {
+          return this._storedElement;
+        },
+      };
+
+      const referenceElementSwan = {
+        _storedElement: undefined,
+        _content: undefined,
+        primitive() {
+          return 'swan';
+        },
+      };
+
+      assert.isTrue(isReferenceElement(referenceElementDuck));
+      assert.isFalse(isReferenceElement(referenceElementSwan));
     });
   });
 });

--- a/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/SpecificationExtensionVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/SpecificationExtensionVisitor.ts
@@ -1,6 +1,6 @@
 import stampit from 'stampit';
 // @ts-ignore
-import { SpecificationVisitor, BREAK, visit } from 'apidom-parser-adapter-json';
+import { appendMetadata, SpecificationVisitor, BREAK, visit } from 'apidom-parser-adapter-json';
 
 import { isAsyncApiExtension } from '../predicates';
 
@@ -24,7 +24,7 @@ const SpecificationExtensionVisitor = stampit(SpecificationVisitor, {
       );
 
       if (isAsyncApiExtension({}, propertyNode)) {
-        memberElement.classes.push('specificationExtension');
+        appendMetadata(['specification-extension'], memberElement);
       }
 
       this.element = memberElement;

--- a/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/async-api-2-0/components/SchemasVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/async-api-2-0/components/SchemasVisitor.ts
@@ -1,5 +1,7 @@
 import stampit from 'stampit';
 import { always } from 'ramda';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-json';
 
 import MapJsonObjectVisitor from '../../generics/MapJsonObjectVisitor';
 import { ValueVisitor } from '../../generics';
@@ -10,7 +12,7 @@ const SchemasVisitor = stampit(ValueVisitor, MapJsonObjectVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('schemas');
+    appendMetadata(['schemas'], this.element);
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/async-api-2-0/parameters/index.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/async-api-2-0/parameters/index.ts
@@ -1,6 +1,9 @@
 import stampit from 'stampit';
 import { test } from 'ramda';
-import { isJsonObject, JsonNode } from 'apidom-ast';
+import { isJsonObject, JsonNode, JsonObject } from 'apidom-ast';
+import { isReferenceElement, ReferenceElement } from 'apidom-ns-asyncapi-2-0';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-json';
 
 import PatternedFieldsJsonObjectVisitor from '../../generics/PatternedFieldsJsonObjectVisitor';
 import { ValueVisitor } from '../../generics';
@@ -20,6 +23,18 @@ const ParametersVisitor = stampit(ValueVisitor, PatternedFieldsJsonObjectVisitor
   },
   init() {
     this.element = new this.namespace.elements.Parameters();
+  },
+  methods: {
+    object(objectNode: JsonObject) {
+      // @ts-ignore
+      const result = PatternedFieldsJsonObjectVisitor.compose.methods.object.call(this, objectNode);
+
+      this.element.filter(isReferenceElement).forEach((referenceElement: ReferenceElement) => {
+        appendMetadata(['json-reference-for-parameter'], referenceElement);
+      });
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/async-api-2-0/server/SecurityVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/async-api-2-0/server/SecurityVisitor.ts
@@ -1,12 +1,14 @@
 import stampit from 'stampit';
 import { isJsonObject, JsonNode } from 'apidom-ast';
 // @ts-ignore
-import { SpecificationVisitor, BREAK } from 'apidom-parser-adapter-json';
+import { appendMetadata, SpecificationVisitor, BREAK } from 'apidom-parser-adapter-json';
 
-const SecurityVisitor = stampit(SpecificationVisitor, {
+import { ValueVisitor } from '../../generics';
+
+const SecurityVisitor = stampit(ValueVisitor, SpecificationVisitor, {
   init() {
     this.element = new this.namespace.elements.Array();
-    this.element.classes.push('security');
+    appendMetadata(['security'], this.element);
   },
   methods: {
     array(arrayNode) {

--- a/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/async-api-2-0/server/VariablesVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-json-2-0/src/parser/visitors/async-api-2-0/server/VariablesVisitor.ts
@@ -1,5 +1,7 @@
 import stampit from 'stampit';
 import { always } from 'ramda';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-json';
 
 import MapJsonObjectVisitor from '../../generics/MapJsonObjectVisitor';
 import { ValueVisitor } from '../../generics';
@@ -10,7 +12,7 @@ const VariablesVisitor = stampit(ValueVisitor, MapJsonObjectVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('variables');
+    appendMetadata(['variables'], this.element);
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/SpecificationExtensionVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/SpecificationExtensionVisitor.ts
@@ -1,7 +1,7 @@
 import stampit from 'stampit';
 import { YamlAlias, YamlKeyValuePair, YamlMapping, YamlScalar, YamlSequence } from 'apidom-ast';
 // @ts-ignore
-import { SpecificationVisitor, BREAK, visit } from 'apidom-parser-adapter-yaml-1-2';
+import { appendMetadata, SpecificationVisitor, BREAK, visit } from 'apidom-parser-adapter-yaml-1-2';
 
 import { isAsyncApiExtension } from '../predicates';
 
@@ -28,7 +28,7 @@ const SpecificationExtensionVisitor = stampit(SpecificationVisitor, {
       );
 
       if (isAsyncApiExtension({}, keyValuePairNode)) {
-        memberElement.classes.push('specificationExtension');
+        appendMetadata(['specification-extension'], memberElement);
       }
 
       this.element = memberElement;

--- a/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/async-api-2-0/components/SchemasVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/async-api-2-0/components/SchemasVisitor.ts
@@ -1,5 +1,7 @@
 import stampit from 'stampit';
 import { always } from 'ramda';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-yaml-1-2';
 
 import MapYamlMappingVisitor from '../../generics/MapYamlMappingVisitor';
 import { KindVisitor } from '../../generics';
@@ -10,7 +12,7 @@ const SchemasVisitor = stampit(KindVisitor, MapYamlMappingVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('schemas');
+    appendMetadata(['schemas'], this.element);
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/async-api-2-0/parameters/index.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/async-api-2-0/parameters/index.ts
@@ -1,9 +1,11 @@
 import stampit from 'stampit';
 import { test } from 'ramda';
-import { isYamlMapping, JsonNode } from 'apidom-ast';
+import { isYamlMapping, JsonNode, YamlMapping } from 'apidom-ast';
+import { isReferenceElement, ReferenceElement } from 'apidom-ns-openapi-3-1';
 // @ts-ignore
-import { isReferenceObject } from 'apidom-parser-adapter-asyncapi-json-2-0';
+import { appendMetadata } from 'apidom-parser-adapter-yaml-1-2';
 
+import { isReferenceObject } from '../../../predicates';
 import PatternedFieldsYamlMappingVisitor from '../../generics/PatternedFieldsYamlMappingVisitor';
 import { KindVisitor } from '../../generics';
 
@@ -21,6 +23,21 @@ const ParametersVisitor = stampit(KindVisitor, PatternedFieldsYamlMappingVisitor
   },
   init() {
     this.element = new this.namespace.elements.Parameters();
+  },
+  methods: {
+    mapping(mappingNode: YamlMapping) {
+      // @ts-ignore
+      const result = PatternedFieldsYamlMappingVisitor.compose.methods.mapping.call(
+        this,
+        mappingNode,
+      );
+
+      this.element.filter(isReferenceElement).forEach((referenceElement: ReferenceElement) => {
+        appendMetadata(['json-reference-for-parameter'], referenceElement);
+      });
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/async-api-2-0/server/SecurityVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/async-api-2-0/server/SecurityVisitor.ts
@@ -1,12 +1,12 @@
 import stampit from 'stampit';
 import { isYamlMapping, YamlSequence } from 'apidom-ast';
 // @ts-ignore
-import { BREAK, SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
+import { appendMetadata, BREAK, SpecificationVisitor } from 'apidom-parser-adapter-yaml-1-2';
 
 const SecurityVisitor = stampit(SpecificationVisitor, {
   init() {
     this.element = new this.namespace.elements.Array();
-    this.element.classes.push('security');
+    appendMetadata(['security'], this.element);
   },
   methods: {
     sequence(sequenceNode: YamlSequence) {

--- a/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/async-api-2-0/server/VariablesVisitor.ts
+++ b/apidom/packages/apidom-parser-adapter-asyncapi-yaml-2-0/src/parser/visitors/async-api-2-0/server/VariablesVisitor.ts
@@ -1,5 +1,7 @@
 import stampit from 'stampit';
 import { always } from 'ramda';
+// @ts-ignore
+import { appendMetadata } from 'apidom-parser-adapter-yaml-1-2';
 
 import MapYamlMappingVisitor from '../../generics/MapYamlMappingVisitor';
 import { KindVisitor } from '../../generics';
@@ -10,7 +12,7 @@ const VariablesVisitor = stampit(KindVisitor, MapYamlMappingVisitor, {
   },
   init() {
     this.element = new this.namespace.elements.Object();
-    this.element.classes.push('variables');
+    appendMetadata(['variables'], this.element);
   },
 });
 


### PR DESCRIPTION
This new metadata will allow us to distinguish the type
of the value (Element) that the Reference Object is referencing.

Refs https://github.com/swagger-api/oss-planning/issues/133