### PR TITLE
feat(reference): reduce Reference Objects into ReferenceMap

### DIFF
--- a/apidom/packages/@types/minim.d.ts
+++ b/apidom/packages/@types/minim.d.ts
@@ -45,7 +45,7 @@ declare module 'minim' {
 
     fromRefract(doc: JSON): Element;
 
-    register(name: string, elementClass: typeof Element): Namespace;
+    register(name: string, elementClass: any): Namespace;
 
     use(plugin: NamespacePlugin): Namespace;
   }
@@ -87,7 +87,7 @@ declare module 'minim' {
   }
 
   export class ObjectElement extends ArrayElement {
-    constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes);
+    constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes);
 
     get(key: string | number): any;
 
@@ -142,6 +142,8 @@ declare module 'minim' {
     filter(predicate: Predicate, thisArg?: unknown): ArraySlice;
 
     reject(predicate: Predicate, thisArg?: unknown): ArraySlice;
+
+    map(callback: (currentValue: any, index: number) => any, thisArg?: unknown): ArraySlice;
 
     hasKey(value: string): boolean;
 

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/AsyncApi2-0.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/AsyncApi2-0.ts
@@ -6,7 +6,7 @@ import InfoElement from './Info';
 import ChannelsElement from './Channels';
 
 class AsyncApi2_0 extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'asyncApi2-0';
     this.classes.push('api');

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/ChannelBindings.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/ChannelBindings.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class ChannelBindings extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'channelBindings';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/ChannelItem.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/ChannelItem.ts
@@ -5,7 +5,7 @@ import ParametersElement from './Parameters';
 import ChannelBindingsElement from './ChannelBindings';
 
 class ChannelItem extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'channelItem';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Channels.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Channels.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Channels extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'channels';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Components.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Components.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Components extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'components';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Contact.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Contact.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement, StringElement } from 'minim';
 
 class Contact extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'contact';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Info.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Info.ts
@@ -3,7 +3,7 @@ import ContactElement from './Contact';
 import LicenseElement from './License';
 
 class Info extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'info';
     this.classes.push('info');

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/License.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/License.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement, StringElement } from 'minim';
 
 class License extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'license';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Operation.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Operation.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Operation extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'operation';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Parameter.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Parameter.ts
@@ -3,7 +3,7 @@ import { Attributes, Meta, ObjectElement, StringElement } from 'minim';
 import SchemaElement from './Schema';
 
 class Parameter extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'parameter';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Parameters.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Parameters.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Parameters extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'parameters';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Reference.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Reference.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement, StringElement } from 'minim';
 
 class Reference extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'reference';
     this.classes.push('json-reference');

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Schema.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Schema.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Schema extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'schema';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/SecurityRequirement.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/SecurityRequirement.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class SecurityRequirement extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'securityRequirement';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Server.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Server.ts
@@ -5,7 +5,7 @@ import SecurityRequirementElement from './SecurityRequirement';
 import ServerBindingsElement from './ServerBindings';
 
 class Server extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'server';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/ServerBindings.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/ServerBindings.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class ServerBindings extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'serverBindings';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/ServerVariable.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/ServerVariable.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement, StringElement } from 'minim';
 
 class ServerVariable extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'serverVariable';
   }

--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Servers.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/elements/Servers.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Servers extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'servers';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Callback.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Callback.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Callback extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'callback';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Components.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Components.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Components extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'components';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Contact.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Contact.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement, StringElement } from 'minim';
 
 class Contact extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'contact';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/ExternalDocumentation.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/ExternalDocumentation.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement, StringElement } from 'minim';
 
 class ExternalDocumentation extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'externalDocumentation';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Info.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Info.ts
@@ -3,7 +3,7 @@ import ContactElement from './Contact';
 import LicenseElement from './License';
 
 class Info extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'info';
     this.classes.push('info');

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/License.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/License.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement, StringElement } from 'minim';
 
 class License extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'license';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/OpenApi3-1.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/OpenApi3-1.ts
@@ -5,7 +5,7 @@ import ServerElement from './Server';
 import ComponentsElement from './Components';
 
 class OpenApi3_1 extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'openApi3-1';
     this.classes.push('api');

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Operation.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Operation.ts
@@ -9,7 +9,7 @@ import CallbackElement from './Callback';
 import SecurityRequirementElement from './SecurityRequirement';
 
 class Operation extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'operation';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Parameter.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Parameter.ts
@@ -3,7 +3,7 @@ import { Attributes, BooleanElement, Meta, ObjectElement, StringElement } from '
 import SchemaElement from './Schema';
 
 class Parameter extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'parameter';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/PathItem.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/PathItem.ts
@@ -6,7 +6,7 @@ import ParameterElement from './Parameter';
 import ReferenceElement from './Reference';
 
 class PathItem extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'pathItem';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Paths.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Paths.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Paths extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'paths';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Reference.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Reference.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement, StringElement } from 'minim';
 
 class Reference extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'reference';
     this.classes.push('openapi-reference');

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/RequestBody.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/RequestBody.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class RequestBody extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'requestBody';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Response.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Response.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Response extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'response';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Responses.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Responses.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Responses extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'responses';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Schema.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Schema.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class Schema extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'schema';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/SecurityRequirement.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/SecurityRequirement.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
 class SecurityRequirement extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'securityRequirement';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Server.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Server.ts
@@ -2,7 +2,7 @@ import { Attributes, Meta, ObjectElement, StringElement } from 'minim';
 import ServerVariable from './ServerVariable';
 
 class Server extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'server';
   }

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/ServerVariable.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/ServerVariable.ts
@@ -1,7 +1,7 @@
 import { Attributes, Meta, ObjectElement, ArrayElement, StringElement } from 'minim';
 
 class ServerVariable extends ObjectElement {
-  constructor(content?: Array<unknown>, meta?: Meta, attributes?: Attributes) {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'serverVariable';
   }

--- a/apidom/packages/apidom-reference/src/ReferenceMap.ts
+++ b/apidom/packages/apidom-reference/src/ReferenceMap.ts
@@ -1,19 +1,34 @@
 import stampit from 'stampit';
+import { keys } from 'ramda';
 
 interface ReferenceMap {
-  root: null;
-  refs: Array<any>;
+  rootRef: null;
+  refs: Record<string, any>;
   circular: boolean;
+  readonly length: number;
+
+  set(uri: string, value?: unknown): ReferenceMap;
 }
 
 const ReferenceMap: stampit.Stamp<ReferenceMap> = stampit({
   props: {
-    root: null,
+    rootRef: null,
     refs: {},
     circular: false,
   },
   init() {
     this.refs = {};
+  },
+  methods: {
+    get length(): number {
+      return keys(this.refs).length;
+    },
+
+    set(uri: string, value: unknown = null): ReferenceMap {
+      this.refs[uri] = value;
+      this.rootRef = this.rootRef === null ? uri : this.rootRef;
+      return this;
+    },
   },
 });
 

--- a/apidom/packages/apidom-reference/src/strategies/openapi-3-1/predicates.ts
+++ b/apidom/packages/apidom-reference/src/strategies/openapi-3-1/predicates.ts
@@ -1,9 +1,19 @@
-import { complement, pathSatisfies, startsWith, both } from 'ramda';
+import { startsWith } from 'ramda';
+import { isStringElement } from 'apidom';
 import { isReferenceElement } from 'apidom-ns-openapi-3-1';
 
-export const isExternalReferenceElement = both(
-  isReferenceElement,
-  pathSatisfies(complement(startsWith('#')), ['$ref']),
-);
+export const isExternalReferenceElement = (element: any): boolean => {
+  if (!isReferenceElement(element)) {
+    return false;
+  }
+  // @ts-ignore
+  const $refElement = element.$ref;
+
+  if (!isStringElement($refElement)) {
+    return false;
+  }
+
+  return !startsWith('#', $refElement.toValue());
+};
 
 export { isReferenceElement };

--- a/apidom/packages/apidom-reference/src/strategies/openapi-3-1/resolve/resolve-reference-objects.ts
+++ b/apidom/packages/apidom-reference/src/strategies/openapi-3-1/resolve/resolve-reference-objects.ts
@@ -1,6 +1,10 @@
-// import { Element, filter } from 'apidom';
-//
-// import { isExternalReferenceElement } from '../predicates';
+import { transduce, map, mergeDeepRight } from 'ramda';
+import { Element, filter } from 'apidom';
+import { ReferenceElement } from 'apidom-ns-openapi-3-1';
+
+import * as url from '../../../util/url';
+import { isExternalReferenceElement } from '../predicates';
+import ReferenceMap from '../../../ReferenceMap';
 
 /**
  * 1.) Compute base URI
@@ -15,12 +19,38 @@
  *     is created and all non-root References are assigned as direct
  */
 
-// interface ResolveOptions {
-//   maxDepth?: number;
-// }
-//
-// const resolve = <T extends Element>(element: T, options: ResolveOptions = {}): unknown => {
-//   const externalReferences = filter(isExternalReferenceElement)(element);
-// };
-//
-// export default resolve;
+/**
+ * If the path is a filesystem path, then convert it to a URL.
+ *
+ * NOTE: According to the JSON Reference spec, these should already be URLs,
+ * but, in practice, many people use local filesystem paths instead.
+ * So we're being generous here and doing the conversion automatically.
+ * This is not intended to be a 100% bulletproof solution.
+ * If it doesn't work for your use-case, then use a URL instead.
+ */
+const sanitizeBaseURI = (baseURI: string): string => {
+  return url.isFileSystemPath(baseURI) ? url.fromFileSystemPath(baseURI) : baseURI;
+};
+
+const defaultOptions = {
+  baseURI: '',
+};
+
+/**
+ * Find and resolve ReferenceElements into ReferenceMap.
+ */
+const resolve = <T extends Element>(element: T, options = defaultOptions): ReferenceMap => {
+  const mergedOpts = mergeDeepRight(defaultOptions, options);
+  const baseURI = url.resolve(url.cwd(), sanitizeBaseURI(mergedOpts.baseURI)); // make it absolut
+  const externalRefs = filter(isExternalReferenceElement)(element);
+  const transducer = map((ref: ReferenceElement) => url.stripHash(ref.$ref.toValue()));
+  const iteratorFn = (acc: ReferenceMap, uri: string) => acc.set(uri);
+  const refMap = ReferenceMap();
+
+  refMap.set(baseURI);
+
+  // @ts-ignore
+  return transduce(transducer, iteratorFn, refMap, externalRefs);
+};
+
+export default resolve;

--- a/apidom/packages/apidom-reference/src/util/url.ts
+++ b/apidom/packages/apidom-reference/src/util/url.ts
@@ -118,7 +118,7 @@ export const toFileSystemPath = (uri: string, options?: ToFileSystemPathOptions)
 /**
  * Converts a filesystem path to a properly-encoded URL.
  *
- * This is intended to handle situations where JSON Schema $Ref Parser is called
+ * This is intended to handle situations where resolver is called
  * with a filesystem path that contains characters which are not allowed in URLs.
  *
  * @example
@@ -195,4 +195,16 @@ export const resolve = (from: string, to: string): string => {
   }
 
   return new URL(to, from).toString();
+};
+
+/**
+ * Removes the hash (URL fragment), if any, from the given path.
+ */
+export const stripHash = (uri: string): string => {
+  const hashIndex = uri.indexOf('#');
+  let hashStrippedUri = uri;
+  if (hashIndex >= 0) {
+    hashStrippedUri = uri.substr(0, hashIndex);
+  }
+  return hashStrippedUri;
 };

--- a/apidom/packages/apidom-reference/test/strategies/openapi-3-1/predicates.ts
+++ b/apidom/packages/apidom-reference/test/strategies/openapi-3-1/predicates.ts
@@ -1,0 +1,66 @@
+import { assert } from 'chai';
+import {
+  StringElement,
+  ObjectElement,
+  BooleanElement,
+  ArrayElement,
+  NumberElement,
+  NullElement,
+} from 'apidom';
+import { ReferenceElement } from 'apidom-ns-openapi-3-1';
+
+import { isExternalReferenceElement } from '../../../src/strategies/openapi-3-1/predicates';
+
+describe('strategies', function () {
+  context('openapi-3-1', function () {
+    context('predicates', function () {
+      context('isExternalReferenceElement', function () {
+        context('given external reference element with URL', function () {
+          specify('should return true', function () {
+            const externalReferenceElement = new ReferenceElement({
+              $ref: 'https://swagger.io/petstore.json',
+              summary: 'summary',
+              description: 'description',
+            });
+
+            assert.isTrue(isExternalReferenceElement(externalReferenceElement));
+          });
+        });
+
+        context('given external reference element with hash', function () {
+          specify('should return true', function () {
+            const externalReferenceElement = new ReferenceElement({
+              $ref: '#/path/to/data',
+              summary: 'summary',
+              description: 'description',
+            });
+
+            assert.isFalse(isExternalReferenceElement(externalReferenceElement));
+          });
+        });
+
+        context('given other elements', function () {
+          specify('should return false', function () {
+            assert.isFalse(isExternalReferenceElement(new StringElement()));
+            assert.isFalse(isExternalReferenceElement(new ObjectElement()));
+            assert.isFalse(isExternalReferenceElement(new ArrayElement()));
+            assert.isFalse(isExternalReferenceElement(new BooleanElement()));
+            assert.isFalse(isExternalReferenceElement(new NumberElement()));
+            assert.isFalse(isExternalReferenceElement(new NullElement()));
+          });
+        });
+
+        context('given javascript value', function () {
+          specify('should return false', function () {
+            assert.isFalse(isExternalReferenceElement(null));
+            assert.isFalse(isExternalReferenceElement(undefined));
+            assert.isFalse(isExternalReferenceElement('string'));
+            assert.isFalse(isExternalReferenceElement(true));
+            assert.isFalse(isExternalReferenceElement(1));
+            assert.isFalse(isExternalReferenceElement([]));
+          });
+        });
+      });
+    });
+  });
+});

--- a/apidom/packages/apidom-reference/test/strategies/openapi-3-1/resolve/fixtures/single-external-reference.json
+++ b/apidom/packages/apidom-reference/test/strategies/openapi-3-1/resolve/fixtures/single-external-reference.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.1.0",
+  "x-top-level": "value",
+  "info": {
+    "title": "Sample API",
+    "description": "Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.",
+    "summary": "example summary",
+    "termsOfService": "Terms of service",
+    "version": "0.1.9",
+    "x-version": "0.1.9-beta",
+    "license": {
+      "name": "Apache License 2.0",
+      "x-fullName": "Apache License 2.0",
+      "identifier": "Apache License 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "contact": {
+      "name": "Vladimir Gorej",
+      "x-username": "char0n",
+      "url": "https://www.linkedin.com/in/vladimirgorej/",
+      "email": "vladimir.gorej@gmail.com"
+    }
+  },
+  "paths": {
+    "/users": {
+      "summary": "path item summary",
+      "description": "path item description",
+      "get": {
+        "tags": ["tag1", "tag2"],
+        "summary": "Returns a list of users.",
+        "description": "Optional extended description in CommonMark or HTML.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://example.com"
+        },
+        "operationId": "getUserList",
+        "parameters": [
+          {
+            "$ref": "https://swagger.io/path/to/file.json#/components/parameters/userId"
+          }
+        ],
+        "requestBody": {
+          "content": {}
+        },
+        "responses": {
+          "200": {
+            "description": "A JSON array of user names",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "A response"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "userId",
+          "in": "query",
+          "description": "ID of the user",
+          "required": true
+        }
+      ]
+    }
+  }
+}

--- a/apidom/packages/apidom-reference/test/strategies/openapi-3-1/resolve/resolve-reference-objects.ts
+++ b/apidom/packages/apidom-reference/test/strategies/openapi-3-1/resolve/resolve-reference-objects.ts
@@ -1,0 +1,26 @@
+import { assert } from 'chai';
+import fs from 'fs';
+import path from 'path';
+// @ts-ignore
+import * as adapter from 'apidom-parser-adapter-openapi-json-3-1';
+
+import resolve from '../../../../src/strategies/openapi-3-1/resolve/resolve-reference-objects';
+
+describe('strategies', function () {
+  context('openapi-3-1', function () {
+    context('resolve', function () {
+      context('resolve-reference-objects', function () {
+        context('given parsed OpenApi 3.1.x document with single reference', function () {
+          specify('should have 2 references in reference map', async function () {
+            const jsonDataPath = path.join(__dirname, 'fixtures', 'single-external-reference.json');
+            const jsonData = fs.readFileSync(jsonDataPath).toString();
+            const parseResult = await adapter.parse(jsonData);
+            const refMap = resolve(parseResult);
+
+            assert.strictEqual(refMap.length, 2);
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
We're not able to find all Reference Objects within
ApiDOM including root document's base URI and reduce
it into ReferenceMap.

This only works for n+1 reference depth level.

Refs https://github.com/swagger-api/apidom/issues/136