### PR TITLE
feat(ns-openapi-3-1): implement refractor plugin for $id inheritance

### DIFF
--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/index.ts
@@ -6,7 +6,8 @@ import { visit, Element, dereference, mergeAllVisitors } from 'apidom';
 import specification from './specification';
 import { keyMap, getNodeType } from '../traversal/visitor';
 import createToolbox from './toolbox';
-import embeddedResoucesPlugin from './plugins/embedded-resources-$schema';
+import embeddedResources$schemaPlugin from './plugins/embedded-resources-$schema';
+import embeddedResources$idPlugin from './plugins/embedded-resources-$id';
 
 const refract = <T extends Element>(
   value: any,
@@ -29,7 +30,7 @@ const refract = <T extends Element>(
    * Running plugins visitors means extra single traversal.
    * This can be optimized in future for performance.
    */
-  const defaultPlugins = [embeddedResoucesPlugin];
+  const defaultPlugins = [embeddedResources$schemaPlugin, embeddedResources$idPlugin];
   const allPlugins = concat(defaultPlugins, plugins);
 
   if (allPlugins.length > 0) {

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/plugins/embedded-resources-$id.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/plugins/embedded-resources-$id.ts
@@ -1,0 +1,46 @@
+import { last, defaultTo } from 'ramda';
+import { isNonEmptyString } from 'ramda-adjunct';
+
+// @ts-ignore
+const plugin = ({ predicates, namespace }) => {
+  const { Schema: SchemaElement } = namespace.elements;
+  const { isStringElement, isSchemaElement } = predicates;
+
+  let ancestors: Array<typeof SchemaElement>;
+
+  return {
+    name: 'embedded-resources-$id',
+    pre() {
+      ancestors = [];
+    },
+    visitor: {
+      SchemaElement: {
+        enter(schemaElement: typeof SchemaElement) {
+          const parentSchema = last(ancestors);
+
+          if (isSchemaElement(parentSchema) && !isStringElement(schemaElement.$id)) {
+            // parent is available and no $id is defined, set parent $id
+            const inherited$id = defaultTo(
+              parentSchema.meta.get('inherited$id')?.toValue(),
+              parentSchema.$id?.toValue(),
+            );
+
+            if (isNonEmptyString(inherited$id)) {
+              schemaElement.setMetaProperty('inherited$id', inherited$id);
+            }
+          }
+
+          ancestors.push(schemaElement);
+        },
+        leave() {
+          ancestors.pop();
+        },
+      },
+    },
+    post() {
+      ancestors = [];
+    },
+  };
+};
+
+export default plugin;

--- a/apidom/packages/apidom-ns-openapi-3-1/test/refractor/plugins/embedded-resources-$id.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/test/refractor/plugins/embedded-resources-$id.ts
@@ -1,0 +1,109 @@
+import { assert } from 'chai';
+import { ObjectElement, find } from 'apidom';
+
+import { isSchemaElement, OpenApi3_1Element } from '../../../src';
+
+describe('refractor', function () {
+  context('plugins', function () {
+    context('embedded-resources-$id', function () {
+      context('given Schema Object without $id field', function () {
+        specify('should not inherited $id from parent schema', function () {
+          const genericObjectElement = new ObjectElement({
+            openapi: '3.1.0',
+            components: {
+              schemas: {
+                user: {
+                  type: 'object',
+                },
+              },
+            },
+          });
+          const openApiElement = OpenApi3_1Element.refract(genericObjectElement);
+          const schemaElement = find((e) => isSchemaElement(e), openApiElement);
+          const actual = schemaElement?.meta.get('inherited$id');
+
+          assert.isUndefined(actual);
+        });
+      });
+
+      context('given Schema Object with inner Schemas', function () {
+        let genericObjectElement: any;
+        let openApiElement: any;
+
+        beforeEach(function () {
+          genericObjectElement = new ObjectElement({
+            openapi: '3.1.0',
+            components: {
+              schemas: {
+                user: {
+                  $anchor: '1',
+                  type: 'object',
+                  oneOf: [
+                    {
+                      $id: '$id1',
+                      $anchor: '2',
+                      type: 'number',
+                      contains: { $anchor: '3', type: 'object' },
+                    },
+                  ],
+                  contains: {
+                    $anchor: '4',
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          });
+          openApiElement = OpenApi3_1Element.refract(genericObjectElement);
+        });
+
+        specify('should not annotate Schema Object($anchor=1) with inherited $id', function () {
+          const schemaElement = find(
+            (e) => isSchemaElement(e) && e.$anchor.equals('1'),
+            openApiElement,
+          );
+          const actual = schemaElement?.meta.get('inherited$id');
+
+          assert.isUndefined(actual);
+        });
+
+        specify('should have Schema Object($anchor=2) $id set for appropriate value', function () {
+          const schemaElement = find(
+            (e) => isSchemaElement(e) && e.$anchor.equals('2'),
+            openApiElement,
+          );
+          // @ts-ignore
+          const actual = schemaElement?.$id.toValue();
+          const expected = '$id1';
+
+          assert.strictEqual(actual, expected);
+          assert.isFalse(schemaElement?.meta.hasKey('inherited$id'));
+        });
+
+        specify(
+          'should annotate Schema Object($anchor=3) with appropriate inherited $id',
+          function () {
+            const schemaElement = find(
+              (e) => isSchemaElement(e) && e.$anchor.equals('3'),
+              openApiElement,
+            );
+            const actual = schemaElement?.meta.get('inherited$id').toValue();
+            const expected = '$id1';
+
+            assert.strictEqual(actual, expected);
+          },
+        );
+
+        specify('should not annotate Schema Object($anchor=4) with inherited $id', function () {
+          const schemaElement = find(
+            (e) => isSchemaElement(e) && e.$anchor.equals('4'),
+            openApiElement,
+          );
+          const actual = schemaElement?.meta.get('inherited$id');
+
+          assert.isUndefined(actual);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This plugin transforms all Schema Elements in advance
and assigns information about inherited JSON Schema $id to
Schema Element. One only has to inspect $id property of Schema Element or
look into inherited meta property (inherited$id) to identify
an actual schema resource. If $id and inherited$id are both
not present then $id of the schema is assumed according to
https://json-schema.org/draft/2020-12/json-schema-core.html#initial-base.

Closes #363