### PR TITLE
feat(reference): add additional metadata during dereference

### DIFF
--- a/apidom/packages/apidom-reference/src/dereference/strategies/asyncapi-2-0/visitor.ts
+++ b/apidom/packages/apidom-reference/src/dereference/strategies/asyncapi-2-0/visitor.ts
@@ -119,6 +119,12 @@ const AsyncApi2_0DereferenceVisitor = stampit({
       });
       fragment = await visitAsync(fragment, visitor, { keyMap, nodeTypeGetter: getNodeType });
 
+      // annotate fragment with info about original Reference element
+      fragment = fragment.clone();
+      fragment.setMetaProperty('ref-fields', {
+        $ref: referenceElement.$ref.toValue(),
+      });
+
       this.indirections.pop();
 
       // transclude the element for a fragment

--- a/apidom/packages/apidom-reference/test/dereference/strategies/asyncapi-2-0/reference-object/index.ts
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/asyncapi-2-0/reference-object/index.ts
@@ -40,6 +40,22 @@ describe('dereference', function () {
 
             assert.isTrue(isParameterElement(fragment));
           });
+
+          specify(
+            'should annotate transcluded element with additional metadata',
+            async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const dereferenced = await dereference(rootFilePath, {
+                parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
+              });
+              const fragment = evaluate('/0/components/parameters/userId', dereferenced);
+
+              assert.strictEqual(
+                fragment.meta.get('ref-fields').get('$ref').toValue(),
+                '#/components/parameters/indirection1',
+              );
+            },
+          );
         });
 
         context('given Reference Objects pointing internally only', function () {

--- a/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/index.ts
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/index.ts
@@ -40,6 +40,26 @@ describe('dereference', function () {
 
             assert.isTrue(isParameterElement(fragment));
           });
+
+          specify(
+            'should annotate transcluded element with additional metadata',
+            async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const dereferenced = await dereference(rootFilePath, {
+                parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
+              });
+              const fragment = evaluate('/0/components/parameters/userId', dereferenced);
+
+              assert.strictEqual(
+                fragment.meta.get('ref-fields').get('$ref').toValue(),
+                '#/components/parameters/indirection1',
+              );
+              assert.strictEqual(
+                fragment.meta.get('ref-fields').get('description').toValue(),
+                'override',
+              );
+            },
+          );
         });
       });
 

--- a/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/index.ts
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/index.ts
@@ -41,6 +41,25 @@ describe('dereference', function () {
 
             assert.isTrue(isSchemaElement(fragment));
           });
+
+          specify(
+            'should annotate transcluded element with additional metadata',
+            async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const dereferenced = await dereference(rootFilePath, {
+                parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
+              });
+              const fragment = evaluate(
+                '/0/components/schemas/User/properties/profile',
+                dereferenced,
+              );
+
+              assert.strictEqual(
+                fragment.meta.get('ref-fields').get('$ref').toValue(),
+                '#/components/schemas/UserProfile',
+              );
+            },
+          );
         });
 
         context('given Schema Objects pointing internally only', function () {


### PR DESCRIPTION
Metadata is taken from original referencing element
and translated as metadata to referenced element.

Closes #384