### PR TITLE
feat(reference): implement POC of external dereference

### DIFF
--- a/apidom/packages/@types/minim.d.ts
+++ b/apidom/packages/@types/minim.d.ts
@@ -61,6 +61,8 @@ declare module 'minim' {
     register(name: string, elementClass: any): Namespace;
 
     use(plugin: NamespacePlugin): Namespace;
+
+    getElementClass(element: string): typeof Element;
   }
 
   export interface NamespacePluginOptions {

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/predicates.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/predicates.ts
@@ -1,5 +1,5 @@
 import { MemberElement, isStringElement, isObjectElement, Element } from 'apidom';
-import { startsWith } from 'ramda';
+import { startsWith, all } from 'ramda';
 
 export const isOpenApi3_1LikeElement = <T extends Element>(element: T): boolean => {
   // @ts-ignore
@@ -12,8 +12,20 @@ export const isParameterLikeElement = <T extends Element>(element: T): boolean =
 };
 
 export const isReferenceLikeElement = <T extends Element>(element: T): boolean => {
-  // @ts-ignore
-  return isObjectElement(element) && element.hasKey('$ref');
+  const isAllowedProperty = (property: string): boolean => {
+    // @ts-ignore
+    return ['$ref', 'description', 'summary'].includes(property);
+  };
+
+  return (
+    isObjectElement(element) &&
+    // @ts-ignore
+    element.hasKey('$ref') &&
+    // @ts-ignore
+    element.keys.length <= 3 &&
+    // @ts-ignore
+    all(isAllowedProperty)(element.keys)
+  );
 };
 
 export const isRequestBodyLikeElement = <T extends Element>(element: T): boolean => {

--- a/apidom/packages/apidom-reference/src/ReferenceSet.ts
+++ b/apidom/packages/apidom-reference/src/ReferenceSet.ts
@@ -1,6 +1,6 @@
 import stampit from 'stampit';
 import { propEq } from 'ramda';
-import { isNotUndefined } from 'ramda-adjunct';
+import { isNotUndefined, isString } from 'ramda-adjunct';
 
 import { Reference as IReference, ReferenceSet as IReferenceSet } from './types';
 
@@ -10,8 +10,9 @@ const ReferenceSet: stampit.Stamp<IReferenceSet> = stampit({
     refs: [],
     circular: false,
   },
-  init() {
+  init({ refs = [] } = {}) {
     this.refs = [];
+    refs.forEach((ref: IReference) => this.refs.add(ref));
   },
   methods: {
     get size(): number {
@@ -23,6 +24,7 @@ const ReferenceSet: stampit.Stamp<IReferenceSet> = stampit({
       if (!this.has(reference)) {
         this.refs.push(reference);
         this.rootRef = this.rootRef === null ? reference : this.rootRef;
+        reference.refSet = this; // eslint-disable-line no-param-reassign
       }
       return this;
     },
@@ -34,7 +36,8 @@ const ReferenceSet: stampit.Stamp<IReferenceSet> = stampit({
       return this;
     },
 
-    has(uri: string): boolean {
+    has(thing: string | IReference): boolean {
+      const uri = isString(thing) ? thing : thing.uri;
       return isNotUndefined(this.find(propEq('uri', uri)));
     },
 

--- a/apidom/packages/apidom-reference/test/fixtures/dereference/reference-objects.json
+++ b/apidom/packages/apidom-reference/test/fixtures/dereference/reference-objects.json
@@ -3,21 +3,25 @@
   "components": {
      "parameters": {
       "userId": {
-        "$ref": "#/components/parameters/indirection",
+        "$ref": "#/components/parameters/indirection1",
         "description": "override"
       },
-      "indirection": {
-        "$ref": "#/components/parameters/userIdRef",
+      "indirection1": {
+        "$ref": "#/components/parameters/indirection2",
         "summary": "indirect summary"
       },
-      "userIdRef": {
+       "indirection2": {
+         "$ref": "#/components/parameters/userIdRef",
+         "summary": "indirect summary"
+       },
+       "userIdRef": {
         "name": "userId",
         "in": "query",
         "description": "ID of the user",
         "required": true
       },
       "externalRef": {
-        "$ref": "./external-reference-objects.json",
+        "$ref": "./external-reference-objects.json#/externalParameter",
         "description": "another ref"
       }
     }

--- a/apidom/packages/apidom/src/index.ts
+++ b/apidom/packages/apidom/src/index.ts
@@ -39,6 +39,7 @@ export {
   isAnnotationElement,
   isParseResultElement,
   isSourceMapElement,
+  isPrimitiveElement,
   hasElementSourceMap,
   includesSymbols,
   includesClasses,

--- a/apidom/packages/apidom/src/predicates/index.ts
+++ b/apidom/packages/apidom/src/predicates/index.ts
@@ -10,14 +10,14 @@ import {
   LinkElement,
   RefElement,
 } from 'minim';
-import { all, isEmpty, either, curry, allPass, is, both } from 'ramda';
+import { all, isEmpty, either, curry, allPass, is, both, anyPass } from 'ramda';
 import { included } from 'ramda-adjunct';
 
 import AnnotationElement from '../elements/Annotation';
 import CommentElement from '../elements/Comment';
 import ParserResultElement from '../elements/ParseResult';
 import SourceMapElement from '../elements/SourceMap';
-import createPredicate from './helpers';
+import createPredicate, { isElementType as isElementTypeHelper } from './helpers';
 
 export const isElement = createPredicate(({ hasBasicElementProps, primitiveEq }) => {
   const primitiveEqUndefined = primitiveEq(undefined);
@@ -202,6 +202,23 @@ export const isSourceMapElement = createPredicate(
     );
   },
 );
+
+export const isPrimitiveElement = anyPass([
+  // @ts-ignore
+  isElementTypeHelper('object'),
+  // @ts-ignore
+  isElementTypeHelper('array'),
+  // @ts-ignore
+  isElementTypeHelper('member'),
+  // @ts-ignore
+  isElementTypeHelper('boolean'),
+  // @ts-ignore
+  isElementTypeHelper('number'),
+  // @ts-ignore
+  isElementTypeHelper('string'),
+  // @ts-ignore
+  isElementTypeHelper('null'),
+]);
 
 export const hasElementSourceMap = createPredicate(() => {
   return (element) => isSourceMapElement(element.meta.get('sourceMap'));

--- a/apidom/packages/apidom/src/traversal/visitor.ts
+++ b/apidom/packages/apidom/src/traversal/visitor.ts
@@ -1,7 +1,7 @@
 import stampit from 'stampit';
 import { Element } from 'minim';
-import { curryN, F as stubFalse, pipe, either } from 'ramda';
-import { isString, isArray } from 'ramda-adjunct';
+import { curryN, F as stubFalse, pipe } from 'ramda';
+import { isString } from 'ramda-adjunct';
 import { visit as astVisit, BREAK, mergeAllVisitors } from 'apidom-ast';
 
 import {
@@ -51,7 +51,7 @@ export const getNodeType = <T extends Element>(element: T): string | undefined =
 };
 
 // isNode :: Node -> Boolean
-const isNode = curryN(1, pipe(getNodeType, either(isString, isArray)));
+const isNode = curryN(1, pipe(getNodeType, isString));
 
 export const keyMapDefault = {
   ObjectElement: ['content'],
@@ -63,6 +63,10 @@ export const keyMapDefault = {
   NullElement: [],
   RefElement: [],
   LinkElement: [],
+  Annotation: [],
+  Comment: [],
+  ParseResultElement: ['content'],
+  SourceMap: ['content'],
 };
 
 export const PredicateVisitor = stampit({


### PR DESCRIPTION
Dereference is specific to OpenApi 3.1 and currently only
involves Reference Objects only.

Every Reference Object is replaces with either Object
from the same OpenApi 3.1 document or by semantically
transformed Object from external file.

Refs https://github.com/swagger-api/oss-planning/issues/133