### PR TITLE
feat: add support for worker environment

### DIFF
--- a/apidom/packages/apidom-parser-adapter-json/src/parser/index-browser-patch.ts
+++ b/apidom/packages/apidom-parser-adapter-json/src/parser/index-browser-patch.ts
@@ -4,12 +4,12 @@ import { isString } from 'ramda-adjunct';
 import treeSitterWasm from 'web-tree-sitter/tree-sitter.wasm';
 
 // patch fetch() to let emscripten load the WASM file
-const realFetch = window.fetch;
-window.fetch = (...args) => {
+const realFetch = globalThis.fetch;
+globalThis.fetch = (...args) => {
   // @ts-ignore
   if (isString(args[0]) && args[0].endsWith('/tree-sitter.wasm')) {
     // @ts-ignore
-    return realFetch.apply(window, [treeSitterWasm, tail(args)]);
+    return realFetch.apply(globalThis, [treeSitterWasm, tail(args)]);
   }
-  return realFetch.apply(window, args);
+  return realFetch.apply(globalThis, args);
 };

--- a/apidom/packages/apidom-parser-adapter-yaml-1-2/src/parser/index-browser-patch.ts
+++ b/apidom/packages/apidom-parser-adapter-yaml-1-2/src/parser/index-browser-patch.ts
@@ -4,12 +4,12 @@ import { isString } from 'ramda-adjunct';
 import treeSitterWasm from 'web-tree-sitter/tree-sitter.wasm';
 
 // patch fetch() to let emscripten load the WASM file
-const realFetch = window.fetch;
-window.fetch = (...args) => {
+const realFetch = globalThis.fetch;
+globalThis.fetch = (...args) => {
   // @ts-ignore
   if (isString(args[0]) && args[0].endsWith('/tree-sitter.wasm')) {
     // @ts-ignore
-    return realFetch.apply(window, [treeSitterWasm, tail(args)]);
+    return realFetch.apply(globalThis, [treeSitterWasm, tail(args)]);
   }
-  return realFetch.apply(window, args);
+  return realFetch.apply(globalThis, args);
 };

--- a/apidom/packages/apidom-reference/src/util/url.ts
+++ b/apidom/packages/apidom-reference/src/util/url.ts
@@ -170,7 +170,7 @@ export const getHash = (uri: string): string => {
 export const cwd = (): string => {
   // @ts-ignore
   if (process.browser) {
-    return window.location.href;
+    return globalThis.location.href;
   }
 
   const path = process.cwd();

--- a/experiments/apidom-playground/babel.config.js
+++ b/experiments/apidom-playground/babel.config.js
@@ -5,7 +5,7 @@ const apiDOMResolverPlugin = [
   {
     root: ['./src'],
     alias: {
-      apidom: '../../apidom/packages/apidom/cjs',
+      apidom: '../../apidom/packages/apidom',
       'apidom-ast': '../../apidom/packages/apidom-ast',
       'apidom-ns-asyncapi-2-0': '../../apidom/packages/apidom-ns-asyncapi-2-0',
       'apidom-ns-openapi-3-1': '../../apidom/packages/apidom-ns-openapi-3-1',

--- a/experiments/apidom-playground/config/paths.js
+++ b/experiments/apidom-playground/config/paths.js
@@ -7,7 +7,7 @@ const getPublicUrlOrPath = require('react-dev-utils/getPublicUrlOrPath');
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebook/create-react-app/issues/637
 const appDirectory = fs.realpathSync(process.cwd());
-const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
+const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 
 // We use `PUBLIC_URL` environment variable or "homepage" field to infer
 // "public path" at which the app is served.
@@ -37,7 +37,7 @@ const moduleFileExtensions = [
 
 // Resolve file paths in the same order as webpack
 const resolveModule = (resolveFn, filePath) => {
-  const extension = moduleFileExtensions.find(extension =>
+  const extension = moduleFileExtensions.find((extension) =>
     fs.existsSync(resolveFn(`${filePath}.${extension}`))
   );
 
@@ -65,9 +65,8 @@ module.exports = {
   proxySetup: resolveApp('src/setupProxy.js'),
   appNodeModules: resolveApp('node_modules'),
   swSrc: resolveModule(resolveApp, 'src/service-worker'),
+  apidomPath: path.resolve(__dirname, '..', '..', '..', 'apidom', 'packages'),
   publicUrlOrPath,
 };
-
-
 
 module.exports.moduleFileExtensions = moduleFileExtensions;

--- a/experiments/apidom-playground/config/webpack.config.js
+++ b/experiments/apidom-playground/config/webpack.config.js
@@ -1,53 +1,47 @@
-"use strict";
+'use strict';
 
-const fs = require("fs");
-const path = require("path");
-const webpack = require("webpack");
-const resolve = require("resolve");
-const PnpWebpackPlugin = require("pnp-webpack-plugin");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
-const CaseSensitivePathsPlugin = require("case-sensitive-paths-webpack-plugin");
-const InlineChunkHtmlPlugin = require("react-dev-utils/InlineChunkHtmlPlugin");
-const TerserPlugin = require("terser-webpack-plugin");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
-const safePostCssParser = require("postcss-safe-parser");
-const ManifestPlugin = require("webpack-manifest-plugin");
-const InterpolateHtmlPlugin = require("react-dev-utils/InterpolateHtmlPlugin");
-const WorkboxWebpackPlugin = require("workbox-webpack-plugin");
-const WatchMissingNodeModulesPlugin = require("react-dev-utils/WatchMissingNodeModulesPlugin");
+const fs = require('fs');
+const path = require('path');
+const webpack = require('webpack');
+const resolve = require('resolve');
+const PnpWebpackPlugin = require('pnp-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
+const InlineChunkHtmlPlugin = require('react-dev-utils/InlineChunkHtmlPlugin');
+const TerserPlugin = require('terser-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const safePostCssParser = require('postcss-safe-parser');
+const ManifestPlugin = require('webpack-manifest-plugin');
+const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
+const WorkboxWebpackPlugin = require('workbox-webpack-plugin');
+const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 // const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
-const getCSSModuleLocalIdent = require("react-dev-utils/getCSSModuleLocalIdent");
-const ESLintPlugin = require("eslint-webpack-plugin");
-const paths = require("./paths");
-const modules = require("./modules");
-const getClientEnvironment = require("./env");
-const ModuleNotFoundPlugin = require("react-dev-utils/ModuleNotFoundPlugin");
-const ForkTsCheckerWebpackPlugin = require("react-dev-utils/ForkTsCheckerWebpackPlugin");
-const typescriptFormatter = require("react-dev-utils/typescriptFormatter");
-const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
+const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
+const ESLintPlugin = require('eslint-webpack-plugin');
+const paths = require('./paths');
+const modules = require('./modules');
+const getClientEnvironment = require('./env');
+const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin');
+const ForkTsCheckerWebpackPlugin = require('react-dev-utils/ForkTsCheckerWebpackPlugin');
+const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
-const postcssNormalize = require("postcss-normalize");
+const postcssNormalize = require('postcss-normalize');
 
 const appPackageJson = require(paths.appPackageJson);
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
-const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== "false";
+const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 
-const webpackDevClientEntry = require.resolve(
-  "react-dev-utils/webpackHotDevClient"
-);
-const reactRefreshOverlayEntry = require.resolve(
-  "react-dev-utils/refreshOverlayInterop"
-);
+const webpackDevClientEntry = require.resolve('react-dev-utils/webpackHotDevClient');
+const reactRefreshOverlayEntry = require.resolve('react-dev-utils/refreshOverlayInterop');
 
 // Some apps do not need the benefits of saving a web request, so not inlining the chunk
 // makes for a smoother build process.
-const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== "false";
+const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 
-const imageInlineSizeLimit = parseInt(
-  process.env.IMAGE_INLINE_SIZE_LIMIT || "10000"
-);
+const imageInlineSizeLimit = parseInt(process.env.IMAGE_INLINE_SIZE_LIMIT || '10000');
 
 // Check if TypeScript is setup
 const useTypeScript = fs.existsSync(paths.appTsConfig);
@@ -62,12 +56,12 @@ const sassRegex = /\.(scss|sass)$/;
 const sassModuleRegex = /\.module\.(scss|sass)$/;
 
 const hasJsxRuntime = (() => {
-  if (process.env.DISABLE_NEW_JSX_TRANSFORM === "true") {
+  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
     return false;
   }
 
   try {
-    require.resolve("react/jsx-runtime");
+    require.resolve('react/jsx-runtime');
     return true;
   } catch (e) {
     return false;
@@ -77,13 +71,12 @@ const hasJsxRuntime = (() => {
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 module.exports = function (webpackEnv) {
-  const isEnvDevelopment = webpackEnv === "development";
-  const isEnvProduction = webpackEnv === "production";
+  const isEnvDevelopment = webpackEnv === 'development';
+  const isEnvProduction = webpackEnv === 'production';
 
   // Variable used for enabling profiling in Production
   // passed into alias object. Uses a flag if passed into the build command
-  const isEnvProductionProfile =
-    isEnvProduction && process.argv.includes("--profile");
+  const isEnvProductionProfile = isEnvProduction && process.argv.includes('--profile');
 
   // We will provide `paths.publicUrlOrPath` to our app
   // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
@@ -96,33 +89,31 @@ module.exports = function (webpackEnv) {
   // common function to get style loaders
   const getStyleLoaders = (cssOptions, preProcessor) => {
     const loaders = [
-      isEnvDevelopment && require.resolve("style-loader"),
+      isEnvDevelopment && require.resolve('style-loader'),
       isEnvProduction && {
         loader: MiniCssExtractPlugin.loader,
         // css is located in `static/css`, use '../../' to locate index.html folder
         // in production `paths.publicUrlOrPath` can be a relative path
-        options: paths.publicUrlOrPath.startsWith(".")
-          ? { publicPath: "../../" }
-          : {},
+        options: paths.publicUrlOrPath.startsWith('.') ? { publicPath: '../../' } : {},
       },
       {
-        loader: require.resolve("css-loader"),
+        loader: require.resolve('css-loader'),
         options: cssOptions,
       },
       {
         // Options for PostCSS as we reference these options twice
         // Adds vendor prefixing based on your specified browser support in
         // package.json
-        loader: require.resolve("postcss-loader"),
+        loader: require.resolve('postcss-loader'),
         options: {
           // Necessary for external CSS imports to work
           // https://github.com/facebook/create-react-app/issues/2677
-          ident: "postcss",
+          ident: 'postcss',
           plugins: () => [
-            require("postcss-flexbugs-fixes"),
-            require("postcss-preset-env")({
+            require('postcss-flexbugs-fixes'),
+            require('postcss-preset-env')({
               autoprefixer: {
-                flexbox: "no-2009",
+                flexbox: 'no-2009',
               },
               stage: 3,
             }),
@@ -138,7 +129,7 @@ module.exports = function (webpackEnv) {
     if (preProcessor) {
       loaders.push(
         {
-          loader: require.resolve("resolve-url-loader"),
+          loader: require.resolve('resolve-url-loader'),
           options: {
             sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
             root: paths.appSrc,
@@ -156,14 +147,14 @@ module.exports = function (webpackEnv) {
   };
 
   return {
-    mode: isEnvProduction ? "production" : isEnvDevelopment && "development",
+    mode: isEnvProduction ? 'production' : isEnvDevelopment && 'development',
     // Stop compilation early in production
     bail: isEnvProduction,
     devtool: isEnvProduction
       ? shouldUseSourceMap
-        ? "source-map"
+        ? 'source-map'
         : false
-      : isEnvDevelopment && "cheap-module-source-map",
+      : isEnvDevelopment && 'cheap-module-source-map',
     // These are the "entry points" to our application.
     // This means they will be the "root" imports that are included in JS bundle.
     entry:
@@ -199,33 +190,29 @@ module.exports = function (webpackEnv) {
       // There will be one main bundle, and one file per asynchronous chunk.
       // In development, it does not produce real files.
       filename: isEnvProduction
-        ? "static/js/[name].[contenthash:8].js"
-        : isEnvDevelopment && "static/js/bundle.js",
+        ? 'static/js/[name].[contenthash:8].js'
+        : isEnvDevelopment && 'static/js/bundle.js',
       // TODO: remove this when upgrading to webpack 5
       futureEmitAssets: true,
       // There are also additional JS chunk files if you use code splitting.
       chunkFilename: isEnvProduction
-        ? "static/js/[name].[contenthash:8].chunk.js"
-        : isEnvDevelopment && "static/js/[name].chunk.js",
+        ? 'static/js/[name].[contenthash:8].chunk.js'
+        : isEnvDevelopment && 'static/js/[name].chunk.js',
       // webpack uses `publicPath` to determine where the app is being served from.
       // It requires a trailing slash, or the file assets will get an incorrect path.
       // We inferred the "public path" (such as / or /my-project) from homepage.
       publicPath: paths.publicUrlOrPath,
       // Point sourcemap entries to original disk location (format as URL on Windows)
       devtoolModuleFilenameTemplate: isEnvProduction
-        ? (info) =>
-            path
-              .relative(paths.appSrc, info.absoluteResourcePath)
-              .replace(/\\/g, "/")
+        ? (info) => path.relative(paths.appSrc, info.absoluteResourcePath).replace(/\\/g, '/')
         : isEnvDevelopment &&
-          ((info) =>
-            path.resolve(info.absoluteResourcePath).replace(/\\/g, "/")),
+          ((info) => path.resolve(info.absoluteResourcePath).replace(/\\/g, '/')),
       // Prevents conflicts when multiple webpack runtimes (from different apps)
       // are used on the same page.
       jsonpFunction: `webpackJsonp${appPackageJson.name}`,
       // this defaults to 'window', but by setting it to 'this' then
       // module chunks which are built will work in web workers as well.
-      globalObject: "this",
+      globalObject: 'this',
     },
     optimization: {
       minimize: isEnvProduction,
@@ -287,7 +274,7 @@ module.exports = function (webpackEnv) {
               : false,
           },
           cssProcessorPluginOptions: {
-            preset: ["default", { minifyFontValues: { removeQuotes: false } }],
+            preset: ['default', { minifyFontValues: { removeQuotes: false } }],
           },
         }),
       ],
@@ -295,7 +282,7 @@ module.exports = function (webpackEnv) {
       // https://twitter.com/wSokra/status/969633336732905474
       // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
       splitChunks: {
-        chunks: "all",
+        chunks: 'all',
         name: false,
       },
       // Keep the runtime chunk separated to enable long term caching
@@ -310,9 +297,7 @@ module.exports = function (webpackEnv) {
       // We placed these paths second because we want `node_modules` to "win"
       // if there are any conflicts. This matches Node resolution mechanism.
       // https://github.com/facebook/create-react-app/issues/253
-      modules: ["node_modules", paths.appNodeModules].concat(
-        modules.additionalModulePaths || []
-      ),
+      modules: ['node_modules', paths.appNodeModules].concat(modules.additionalModulePaths || []),
       // These are the reasonable defaults supported by the Node ecosystem.
       // We also include JSX as a common component filename extension to support
       // some tools, although we do not recommend using it, see:
@@ -321,16 +306,43 @@ module.exports = function (webpackEnv) {
       // for React Native Web.
       extensions: paths.moduleFileExtensions
         .map((ext) => `.${ext}`)
-        .filter((ext) => useTypeScript || !ext.includes("ts")),
+        .filter((ext) => useTypeScript || !ext.includes('ts')),
       alias: {
         // Support React Native Web
         // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
-        "react-native": "react-native-web",
+        'react-native': 'react-native-web',
         // Allows for better profiling with ReactDevTools
         ...(isEnvProductionProfile && {
-          "react-dom$": "react-dom/profiling",
-          "scheduler/tracing": "scheduler/tracing-profiling",
+          'react-dom$': 'react-dom/profiling',
+          'scheduler/tracing': 'scheduler/tracing-profiling',
         }),
+        apidom: path.resolve(paths.apidomPath, 'apidom'),
+        'apidom-ast': path.resolve(paths.apidomPath, 'apidom-ast'),
+        'apidom-ns-asyncapi-2-0': path.resolve(paths.apidomPath, 'apidom-ns-asyncapi-2-0'),
+        'apidom-ns-openapi-3-1': path.resolve(paths.apidomPath, 'apidom-ns-openapi-3-1'),
+        'apidom-parser': path.resolve(paths.apidomPath, 'apidom-parser'),
+        'apidom-parser-adapter-asyncapi-json-2-0': path.resolve(
+          paths.apidomPath,
+          'apidom-parser-adapter-asyncapi-json-2-0'
+        ),
+        'apidom-parser-adapter-asyncapi-yaml-2-0': path.resolve(
+          paths.apidomPath,
+          'apidom-parser-adapter-asyncapi-yaml-2-0'
+        ),
+        'apidom-parser-adapter-json': path.resolve(paths.apidomPath, 'apidom-parser-adapter-json'),
+        'apidom-parser-adapter-openapi-json-3-1': path.resolve(
+          paths.apidomPath,
+          'apidom-parser-adapter-openapi-json-3-1'
+        ),
+        'apidom-parser-adapter-openapi-yaml-3-1': path.resolve(
+          paths.apidomPath,
+          'apidom-parser-adapter-openapi-yaml-3-1'
+        ),
+        'apidom-parser-adapter-yaml-1-2': path.resolve(
+          paths.apidomPath,
+          'apidom-parser-adapter-yaml-1-2'
+        ),
+        'apidom-reference': path.resolve(paths.apidomPath, 'apidom-reference'),
         ...(modules.webpackAliases || {}),
       },
       plugins: [
@@ -369,16 +381,20 @@ module.exports = function (webpackEnv) {
             // https://github.com/jshttp/mime-db
             {
               test: /\.wasm$/,
-              loader: "file-loader",
-              type: "javascript/auto",
+              loader: 'file-loader',
+              type: 'javascript/auto',
+            },
+            {
+              test: /\.worker\.js$/,
+              use: { loader: 'worker-loader' },
             },
             {
               test: [/\.avif$/],
-              loader: require.resolve("url-loader"),
+              loader: require.resolve('url-loader'),
               options: {
                 limit: imageInlineSizeLimit,
-                mimetype: "image/avif",
-                name: "static/media/[name].[hash:8].[ext]",
+                mimetype: 'image/avif',
+                name: 'static/media/[name].[hash:8].[ext]',
               },
             },
             // "url" loader works like "file" loader except that it embeds assets
@@ -386,10 +402,10 @@ module.exports = function (webpackEnv) {
             // A missing `test` is equivalent to a match.
             {
               test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
-              loader: require.resolve("url-loader"),
+              loader: require.resolve('url-loader'),
               options: {
                 limit: imageInlineSizeLimit,
-                name: "static/media/[name].[hash:8].[ext]",
+                name: 'static/media/[name].[hash:8].[ext]',
               },
             },
             // Process application JS with Babel.
@@ -397,27 +413,24 @@ module.exports = function (webpackEnv) {
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
               include: paths.appSrc,
-              loader: require.resolve("babel-loader"),
+              loader: require.resolve('babel-loader'),
               options: {
-                customize: require.resolve(
-                  "babel-preset-react-app/webpack-overrides"
-                ),
+                customize: require.resolve('babel-preset-react-app/webpack-overrides'),
 
                 plugins: [
                   [
-                    require.resolve("babel-plugin-named-asset-import"),
+                    require.resolve('babel-plugin-named-asset-import'),
                     {
                       loaderMap: {
                         svg: {
-                          ReactComponent:
-                            "@svgr/webpack?-svgo,+titleProp,+ref![path]",
+                          ReactComponent: '@svgr/webpack?-svgo,+titleProp,+ref![path]',
                         },
                       },
                     },
                   ],
                   isEnvDevelopment &&
                     shouldUseReactRefresh &&
-                    require.resolve("react-refresh/babel"),
+                    require.resolve('react-refresh/babel'),
                 ].filter(Boolean),
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/
@@ -433,16 +446,13 @@ module.exports = function (webpackEnv) {
             {
               test: /\.(js|mjs)$/,
               exclude: /@babel(?:\/|\\{1,2})runtime/,
-              loader: require.resolve("babel-loader"),
+              loader: require.resolve('babel-loader'),
               options: {
                 babelrc: false,
                 configFile: false,
                 compact: false,
                 presets: [
-                  [
-                    require.resolve("babel-preset-react-app/dependencies"),
-                    { helpers: true },
-                  ],
+                  [require.resolve('babel-preset-react-app/dependencies'), { helpers: true }],
                 ],
                 cacheDirectory: true,
                 // See #6846 for context on why cacheCompression is disabled
@@ -467,9 +477,7 @@ module.exports = function (webpackEnv) {
               exclude: cssModuleRegex,
               use: getStyleLoaders({
                 importLoaders: 1,
-                sourceMap: isEnvProduction
-                  ? shouldUseSourceMap
-                  : isEnvDevelopment,
+                sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
               }),
               // Don't consider CSS imports dead code even if the
               // containing package claims to have no side effects.
@@ -483,9 +491,7 @@ module.exports = function (webpackEnv) {
               test: cssModuleRegex,
               use: getStyleLoaders({
                 importLoaders: 1,
-                sourceMap: isEnvProduction
-                  ? shouldUseSourceMap
-                  : isEnvDevelopment,
+                sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
                 modules: {
                   getLocalIdent: getCSSModuleLocalIdent,
                 },
@@ -500,11 +506,9 @@ module.exports = function (webpackEnv) {
               use: getStyleLoaders(
                 {
                   importLoaders: 3,
-                  sourceMap: isEnvProduction
-                    ? shouldUseSourceMap
-                    : isEnvDevelopment,
+                  sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
                 },
-                "sass-loader"
+                'sass-loader'
               ),
               // Don't consider CSS imports dead code even if the
               // containing package claims to have no side effects.
@@ -519,14 +523,12 @@ module.exports = function (webpackEnv) {
               use: getStyleLoaders(
                 {
                   importLoaders: 3,
-                  sourceMap: isEnvProduction
-                    ? shouldUseSourceMap
-                    : isEnvDevelopment,
+                  sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
                   modules: {
                     getLocalIdent: getCSSModuleLocalIdent,
                   },
                 },
-                "sass-loader"
+                'sass-loader'
               ),
             },
             // "file" loader makes sure those assets get served by WebpackDevServer.
@@ -535,14 +537,14 @@ module.exports = function (webpackEnv) {
             // This loader doesn't use a "test" so it will catch all modules
             // that fall through the other loaders.
             {
-              loader: require.resolve("file-loader"),
+              loader: require.resolve('file-loader'),
               // Exclude `js` files to keep "css" loader working as it injects
               // its runtime that would otherwise be processed through "file" loader.
               // Also exclude `html` and `json` extensions so they get processed
               // by webpacks internal loaders.
               exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
               options: {
-                name: "static/media/[name].[hash:8].[ext]",
+                name: 'static/media/[name].[hash:8].[ext]',
               },
             },
             // ** STOP ** Are you adding a new loader?
@@ -624,14 +626,13 @@ module.exports = function (webpackEnv) {
       // to restart the development server for webpack to discover it. This plugin
       // makes the discovery automatic so you don't have to restart.
       // See https://github.com/facebook/create-react-app/issues/186
-      isEnvDevelopment &&
-        new WatchMissingNodeModulesPlugin(paths.appNodeModules),
+      isEnvDevelopment && new WatchMissingNodeModulesPlugin(paths.appNodeModules),
       isEnvProduction &&
         new MiniCssExtractPlugin({
           // Options similar to the same options in webpackOptions.output
           // both options are optional
-          filename: "static/css/[name].[contenthash:8].css",
-          chunkFilename: "static/css/[name].[contenthash:8].chunk.css",
+          filename: 'static/css/[name].[contenthash:8].css',
+          chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
         }),
       // Generate an asset manifest file with the following content:
       // - "files" key: Mapping of all asset filenames to their corresponding
@@ -640,16 +641,14 @@ module.exports = function (webpackEnv) {
       // - "entrypoints" key: Array of files which are included in `index.html`,
       //   can be used to reconstruct the HTML if necessary
       new ManifestPlugin({
-        fileName: "asset-manifest.json",
+        fileName: 'asset-manifest.json',
         publicPath: paths.publicUrlOrPath,
         generate: (seed, files, entrypoints) => {
           const manifestFiles = files.reduce((manifest, file) => {
             manifest[file.name] = file.path;
             return manifest;
           }, seed);
-          const entrypointFiles = entrypoints.main.filter(
-            (fileName) => !fileName.endsWith(".map")
-          );
+          const entrypointFiles = entrypoints.main.filter((fileName) => !fileName.endsWith('.map'));
 
           return {
             files: manifestFiles,
@@ -675,14 +674,12 @@ module.exports = function (webpackEnv) {
       // TypeScript type checking
       useTypeScript &&
         new ForkTsCheckerWebpackPlugin({
-          typescript: resolve.sync("typescript", {
+          typescript: resolve.sync('typescript', {
             basedir: paths.appNodeModules,
           }),
           async: isEnvDevelopment,
           checkSyntacticErrors: true,
-          resolveModuleNameModule: process.versions.pnp
-            ? `${__dirname}/pnpTs.js`
-            : undefined,
+          resolveModuleNameModule: process.versions.pnp ? `${__dirname}/pnpTs.js` : undefined,
           resolveTypeReferenceDirectiveModule: process.versions.pnp
             ? `${__dirname}/pnpTs.js`
             : undefined,
@@ -692,12 +689,12 @@ module.exports = function (webpackEnv) {
             // as micromatch doesn't match
             // '../cra-template-typescript/template/src/App.tsx'
             // otherwise.
-            "../**/src/**/*.{ts,tsx}",
-            "**/src/**/*.{ts,tsx}",
-            "!**/src/**/__tests__/**",
-            "!**/src/**/?(*.)(spec|test).*",
-            "!**/src/setupProxy.*",
-            "!**/src/setupTests.*",
+            '../**/src/**/*.{ts,tsx}',
+            '**/src/**/*.{ts,tsx}',
+            '!**/src/**/__tests__/**',
+            '!**/src/**/?(*.)(spec|test).*',
+            '!**/src/setupProxy.*',
+            '!**/src/setupTests.*',
           ],
           silent: true,
           // The formatter is invoked directly in WebpackDevServerUtils during development
@@ -705,18 +702,18 @@ module.exports = function (webpackEnv) {
         }),
       new ESLintPlugin({
         // Plugin options
-        extensions: ["js", "mjs", "jsx", "ts", "tsx"],
-        formatter: require.resolve("react-dev-utils/eslintFormatter"),
-        eslintPath: require.resolve("eslint"),
+        extensions: ['js', 'mjs', 'jsx', 'ts', 'tsx'],
+        formatter: require.resolve('react-dev-utils/eslintFormatter'),
+        eslintPath: require.resolve('eslint'),
         context: paths.appSrc,
         // ESLint class options
         cwd: paths.appPath,
         resolvePluginsRelativeTo: __dirname,
         baseConfig: {
-          extends: [require.resolve("eslint-config-react-app/base")],
+          extends: [require.resolve('eslint-config-react-app/base')],
           rules: {
             ...(!hasJsxRuntime && {
-              "react/react-in-jsx-scope": "error",
+              'react/react-in-jsx-scope': 'error',
             }),
           },
         },
@@ -725,14 +722,14 @@ module.exports = function (webpackEnv) {
     // Some libraries import Node modules but don't use them in the browser.
     // Tell webpack to provide empty mocks for them so importing them works.
     node: {
-      module: "empty",
-      dgram: "empty",
-      dns: "mock",
-      fs: "empty",
-      http2: "empty",
-      net: "empty",
-      tls: "empty",
-      child_process: "empty",
+      module: 'empty',
+      dgram: 'empty',
+      dns: 'mock',
+      fs: 'empty',
+      http2: 'empty',
+      net: 'empty',
+      tls: 'empty',
+      child_process: 'empty',
     },
     // Turn off performance processing because we utilize
     // our own hints via the FileSizeReporter

--- a/experiments/apidom-playground/package-lock.json
+++ b/experiments/apidom-playground/package-lock.json
@@ -5084,6 +5084,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "comlink": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+      "integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g=="
+    },
     "commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -23238,6 +23243,29 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "worker-loader": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
+      "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
       }
     },
     "worker-rpc": {

--- a/experiments/apidom-playground/package.json
+++ b/experiments/apidom-playground/package.json
@@ -22,6 +22,7 @@
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@reduxjs/toolkit": "^1.5.0",
     "classnames": "^2.2.6",
+    "comlink": "^4.3.0",
     "install": "^0.13.0",
     "npm": "^6.14.10",
     "prop-types": "^15.7.2",
@@ -104,6 +105,7 @@
     "webpack": "4.44.2",
     "webpack-dev-server": "3.11.0",
     "webpack-manifest-plugin": "2.2.0",
-    "workbox-webpack-plugin": "5.1.4"
+    "workbox-webpack-plugin": "5.1.4",
+    "worker-loader": "^3.0.8"
   }
 }

--- a/experiments/apidom-playground/src/features/app/apidom.worker.js
+++ b/experiments/apidom-playground/src/features/app/apidom.worker.js
@@ -1,0 +1,69 @@
+/* eslint-disable camelcase */
+import * as Comlink from 'comlink';
+import { dehydrate, from } from 'apidom';
+import ApiDOMParser from 'apidom-parser';
+import * as jsonAdapter from 'apidom-parser-adapter-json';
+import * as yamlAdapter from 'apidom-parser-adapter-yaml-1-2';
+import * as openapi3_1AdapterJson from 'apidom-parser-adapter-openapi-json-3-1';
+import * as openapi3_1AdapterYaml from 'apidom-parser-adapter-openapi-yaml-3-1';
+import * as asyncapi2_0AdapterJson from 'apidom-parser-adapter-asyncapi-json-2-0';
+import * as asyncapi2_0AdapterYaml from 'apidom-parser-adapter-asyncapi-yaml-2-0';
+import {
+  readFile,
+  resolveApiDOM as resolveApiDOMReferences,
+  dereferenceApiDOM as derefereceApiDOMReferences,
+} from 'apidom-reference';
+
+const parser = ApiDOMParser()
+  .use(jsonAdapter)
+  .use(yamlAdapter)
+  .use(openapi3_1AdapterJson)
+  .use(openapi3_1AdapterYaml)
+  .use(asyncapi2_0AdapterJson)
+  .use(asyncapi2_0AdapterYaml);
+
+/* eslint-disable */
+const service = {
+  async parse(source, { mediaType }) {
+    const namespace = parser.findNamespace(source, { sourceMap: true, mediaType });
+    const parseResult = await parser.parse(source, { sourceMap: true, mediaType });
+    const refract = dehydrate(parseResult, namespace);
+
+    return JSON.stringify(refract, undefined, 2);
+  },
+
+  async readFile(url) {
+    const buffer = await readFile(url, {});
+    return buffer.toString();
+  },
+
+  async resolveApiDOM(apiDOM, { source, mediaType, baseURI }) {
+    const namespace = parser.findNamespace(source, { mediaType });
+    const parseResult = from(apiDOM, namespace);
+
+    return resolveApiDOMReferences(parseResult, { parse: { mediaType }, resolve: { baseURI } });
+  },
+
+  async dereferenceApiDOM(apiDOM, { source, mediaType, baseURI }) {
+    const namespace = parser.findNamespace(source, { mediaType });
+    const parseResult = from(apiDOM, namespace);
+    const dereferenced = await derefereceApiDOMReferences(parseResult.api, {
+      parse: { mediaType },
+      resolve: { baseURI },
+    });
+    const refract = dehydrate(dereferenced, namespace);
+
+    return JSON.stringify(refract, undefined, 2);
+  },
+
+  humanizeDereferenced(dereferenced, { source, mediaType }) {
+    const namespace = parser.findNamespace(source, { mediaType });
+    const element = from(dereferenced, namespace);
+    const pojo = toValue(element, namespace);
+
+    return JSON.stringify(pojo, undefined, 2);
+  },
+};
+
+Comlink.expose(service, globalThis); // eslint-disable-line no-undef
+/* eslint-enable */

--- a/experiments/apidom-playground/src/features/app/slice.js
+++ b/experiments/apidom-playground/src/features/app/slice.js
@@ -1,28 +1,10 @@
-import { createSlice, createAsyncThunk, createSelector } from '@reduxjs/toolkit';
-import { isNonEmptyString, isEmptyString } from 'ramda-adjunct';
-import { from, dehydrate, traverse, toValue } from 'apidom';
-import ApiDOMParser from 'apidom-parser';
-import * as jsonAdapter from 'apidom-parser-adapter-json';
-import * as yamlAdapter from 'apidom-parser-adapter-yaml-1-2';
 /* eslint-disable camelcase */
-import * as openapi3_1AdapterJson from 'apidom-parser-adapter-openapi-json-3-1';
-import * as openapi3_1AdapterYaml from 'apidom-parser-adapter-openapi-yaml-3-1';
-import * as asyncapi2_0AdapterJson from 'apidom-parser-adapter-asyncapi-json-2-0';
-import * as asyncapi2_0AdapterYaml from 'apidom-parser-adapter-asyncapi-yaml-2-0';
+import { createSlice, createAsyncThunk, createSelector } from '@reduxjs/toolkit';
+import { isNonEmptyString, isEmptyString, isNull } from 'ramda-adjunct';
+import { from, traverse, createNamespace } from 'apidom';
+import openApi3_1NsPlugin from 'apidom-ns-openapi-3-1';
+import asyncApi2_0NsPlugin from 'apidom-ns-asyncapi-2-0';
 /* eslint-enable */
-import {
-  readFile,
-  resolveApiDOM as resolveApiDOMReferences,
-  dereferenceApiDOM as derefereceApiDOMReferences,
-} from 'apidom-reference';
-
-const parser = ApiDOMParser()
-  .use(jsonAdapter)
-  .use(yamlAdapter)
-  .use(openapi3_1AdapterJson)
-  .use(openapi3_1AdapterYaml)
-  .use(asyncapi2_0AdapterJson)
-  .use(asyncapi2_0AdapterYaml);
 
 const initialState = {
   source: '',
@@ -55,16 +37,28 @@ export const selectDereferenced = (state) => state.dereferenced;
 
 export const selectIsLoading = (state) => state.isLoading;
 
+export const selectApiDOMNamespace = createSelector(selectMediaType, (mediaType) => {
+  if (isEmptyString(mediaType)) {
+    return null;
+  }
+  if (mediaType.includes('vnd.oai.openapi')) {
+    return createNamespace(openApi3_1NsPlugin);
+  }
+  if (mediaType.includes('vnd.aai.asyncapi')) {
+    return createNamespace(asyncApi2_0NsPlugin);
+  }
+  return createNamespace();
+});
+
 export const selectApiDOMInstance = createSelector(
   selectSource,
   selectApiDOM,
-  selectMediaType,
-  (source, apiDOM, mediaType) => {
-    if (isEmptyString(source) || isEmptyString(apiDOM) || isEmptyString(mediaType)) {
+  selectApiDOMNamespace,
+  (source, apiDOM, namespace) => {
+    if (isEmptyString(source) || isEmptyString(apiDOM) || isNull(namespace)) {
       return null;
     }
 
-    const namespace = parser.findNamespace(source, { mediaType });
     return from(apiDOM, namespace);
   }
 );
@@ -113,26 +107,24 @@ export const selectCanDereference = createSelector(
  * Thunks.
  */
 
-export const importURL = createAsyncThunk('importURLStatus', async (url) => {
-  const buffer = await readFile(url, {});
-  return buffer.toString();
-});
+export const importURL = createAsyncThunk(
+  'importURLStatus',
+  async (url, { extra: { apiDOMService } }) => {
+    return apiDOMService.readFile(url);
+  }
+);
 
-export const parseSource = createAsyncThunk('parseSourceStatus', async ({ source, mediaType }) => {
-  const namespace = parser.findNamespace(source, { sourceMap: true, mediaType });
-  const parseResult = await parser.parse(source, { sourceMap: true, mediaType });
-  const refract = dehydrate(parseResult, namespace);
-
-  return JSON.stringify(refract, undefined, 2);
-});
+export const parseSource = createAsyncThunk(
+  'parseSourceStatus',
+  async ({ source, mediaType }, { extra: { apiDOMService } }) => {
+    return apiDOMService.parse(source, { mediaType });
+  }
+);
 
 export const resolveApiDOM = createAsyncThunk(
   'resolveApiDOMStatus',
-  async ({ source, apiDOM, mediaType, baseURI }) => {
-    const namespace = parser.findNamespace(source, { mediaType });
-    const parseResult = from(apiDOM, namespace);
-
-    return resolveApiDOMReferences(parseResult, { parse: { mediaType }, resolve: { baseURI } });
+  async ({ source, apiDOM, mediaType, baseURI }, { extra: { apiDOMService } }) => {
+    return apiDOMService.resolveApiDOM(apiDOM, { source, mediaType, baseURI });
   }
 );
 
@@ -143,27 +135,15 @@ export const interpretApiDOM = createAsyncThunk('interpretApiDOMStatus', async (
 
 export const dereferenceApiDOM = createAsyncThunk(
   'dereferenceApiDOMStatus',
-  async ({ source, apiDOM, mediaType, baseURI }) => {
-    const namespace = parser.findNamespace(source, { mediaType });
-    const parseResult = from(apiDOM, namespace);
-    const dereferenced = await derefereceApiDOMReferences(parseResult.api, {
-      parse: { mediaType },
-      resolve: { baseURI },
-    });
-    const refract = dehydrate(dereferenced, namespace);
-
-    return JSON.stringify(refract, undefined, 2);
+  async ({ source, apiDOM, mediaType, baseURI }, { extra: { apiDOMService } }) => {
+    return apiDOMService.dereferenceApiDOM(apiDOM, { source, mediaType, baseURI });
   }
 );
 
 export const humanizeDereferencedApiDOM = createAsyncThunk(
   'humanizeDereferencedApiDOMStatus',
-  ({ source, mediaType, dereferenced }) => {
-    const namespace = parser.findNamespace(source, { mediaType });
-    const element = from(dereferenced, namespace);
-    const pojo = toValue(element, namespace);
-
-    return JSON.stringify(pojo, undefined, 2);
+  ({ source, mediaType, dereferenced }, { extra: { apiDOMService } }) => {
+    return apiDOMService.humanizeDereferenced(dereferenced, { source, mediaType });
   }
 );
 

--- a/experiments/apidom-playground/src/index.jsx
+++ b/experiments/apidom-playground/src/index.jsx
@@ -6,7 +6,9 @@ import { CssBaseline } from '@material-ui/core';
 import './index.scss';
 import App from './features/app/components/App';
 import reportWebVitals from './reportWebVitals';
-import store from './store';
+import createStore from './store';
+
+const store = createStore();
 
 ReactDOM.render(
   <React.StrictMode>

--- a/experiments/apidom-playground/src/store.js
+++ b/experiments/apidom-playground/src/store.js
@@ -1,14 +1,24 @@
 import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
+import * as Complink from 'comlink';
 import rootReducer from 'features/app/slice';
+import ApiDOMWorker from 'features/app/apidom.worker';
 
-const store = configureStore({
-  reducer: rootReducer,
-  middleware: getDefaultMiddleware({
-    serializableCheck: {
-      // Ignore these field paths in all actions
-      ignoredActionPaths: ['payload'],
-    },
-  }),
-});
+const createStore = () => {
+  const apiDOMWorker = new ApiDOMWorker();
+  const apiDOMService = Complink.wrap(apiDOMWorker);
 
-export default store;
+  return configureStore({
+    reducer: rootReducer,
+    middleware: getDefaultMiddleware({
+      thunk: {
+        extraArgument: { apiDOMService },
+      },
+      serializableCheck: {
+        // Ignore these field paths in all actions
+        ignoredActionPaths: ['payload'],
+      },
+    }),
+  });
+};
+
+export default createStore;


### PR DESCRIPTION
ApiDOM playground now demonstrates that offloading all processing
of apidom packages works in web worker environment.

For actual implementation of web worker I've used library
called Comlink to abstract web worker communication with
RPC protocol.

For referencing the global object in different environments
we now use globalThis symbol which abstracts environments
and is standardized.

Refs #287