### PR TITLE
refactor(visit): switch to different impl of parallel traversal

### DIFF
--- a/apidom/packages/apidom-ns-asyncapi-2-0/src/refractor/index.ts
+++ b/apidom/packages/apidom-ns-asyncapi-2-0/src/refractor/index.ts
@@ -33,7 +33,10 @@ const refract = <T extends Element>(
     const namespace = createNamespace(asyncApi2_0Namespace);
     const toolbox = { predicates: { ...predicates }, namespace };
     const pluginsSpecs = plugins.map((plugin: any) => plugin(toolbox));
-    const pluginsVisitor = mergeAllVisitors(pluginsSpecs.map(propOr({}, 'visitor')));
+    const pluginsVisitor = mergeAllVisitors(pluginsSpecs.map(propOr({}, 'visitor')), {
+      // @ts-ignore
+      nodeTypeGetter: getNodeType,
+    });
     pluginsSpecs.forEach(invokeArgs(['pre'], []));
     const newElement: any = visit(rootVisitor.element, pluginsVisitor, {
       keyMap,

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/index.ts
@@ -33,7 +33,10 @@ const refract = <T extends Element>(
     const namespace = createNamespace(openApi3_1Namespace);
     const toolbox = { predicates: { ...predicates }, namespace };
     const pluginsSpecs = plugins.map((plugin: any) => plugin(toolbox));
-    const pluginsVisitor = mergeAllVisitors(pluginsSpecs.map(propOr({}, 'visitor')));
+    const pluginsVisitor = mergeAllVisitors(pluginsSpecs.map(propOr({}, 'visitor')), {
+      // @ts-ignore
+      nodeTypeGetter: getNodeType,
+    });
     pluginsSpecs.forEach(invokeArgs(['pre'], []));
     const newElement: any = visit(rootVisitor.element, pluginsVisitor, {
       keyMap,


### PR DESCRIPTION
Current paraller traversal was unnecessarily complex and
contained bugs that were very hard to fix.

I've switched impl to teoretically less performant version
though very well battletested.