### PR TITLE
feat: introduce namespace refractor

### DIFF
--- a/apidom/packages/@types/minim.d.ts
+++ b/apidom/packages/@types/minim.d.ts
@@ -7,14 +7,18 @@ declare module 'minim' {
   export type Predicate = (element: Element) => boolean;
   type Callback = (element: Element) => void;
 
+  export function refract(value: any): Element;
+
   export class Element {
+    static refract(value: any, option?: Record<string, any>): Element;
+
     public element: string;
 
     public meta: ObjectElement;
 
-    public classes: ArrayElement;
+    public attributes: ObjectElement;
 
-    public attributes: Attributes;
+    public classes: ArrayElement;
 
     public children: ArraySlice;
 
@@ -90,6 +94,8 @@ declare module 'minim' {
 
     push(value: any): ArrayElement;
 
+    forEach(callback: (item: Element, index: number) => void, thisArg?: unknown): void;
+
     [Symbol.iterator](): IterableIterator<any>;
 
     get length(): number;
@@ -105,6 +111,12 @@ declare module 'minim' {
     hasKey(value: string): boolean;
 
     getMember(key: string): MemberElement;
+
+    // @ts-ignore
+    forEach(
+      callback: (value: Element, key: Element, item: Element) => void,
+      thisArg?: unknown,
+    ): void;
 
     map(
       callback: (value: Element, key: Element, member: MemberElement) => MemberElement,

--- a/apidom/packages/apidom-ns-openapi-3-1/src/namespace.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/namespace.ts
@@ -1,4 +1,5 @@
 import { NamespacePluginOptions } from 'minim';
+
 import OpenApi3_1 from './elements/OpenApi3-1';
 import Openapi from './elements/Openapi';
 import Info from './elements/Info';
@@ -19,6 +20,37 @@ import Responses from './elements/Responses';
 import Callback from './elements/Callback';
 import SecurityRequirement from './elements/SecurityRequirement';
 import Response from './elements/Response';
+
+import { createRefractor } from './refractor';
+
+// register refractors specific to element types
+OpenApi3_1.refract = createRefractor(['visitors', 'document', 'objects', 'OpenApi', '$visitor']);
+Openapi.refract = createRefractor([
+  'visitors',
+  'document',
+  'objects',
+  'OpenApi',
+  'fixedFields',
+  'Openapi',
+]);
+Info.refract = createRefractor(['visitors', 'document', 'objects', 'Info', '$visitor']);
+License.refract = createRefractor(['visitors', 'document', 'objects', 'License', '$visitor']);
+Contact.refract = createRefractor(['visitors', 'document', 'objects', 'Contact', '$visitor']);
+Server.refract = createRefractor(['visitors', 'document', 'objects', 'Server', '$visitor']);
+ServerVariable.refract = createRefractor([
+  'visitors',
+  'document',
+  'objects',
+  'ServerVariable',
+  '$visitor',
+]);
+SecurityRequirement.refract = createRefractor([
+  'visitors',
+  'document',
+  'objects',
+  'SecurityRequirement',
+  '$visitor',
+]);
 
 const openApi3_1 = {
   namespace: (options: NamespacePluginOptions) => {

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/index.ts
@@ -1,0 +1,28 @@
+import { refract as baseRefract } from 'minim';
+import { Element } from 'apidom';
+import { invokeArgs } from 'ramda-adjunct';
+
+import { visit } from '../traversal/visitor';
+import specification, { dereference } from './specification';
+
+const refract = <T extends Element>(
+  value: any,
+  {
+    specPath = ['visitors', 'document', 'objects', 'OpenApi', '$visitor'],
+    specObj = specification,
+  } = {},
+): T => {
+  const element = baseRefract(value);
+  const resolvedSpec = dereference(specObj);
+  const visitor = invokeArgs(specPath, [], resolvedSpec);
+
+  // @ts-ignore
+  visit(element, visitor, { state: { specObj: resolvedSpec } });
+
+  return visitor.element;
+};
+
+export const createRefractor = (specPath: string[]) => (value: any, options = {}) =>
+  refract(value, { specPath, ...options });
+
+export default refract;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/metadata.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/metadata.ts
@@ -1,0 +1,11 @@
+import { Element } from 'apidom';
+
+// eslint-disable-next-line import/prefer-default-export
+export const appendMetadata = <T extends Element>(metadata: string[], element: T): T => {
+  metadata.forEach((md: string) => {
+    element.classes.push(md);
+    element.getMetaProperty('symbols', []).push(md);
+  });
+
+  return element;
+};

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/predicates.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/predicates.ts
@@ -1,0 +1,12 @@
+import { MemberElement, isStringElement, isObjectElement, Element } from 'apidom';
+import { startsWith } from 'ramda';
+
+export const isOpenApiExtension = (element: MemberElement): boolean => {
+  // @ts-ignore
+  return isStringElement(element.key) && startsWith('x-', element.key.toValue());
+};
+
+export const isServerLikeElement = <T extends Element>(element: Element): boolean => {
+  // @ts-ignore
+  return isObjectElement(element) && element.hasKey('url');
+};

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/specification.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/specification.ts
@@ -1,0 +1,137 @@
+import { mapObjIndexed, has, path, defaultTo } from 'ramda';
+import { trimCharsStart, isPlainObject } from 'ramda-adjunct';
+
+import OpenApi3_1Visitor from './visitors/open-api-3-1';
+import OpenapiVisitor from './visitors/open-api-3-1/OpenapiVisitor';
+import SpecificationExtensionVisitor from './visitors/SpecificationExtensionVisitor';
+import InfoVisitor from './visitors/open-api-3-1/info';
+import InfoTitleVisitor from './visitors/open-api-3-1/info/TitleVisitor';
+import InfoDescriptionVisitor from './visitors/open-api-3-1/info/DescriptionVisitor';
+import InfoSummaryVisitor from './visitors/open-api-3-1/info/SummaryVisitor';
+import InfoTermsOfServiceVisitor from './visitors/open-api-3-1/info/TermsOfServiceVisitor';
+import InfoVersionVisitor from './visitors/open-api-3-1/info/VersionVisitor';
+import ContactVisitor from './visitors/open-api-3-1/contact';
+import ContactNameVisitor from './visitors/open-api-3-1/contact/NameVisitor';
+import ContactUrlVisitor from './visitors/open-api-3-1/contact/UrlVisitor';
+import ContactEmailVisitor from './visitors/open-api-3-1/contact/EmailVisitor';
+import LicenseVisitor from './visitors/open-api-3-1/license';
+import LicenseNameVisitor from './visitors/open-api-3-1/license/NameVisitor';
+import LicenseIdentifierVisitor from './visitors/open-api-3-1/license/IdentifierVisitor';
+import LicenseUrlVisitor from './visitors/open-api-3-1/license/UrlVisitor';
+import ServerVisitor from './visitors/open-api-3-1/server';
+import ServerUrlVisitor from './visitors/open-api-3-1/server/UrlVisitor';
+import ServerDescriptionVisitor from './visitors/open-api-3-1/server/DescriptionVisitor';
+import ServersVisitor from './visitors/open-api-3-1/ServersVisitor';
+import ServerVariableVisitor from './visitors/open-api-3-1/server-variable';
+import ServerVariableEnumVisitor from './visitors/open-api-3-1/server-variable/EnumVisitor';
+import ServerVariableDefaultVisitor from './visitors/open-api-3-1/server-variable/DefaultVisitor';
+import ServerVariableDescriptionVisitor from './visitors/open-api-3-1/server-variable/DescriptionVisitor';
+import ServerVariablesVisitor from './visitors/open-api-3-1/server/VariablesVisitor';
+import FallbackVisitor from './visitors/FallbackVisitor';
+import SecurityRequirementVisitor from './visitors/open-api-3-1/security-requirement';
+import SecurityVisitor from './visitors/open-api-3-1/SecurityVisitor';
+
+/**
+ * Specification object allows us to have complete control over visitors
+ * when traversing the ApiDOM.
+ * Specification also allows us to create amended refractors from
+ * existing ones by manipulating it.
+ *
+ * Note: Specification object allows to use absolute internal JSON pointers.
+ */
+const specification = {
+  visitors: {
+    value: FallbackVisitor,
+    document: {
+      objects: {
+        OpenApi: {
+          $visitor: OpenApi3_1Visitor,
+          fixedFields: {
+            openapi: OpenapiVisitor,
+            info: {
+              $ref: '#/visitors/document/objects/Info',
+            },
+            servers: ServersVisitor,
+            security: SecurityVisitor,
+          },
+        },
+        Info: {
+          $visitor: InfoVisitor,
+          fixedFields: {
+            title: InfoTitleVisitor,
+            description: InfoDescriptionVisitor,
+            summary: InfoSummaryVisitor,
+            termsOfService: InfoTermsOfServiceVisitor,
+            version: InfoVersionVisitor,
+            contact: {
+              $ref: '#/visitors/document/objects/Contact',
+            },
+            license: {
+              $ref: '#/visitors/document/objects/License',
+            },
+          },
+        },
+        Contact: {
+          $visitor: ContactVisitor,
+          fixedFields: {
+            name: ContactNameVisitor,
+            url: ContactUrlVisitor,
+            email: ContactEmailVisitor,
+          },
+        },
+        License: {
+          $visitor: LicenseVisitor,
+          fixedFields: {
+            name: LicenseNameVisitor,
+            identifier: LicenseIdentifierVisitor,
+            url: LicenseUrlVisitor,
+          },
+        },
+        Server: {
+          $visitor: ServerVisitor,
+          fixedFields: {
+            url: ServerUrlVisitor,
+            description: ServerDescriptionVisitor,
+            variables: ServerVariablesVisitor,
+          },
+        },
+        ServerVariable: {
+          $visitor: ServerVariableVisitor,
+          fixedFields: {
+            enum: ServerVariableEnumVisitor,
+            default: ServerVariableDefaultVisitor,
+            description: ServerVariableDescriptionVisitor,
+          },
+        },
+        SecurityRequirement: {
+          $visitor: SecurityRequirementVisitor,
+        },
+      },
+      extension: {
+        $visitor: SpecificationExtensionVisitor,
+      },
+    },
+  },
+};
+
+export const dereference = (
+  object: Record<string, any>,
+  root?: Record<string, any>,
+): Record<string, any> => {
+  const rootObject = defaultTo(object, root);
+
+  return mapObjIndexed((val) => {
+    if (isPlainObject(val) && has('$ref', val)) {
+      const $ref = path(['$ref'], val);
+      // @ts-ignore
+      const pointer = trimCharsStart('#/', $ref);
+      return path(pointer.split('/'), rootObject);
+    }
+    if (isPlainObject(val)) {
+      return dereference(val, rootObject);
+    }
+    return val;
+  }, object);
+};
+
+export default specification;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/FallbackVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/FallbackVisitor.ts
@@ -1,0 +1,23 @@
+import stampit from 'stampit';
+import { Element } from 'apidom';
+
+import { BREAK } from '../../traversal/visitor';
+import Visitor from './Visitor';
+
+/**
+ * This visitor is responsible for falling back to current traversed element
+ * Given OpenApi3_1Visitor expects ObjectElement to be traversed. If
+ * different Element is provided FallBackVisitor is responsible to assigning
+ * this Element as current element.
+ */
+const FallbackVisitor = stampit(Visitor, {
+  methods: {
+    enter(element: Element) {
+      this.element = element.clone();
+      this.copyMetaAndAttributes(element, this.element);
+      return BREAK;
+    },
+  },
+});
+
+export default FallbackVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/SpecificationExtensionVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/SpecificationExtensionVisitor.ts
@@ -1,0 +1,17 @@
+import stampit from 'stampit';
+
+import { BREAK } from '../../traversal/visitor';
+import SpecificationVisitor from './SpecificationVisitor';
+import { appendMetadata } from '../metadata';
+
+const SpecificationExtensionVisitor = stampit(SpecificationVisitor, {
+  methods: {
+    member(memberElement) {
+      this.element = memberElement.clone();
+      appendMetadata(['specification-extension'], this.element);
+      return BREAK;
+    },
+  },
+});
+
+export default SpecificationExtensionVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/SpecificationVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/SpecificationVisitor.ts
@@ -1,0 +1,51 @@
+import stampit from 'stampit';
+import { pathSatisfies, path, pick, pipe, keys } from 'ramda';
+import { isFunction } from 'ramda-adjunct';
+
+import { visit } from '../../traversal/visitor';
+import Visitor from './Visitor';
+
+/**
+ * This is a base Type for every visitor that does
+ * internal look-ups to retrieve other child visitors.
+ */
+const SpecificationVisitor = stampit(Visitor, {
+  props: {
+    specObj: null,
+  },
+  // @ts-ignore
+  init({ specObj = this.specObj }) {
+    this.specObj = specObj;
+  },
+  methods: {
+    retrievePassingOptions() {
+      return pick(['namespace', 'specObj'], this);
+    },
+
+    retrieveFixedFields(specPath) {
+      return pipe(path(['visitors', ...specPath, 'fixedFields']), keys)(this.specObj);
+    },
+
+    retrieveVisitor(specPath) {
+      if (pathSatisfies(isFunction, ['visitors', ...specPath], this.specObj)) {
+        return path(['visitors', ...specPath], this.specObj);
+      }
+
+      return path(['visitors', ...specPath, '$visitor'], this.specObj);
+    },
+
+    retrieveVisitorInstance(specPath, options = {}) {
+      const passingOpts = this.retrievePassingOptions();
+
+      return this.retrieveVisitor(specPath)({ ...passingOpts, ...options });
+    },
+
+    toRefractedElement(specPath: string[], element, options = {}) {
+      const visitor = this.retrieveVisitorInstance(specPath);
+      visit(element, visitor, options);
+      return visitor.element;
+    },
+  },
+});
+
+export default SpecificationVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/Visitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/Visitor.ts
@@ -1,0 +1,20 @@
+import stampit from 'stampit';
+
+const Visitor = stampit({
+  props: {
+    element: null,
+    namespace: null,
+  },
+  // @ts-ignore
+  init({ namespace = this.namespace } = {}) {
+    this.namespace = namespace;
+  },
+  methods: {
+    copyMetaAndAttributes(from, to) {
+      to.meta = from.meta; // eslint-disable-line no-param-reassign
+      to.attributes = from.attributes; // eslint-disable-line no-param-reassign
+    },
+  },
+});
+
+export default Visitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/generics/FixedFieldsVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/generics/FixedFieldsVisitor.ts
@@ -1,0 +1,72 @@
+import stampit from 'stampit';
+import { noop } from 'ramda-adjunct';
+import { isStringElement, MemberElement, Element } from 'apidom';
+
+import { appendMetadata } from '../../metadata';
+import SpecificationVisitor from '../SpecificationVisitor';
+import { isOpenApiExtension } from '../../predicates';
+import { BREAK } from '../../../traversal/visitor';
+
+const FixedFieldsVisitor = stampit(SpecificationVisitor, {
+  props: {
+    specPath: noop,
+    ignoredFields: [],
+    canSupportSpecificationExtensions: true,
+    specificationExtensionPredicate: isOpenApiExtension,
+  },
+  init({
+    // @ts-ignore
+    specPath = this.specPath,
+    // @ts-ignore
+    ignoredFields = this.ignoredFields,
+    // @ts-ignore
+    canSupportSpecificationExtensions = this.canSupportSpecificationExtensions,
+    // @ts-ignore
+    specificationExtensionPredicate = this.specificationExtensionPredicate,
+  } = {}) {
+    this.specPath = specPath;
+    this.ignoredFields = ignoredFields;
+    this.canSupportSpecificationExtensions = canSupportSpecificationExtensions;
+    this.specificationExtensionPredicate = specificationExtensionPredicate;
+  },
+  methods: {
+    object(objectElement) {
+      const specPath = this.specPath(objectElement);
+      const fields = this.retrieveFixedFields(specPath);
+
+      objectElement.forEach((value: Element, key: Element, memberElement: MemberElement) => {
+        if (
+          isStringElement(key) &&
+          fields.includes(key.toValue()) &&
+          !this.ignoredFields.includes(key.toValue())
+        ) {
+          const fixedFieldElement = this.toRefractedElement(
+            [...specPath, 'fixedFields', key.toValue()],
+            value,
+          );
+          const newMemberElement = new MemberElement(key.clone(), fixedFieldElement);
+          this.copyMetaAndAttributes(memberElement, newMemberElement);
+          appendMetadata(['fixed-field'], newMemberElement);
+          this.element.content.push(newMemberElement);
+        } else if (
+          this.canSupportSpecificationExtensions &&
+          this.specificationExtensionPredicate(memberElement)
+        ) {
+          const extensionElement = this.toRefractedElement(
+            ['document', 'extension'],
+            memberElement,
+          );
+          this.element.content.push(extensionElement);
+        } else if (!this.ignoredFields.includes(key.toValue())) {
+          this.element.content.push(memberElement.clone());
+        }
+      });
+
+      this.copyMetaAndAttributes(objectElement, this.element);
+
+      return BREAK;
+    },
+  },
+});
+
+export default FixedFieldsVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/generics/MapVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/generics/MapVisitor.ts
@@ -1,0 +1,12 @@
+import stampit from 'stampit';
+import { isNonEmptyString } from 'ramda-adjunct';
+
+import PatternedFieldsVisitor from './PatternedFieldsVisitor';
+
+const MapVisitor = stampit(PatternedFieldsVisitor, {
+  props: {
+    fieldPatternPredicate: isNonEmptyString,
+  },
+});
+
+export default MapVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/generics/PatternedFieldsVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/generics/PatternedFieldsVisitor.ts
@@ -1,0 +1,69 @@
+import stampit from 'stampit';
+import { F as stubFalse } from 'ramda';
+import { noop } from 'ramda-adjunct';
+import { ObjectElement, Element, MemberElement } from 'apidom';
+
+import SpecificationVisitor from '../SpecificationVisitor';
+import { isOpenApiExtension } from '../../predicates';
+import { BREAK } from '../../../traversal/visitor';
+import { appendMetadata } from '../../metadata';
+
+const PatternedFieldsJsonObjectVisitor = stampit(SpecificationVisitor, {
+  props: {
+    fieldPatternPredicate: stubFalse,
+    specPath: noop,
+    ignoredFields: [],
+    canSupportSpecificationExtensions: false,
+    specificationExtensionPredicate: isOpenApiExtension,
+  },
+  init({
+    // @ts-ignore
+    specPath = this.specPath,
+    // @ts-ignore
+    ignoredFields = this.ignoredFields,
+    // @ts-ignore
+    canSupportSpecificationExtensions = this.canSupportSpecificationExtensions,
+    // @ts-ignore
+    specificationExtensionPredicate = this.specificationExtensionPredicate,
+  } = {}) {
+    this.specPath = specPath;
+    this.ignoredFields = ignoredFields;
+    this.canSupportSpecificationExtensions = canSupportSpecificationExtensions;
+    this.specificationExtensionPredicate = specificationExtensionPredicate;
+  },
+  methods: {
+    object(objectElement: ObjectElement) {
+      // @ts-ignore
+      objectElement.forEach((value: Element, key: Element, memberElement: MemberElement) => {
+        if (
+          this.canSupportSpecificationExtensions &&
+          this.specificationExtensionPredicate(memberElement)
+        ) {
+          const extensionElement = this.toRefractedElement(
+            ['document', 'extension'],
+            memberElement,
+          );
+          this.element.content.push(extensionElement);
+        } else if (
+          !this.ignoredFields.includes(key.toValue()) &&
+          this.fieldPatternPredicate(key.toValue())
+        ) {
+          const specPath = this.specPath(value);
+          const patternedFieldElement = this.toRefractedElement(specPath, value);
+          const newMemberElement = new MemberElement(key.clone(), patternedFieldElement);
+          this.copyMetaAndAttributes(memberElement, newMemberElement);
+          appendMetadata(['patterned-field'], memberElement);
+          this.element.content.push(newMemberElement);
+        } else if (!this.ignoredFields.includes(key.toValue())) {
+          this.element.content.push(memberElement.clone());
+        }
+      });
+
+      this.copyMetaAndAttributes(objectElement, this.element);
+
+      return BREAK;
+    },
+  },
+});
+
+export default PatternedFieldsJsonObjectVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/OpenapiVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/OpenapiVisitor.ts
@@ -1,0 +1,22 @@
+import stampit from 'stampit';
+import { StringElement } from 'apidom';
+
+import FallbackVisitor from '../FallbackVisitor';
+import SpecificationVisitor from '../SpecificationVisitor';
+import OpenapiElement from '../../../elements/Openapi';
+import { BREAK } from '../../../traversal/visitor';
+
+const OpenapiVisitor = stampit(SpecificationVisitor, FallbackVisitor, {
+  methods: {
+    string(stringElement: StringElement) {
+      const openapiElement = new OpenapiElement(stringElement.toValue());
+
+      this.copyMetaAndAttributes(stringElement, openapiElement);
+
+      this.element = openapiElement;
+      return BREAK;
+    },
+  },
+});
+
+export default OpenapiVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/SecurityVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/SecurityVisitor.ts
@@ -1,0 +1,35 @@
+import stampit from 'stampit';
+import { ArrayElement, isObjectElement } from 'apidom';
+
+import SpecificationVisitor from '../SpecificationVisitor';
+import FallbackVisitor from '../FallbackVisitor';
+import { BREAK } from '../../../traversal/visitor';
+import { appendMetadata } from '../../metadata';
+
+const SecurityVisitor = stampit(SpecificationVisitor, FallbackVisitor, {
+  init() {
+    this.element = new ArrayElement();
+  },
+  methods: {
+    array(arrayElement: ArrayElement) {
+      arrayElement.forEach((item) => {
+        if (isObjectElement(item)) {
+          const element = this.toRefractedElement(
+            ['document', 'objects', 'SecurityRequirement'],
+            item,
+          );
+          this.element.push(element);
+        } else {
+          this.element.push(item.clone());
+        }
+      });
+
+      this.copyMetaAndAttributes(arrayElement, this.element);
+      appendMetadata(['security'], this.element);
+
+      return BREAK;
+    },
+  },
+});
+
+export default SecurityVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/ServersVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/ServersVisitor.ts
@@ -1,0 +1,33 @@
+import stampit from 'stampit';
+import { ArrayElement, Element } from 'apidom';
+
+import SpecificationVisitor from '../SpecificationVisitor';
+import FallbackVisitor from '../FallbackVisitor';
+import { appendMetadata } from '../../metadata';
+import { BREAK } from '../../../traversal/visitor';
+import { isServerLikeElement } from '../../predicates';
+
+const ServersVisitor = stampit(SpecificationVisitor, FallbackVisitor, {
+  init() {
+    this.element = new ArrayElement();
+  },
+  methods: {
+    array(arrayElement: ArrayElement) {
+      arrayElement.forEach((item: Element) => {
+        if (isServerLikeElement(item)) {
+          const serverElement = this.toRefractedElement(['document', 'objects', 'Server'], item);
+          this.element.push(serverElement);
+        } else {
+          this.element.push(item);
+        }
+      });
+
+      this.copyMetaAndAttributes(arrayElement, this.element);
+      appendMetadata(['servers'], this.element);
+
+      return BREAK;
+    },
+  },
+});
+
+export default ServersVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/contact/EmailVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/contact/EmailVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const EmailVisitor = stampit(FallbackVisitor);
+
+export default EmailVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/contact/NameVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/contact/NameVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const NameVisitor = stampit(FallbackVisitor);
+
+export default NameVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/contact/UrlVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/contact/UrlVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const UrlVisitor = stampit(FallbackVisitor);
+
+export default UrlVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/contact/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/contact/index.ts
@@ -1,0 +1,18 @@
+import stampit from 'stampit';
+import { always } from 'ramda';
+
+import ContactElement from '../../../../elements/Contact';
+import FallbackVisitor from '../../FallbackVisitor';
+import FixedFieldsVisitor from '../../generics/FixedFieldsVisitor';
+
+const ContactVisitor = stampit(FixedFieldsVisitor, FallbackVisitor, {
+  props: {
+    specPath: always(['document', 'objects', 'Contact']),
+    canSupportSpecificationExtensions: true,
+  },
+  init() {
+    this.element = new ContactElement();
+  },
+});
+
+export default ContactVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/index.ts
@@ -1,0 +1,18 @@
+import stampit from 'stampit';
+import { always } from 'ramda';
+
+import FixedFieldsVisitor from '../generics/FixedFieldsVisitor';
+import FallbackVisitor from '../FallbackVisitor';
+import OpenApi3_1Element from '../../../elements/OpenApi3-1';
+
+const OpenApi3_1Visitor = stampit(FixedFieldsVisitor, FallbackVisitor, {
+  props: {
+    specPath: always(['document', 'objects', 'OpenApi']),
+    canSupportSpecificationExtensions: true,
+  },
+  init() {
+    this.element = new OpenApi3_1Element();
+  },
+});
+
+export default OpenApi3_1Visitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/DescriptionVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/DescriptionVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const DescriptionVisitor = stampit(FallbackVisitor);
+
+export default DescriptionVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/SummaryVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/SummaryVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const SummaryVisitor = stampit(FallbackVisitor);
+
+export default SummaryVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/TermsOfServiceVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/TermsOfServiceVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const TermsOfServiceVisitor = stampit(FallbackVisitor);
+
+export default TermsOfServiceVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/TitleVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/TitleVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const TitleVisitor = stampit(FallbackVisitor);
+
+export default TitleVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/VersionVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/VersionVisitor.ts
@@ -1,0 +1,20 @@
+import stampit from 'stampit';
+import { StringElement } from 'apidom';
+
+import FallbackVisitor from '../../FallbackVisitor';
+import { appendMetadata } from '../../../metadata';
+import { BREAK } from '../../../../traversal/visitor';
+
+const VersionVisitor = stampit(FallbackVisitor, {
+  methods: {
+    string(stringElement: StringElement) {
+      this.element = new StringElement(stringElement.toValue());
+      this.copyMetaAndAttributes(stringElement, this.element);
+      appendMetadata(['version'], this.element);
+
+      return BREAK;
+    },
+  },
+});
+
+export default VersionVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/info/index.ts
@@ -1,0 +1,18 @@
+import stampit from 'stampit';
+import { always } from 'ramda';
+
+import InfoElement from '../../../../elements/Info';
+import FallbackVisitor from '../../FallbackVisitor';
+import FixedFieldsVisitor from '../../generics/FixedFieldsVisitor';
+
+const InfoVisitor = stampit(FixedFieldsVisitor, FallbackVisitor, {
+  props: {
+    specPath: always(['document', 'objects', 'Info']),
+    canSupportSpecificationExtensions: true,
+  },
+  init() {
+    this.element = new InfoElement();
+  },
+});
+
+export default InfoVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/license/IdentifierVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/license/IdentifierVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const IdentifierVisitor = stampit(FallbackVisitor);
+
+export default IdentifierVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/license/NameVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/license/NameVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const NameVisitor = stampit(FallbackVisitor);
+
+export default NameVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/license/UrlVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/license/UrlVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const UrlVisitor = stampit(FallbackVisitor);
+
+export default UrlVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/license/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/license/index.ts
@@ -1,0 +1,18 @@
+import stampit from 'stampit';
+import { always } from 'ramda';
+
+import LicenseElement from '../../../../elements/License';
+import FallbackVisitor from '../../FallbackVisitor';
+import FixedFieldsVisitor from '../../generics/FixedFieldsVisitor';
+
+const LicenseVisitor = stampit(FixedFieldsVisitor, FallbackVisitor, {
+  props: {
+    specPath: always(['document', 'objects', 'License']),
+    canSupportSpecificationExtensions: true,
+  },
+  init() {
+    this.element = new LicenseElement();
+  },
+});
+
+export default LicenseVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/security-requirement/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/security-requirement/index.ts
@@ -1,0 +1,17 @@
+import stampit from 'stampit';
+import { always } from 'ramda';
+
+import SecurityRequirementElement from '../../../../elements/SecurityRequirement';
+import MapVisitor from '../../generics/MapVisitor';
+import FallbackVisitor from '../../FallbackVisitor';
+
+const SecurityRequirementVisitor = stampit(MapVisitor, FallbackVisitor, {
+  props: {
+    specPath: always(['value']),
+  },
+  init() {
+    this.element = new SecurityRequirementElement();
+  },
+});
+
+export default SecurityRequirementVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server-variable/DefaultVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server-variable/DefaultVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const DefaultVisitor = stampit(FallbackVisitor);
+
+export default DefaultVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server-variable/DescriptionVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server-variable/DescriptionVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const DescriptionVisitor = stampit(FallbackVisitor);
+
+export default DescriptionVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server-variable/EnumVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server-variable/EnumVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const EnumVisitor = stampit(FallbackVisitor);
+
+export default EnumVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server-variable/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server-variable/index.ts
@@ -1,0 +1,18 @@
+import stampit from 'stampit';
+import { always } from 'ramda';
+
+import ServerVariableElement from '../../../../elements/ServerVariable';
+import FallbackVisitor from '../../FallbackVisitor';
+import FixedFieldsVisitor from '../../generics/FixedFieldsVisitor';
+
+const ServerVariableVisitor = stampit(FixedFieldsVisitor, FallbackVisitor, {
+  props: {
+    specPath: always(['document', 'objects', 'ServerVariable']),
+    canSupportSpecificationExtensions: true,
+  },
+  init() {
+    this.element = new ServerVariableElement();
+  },
+});
+
+export default ServerVariableVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server/DescriptionVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server/DescriptionVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const DescriptionVisitor = stampit(FallbackVisitor);
+
+export default DescriptionVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server/UrlVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server/UrlVisitor.ts
@@ -1,0 +1,7 @@
+import stampit from 'stampit';
+
+import FallbackVisitor from '../../FallbackVisitor';
+
+const UrlVisitor = stampit(FallbackVisitor);
+
+export default UrlVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server/VariablesVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server/VariablesVisitor.ts
@@ -1,0 +1,20 @@
+import stampit from 'stampit';
+import { always } from 'ramda';
+import { ObjectElement } from 'apidom';
+
+import { appendMetadata } from '../../../metadata';
+
+import MapVisitor from '../../generics/MapVisitor';
+import FallbackVisitor from '../../FallbackVisitor';
+
+const VariablesVisitor = stampit(MapVisitor, FallbackVisitor, {
+  props: {
+    specPath: always(['document', 'objects', 'ServerVariable']),
+  },
+  init() {
+    this.element = new ObjectElement();
+    appendMetadata(['variables'], this.element);
+  },
+});
+
+export default VariablesVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server/index.ts
@@ -1,0 +1,18 @@
+import stampit from 'stampit';
+import { always } from 'ramda';
+
+import ServerElement from '../../../../elements/Server';
+import FallbackVisitor from '../../FallbackVisitor';
+import FixedFieldsVisitor from '../../generics/FixedFieldsVisitor';
+
+const ServerVisitor = stampit(FixedFieldsVisitor, FallbackVisitor, {
+  props: {
+    specPath: always(['document', 'objects', 'Server']),
+    canSupportSpecificationExtensions: true,
+  },
+  init() {
+    this.element = new ServerElement();
+  },
+});
+
+export default ServerVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/test/refractor/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/test/refractor/index.ts
@@ -1,0 +1,19 @@
+import { ObjectElement, toString, toValue } from 'apidom';
+
+import { OpenApi3_1Element } from '../../src';
+
+describe('refractor', function () {
+  specify('should refract to openapi-3-1 namespace', function () {
+    const genericObject = new ObjectElement({
+      security: [
+        {},
+        {
+          petstore_auth: ['write:pets', 'read:pets'],
+        },
+      ],
+    });
+    const openApiObject = OpenApi3_1Element.refract(genericObject);
+    console.log(toString(openApiObject));
+    console.dir(toValue(openApiObject));
+  });
+});


### PR DESCRIPTION
Refractor is mechanism for transforming generic ApiDOM
into semantic one.

Refs swagger-api/oss-planning/issues/133