### PR TITLE
feat(apidom-ns-openapi-3-1): content in response

### DIFF
--- a/apidom/packages/apidom-ls/test/fixtures/jsonschema/response-content-schema.json
+++ b/apidom/packages/apidom-ls/test/fixtures/jsonschema/response-content-schema.json
@@ -1,0 +1,26 @@
+{
+  "openapi": "3.1.0",
+  "paths": {
+    "/users": {
+      "get": {
+        "responses": {
+          "201": {
+            "description": "A response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apidom/packages/apidom-ls/test/openapi-jsonschema.ts
+++ b/apidom/packages/apidom-ls/test/openapi-jsonschema.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Diagnostic } from 'vscode-languageserver-types';
+// @ts-ignore
+import { Element, traverse } from 'apidom';
+import { getParser } from '../src/parser-factory';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const spec = fs
+  .readFileSync(path.join(__dirname, 'fixtures', 'jsonschema/response-content-schema.json'))
+  .toString();
+
+describe('apidom-jsonschema-prototype-test', function () {
+  it('test parse', async function () {
+    const doc: TextDocument = TextDocument.create('foo://bar/file.json', 'json', 0, spec);
+
+    const parser = getParser(doc);
+    const text: string = doc.getText();
+    const diagnostics: Diagnostic[] = [];
+
+    const result = await parser.parse(text, { sourceMap: true });
+
+    const { api } = result;
+    if (!api) {
+      return diagnostics;
+    }
+    api.freeze(); // !! freeze and add parent !!
+
+    const foundElements: string[] = [];
+    function printAndCheckContent(node: Element): void {
+      // eslint-disable-next-line no-console
+      console.log(node.element, node.toValue());
+      foundElements.push(node.element);
+    }
+
+    traverse(printAndCheckContent, api);
+
+    expect(foundElements).to.include.members(['response', 'mediaType', 'schema']);
+
+    if (result.annotations) {
+      for (const annotation of result.annotations) {
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(annotation));
+      }
+    }
+
+    return result;
+  });
+});

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/MediaType.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/MediaType.ts
@@ -1,0 +1,20 @@
+import { Attributes, Meta, ObjectElement } from 'minim';
+
+import SchemaElement from './Schema';
+
+class MediaType extends ObjectElement {
+  constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
+    super(content, meta, attributes);
+    this.element = 'mediaType';
+  }
+
+  get schema(): SchemaElement {
+    return this.get('schema');
+  }
+
+  set schema(schema: SchemaElement) {
+    this.set('schema', schema);
+  }
+}
+
+export default MediaType;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/elements/Response.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/elements/Response.ts
@@ -1,9 +1,19 @@
 import { Attributes, Meta, ObjectElement } from 'minim';
 
+import MediaType from './MediaType';
+
 class Response extends ObjectElement {
   constructor(content?: Record<string, unknown>, meta?: Meta, attributes?: Attributes) {
     super(content, meta, attributes);
     this.element = 'response';
+  }
+
+  get contentProp(): Record<string, MediaType> {
+    return this.get('content');
+  }
+
+  set contentProp(contentProp: Record<string, MediaType>) {
+    this.set('content', contentProp);
   }
 }
 

--- a/apidom/packages/apidom-ns-openapi-3-1/src/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/index.ts
@@ -36,6 +36,7 @@ export {
   isSecurityRequirementElement,
   isServerElement,
   isServerVariableElement,
+  isMediaTypeElement,
 } from './predicates';
 
 export {
@@ -70,3 +71,4 @@ export { default as SchemaElement } from './elements/Schema';
 export { default as SecurityRequirementElement } from './elements/SecurityRequirement';
 export { default as ServerElement } from './elements/Server';
 export { default as ServerVariableElement } from './elements/ServerVariable';
+export { default as MediaTypeElement } from './elements/MediaType';

--- a/apidom/packages/apidom-ns-openapi-3-1/src/namespace.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/namespace.ts
@@ -20,6 +20,7 @@ import SchemaElement from './elements/Schema';
 import SecurityRequirementElement from './elements/SecurityRequirement';
 import ServerElement from './elements/Server';
 import ServerVariableElement from './elements/ServerVariable';
+import MediaTypeElement from './elements/MediaType';
 
 const openApi3_1 = {
   namespace: (options: NamespacePluginOptions) => {
@@ -45,6 +46,7 @@ const openApi3_1 = {
     base.register('securityRequirement', SecurityRequirementElement);
     base.register('server', ServerElement);
     base.register('serverVariable', ServerVariableElement);
+    base.register('mediaType', MediaTypeElement);
 
     return base;
   },

--- a/apidom/packages/apidom-ns-openapi-3-1/src/predicates.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/predicates.ts
@@ -21,6 +21,7 @@ import SchemaElement from './elements/Schema';
 import SecurityRequirementElement from './elements/SecurityRequirement';
 import ServerElement from './elements/Server';
 import ServerVariableElement from './elements/ServerVariable';
+import MediaTypeElement from './elements/MediaType';
 
 export const isCallbackElement = createPredicate(
   ({ hasBasicElementProps, isElementType, primitiveEq }) => {
@@ -259,6 +260,18 @@ export const isServerVariableElement = createPredicate(
     return either(
       is(ServerVariableElement),
       allPass([hasBasicElementProps, isElementTypeServerVariable, primitiveEqObject]),
+    );
+  },
+);
+
+export const isMediaTypeElement = createPredicate(
+  ({ hasBasicElementProps, isElementType, primitiveEq }) => {
+    const isElementTypeMediaType = isElementType('mediaType');
+    const primitiveEqObject = primitiveEq('object');
+
+    return either(
+      is(MediaTypeElement),
+      allPass([hasBasicElementProps, isElementTypeMediaType, primitiveEqObject]),
     );
   },
 );

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/specification.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/specification.ts
@@ -55,6 +55,7 @@ import PathsVisitor from './visitors/open-api-3-1/paths';
 import RequestBodyVisitor from './visitors/open-api-3-1/request-body';
 import CallbackVisitor from './visitors/open-api-3-1/callback';
 import ResponseVisitor from './visitors/open-api-3-1/response';
+import MediaTypeVisitor from './visitors/open-api-3-1/media-type';
 import ResponsesVisitor from './visitors/open-api-3-1/responses';
 import ResponsesDefaultVisitor from './visitors/open-api-3-1/responses/DefaultVisitor';
 import OperationVisitor from './visitors/open-api-3-1/operation';
@@ -246,6 +247,12 @@ const specification = {
           $visitor: RequestBodyVisitor,
           fixedFields: {},
         },
+        MediaType: {
+          $visitor: MediaTypeVisitor,
+          fixedFields: {
+            schema: SchemaVisitor,
+          },
+        },
         Responses: {
           $visitor: ResponsesVisitor,
           fixedFields: {
@@ -254,7 +261,9 @@ const specification = {
         },
         Response: {
           $visitor: ResponseVisitor,
-          fixedFields: {},
+          fixedFields: {
+            content: ContentVisitor,
+          },
         },
         Callback: {
           $visitor: CallbackVisitor,

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/ContentVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/ContentVisitor.ts
@@ -1,9 +1,19 @@
 import stampit from 'stampit';
+import { always } from 'ramda';
+import { ObjectElement } from 'apidom';
 
+import { appendMetadata } from '../../metadata';
+import MapVisitor from '../generics/MapVisitor';
 import FallbackVisitor from '../FallbackVisitor';
 
-// TODO(vladimir.gorej@gmail.com): this needs to be implemented as specific editor
-// TODO(vladimir.gorej@gmail.com): currently it's only generically encoding any value to ApiDOM
-const ContentVisitor = stampit(FallbackVisitor);
+const ContentVisitor = stampit(MapVisitor, FallbackVisitor, {
+  props: {
+    specPath: always(['document', 'objects', 'MediaType']),
+  },
+  init() {
+    this.element = new ObjectElement();
+    appendMetadata(['content'], this.element);
+  },
+});
 
 export default ContentVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/media-type/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/media-type/index.ts
@@ -1,0 +1,18 @@
+import stampit from 'stampit';
+import { always } from 'ramda';
+
+import MediaTypeElement from '../../../../elements/MediaType';
+import FallbackVisitor from '../../FallbackVisitor';
+import FixedFieldsVisitor from '../../generics/FixedFieldsVisitor';
+
+const MediaTypeVisitor = stampit(FixedFieldsVisitor, FallbackVisitor, {
+  props: {
+    specPath: always(['document', 'objects', 'MediaType']),
+    canSupportSpecificationExtensions: true,
+  },
+  init() {
+    this.element = new MediaTypeElement();
+  },
+});
+
+export default MediaTypeVisitor;

--- a/apidom/packages/apidom-ns-openapi-3-1/src/traversal/visitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/traversal/visitor.ts
@@ -28,5 +28,6 @@ export const keyMap = {
   SecurityRequirementElement: ['content'],
   ServerElement: ['content'],
   ServerVariableElement: ['content'],
+  MediaTypeElement: ['content'],
   ...keyMapBase,
 };


### PR DESCRIPTION
adds response/content/mediaType/schema partial refract for openapi ns.

@char0n also not sure where we could add tests for this, and current tests in apidom-ls don't seem to cause a failure when chai `expect` (or `assert`) fails, not sure why..