### PR TITLE
feat(ns-openapi-3-1): add tests using dehydrated ApiDOM snapshots

### DIFF
--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/ExamplesVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/ExamplesVisitor.ts
@@ -3,20 +3,16 @@ import { Element, ObjectElement } from 'apidom';
 
 import MapVisitor from '../generics/MapVisitor';
 import FallbackVisitor from '../FallbackVisitor';
-import { isReferenceLikeElement, isExampleLikeElement } from '../../predicates';
+import { isReferenceLikeElement } from '../../predicates';
 import { isReferenceElement } from '../../../predicates';
 import ReferenceElement from '../../../elements/Reference';
 
 const ExamplesVisitor = stampit(MapVisitor, FallbackVisitor, {
   props: {
-    specPath: (element: Element) => {
-      // eslint-disable-next-line no-nested-ternary
-      return isReferenceLikeElement(element)
+    specPath: (element: Element) =>
+      isReferenceLikeElement(element)
         ? ['document', 'objects', 'Reference']
-        : isExampleLikeElement(element)
-        ? ['document', 'objects', 'Example']
-        : ['value'];
-    },
+        : ['document', 'objects', 'Example'],
     canSupportSpecificationExtensions: true,
   },
   init() {

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/ParametersVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/ParametersVisitor.ts
@@ -4,6 +4,7 @@ import { ArrayElement, Element, BREAK } from 'apidom';
 import FallbackVisitor from '../FallbackVisitor';
 import SpecificationVisitor from '../SpecificationVisitor';
 import { isReferenceLikeElement } from '../../predicates';
+import { isReferenceElement } from '../../../predicates';
 
 const ParametersVisitor = stampit(SpecificationVisitor, FallbackVisitor, {
   init() {
@@ -16,6 +17,10 @@ const ParametersVisitor = stampit(SpecificationVisitor, FallbackVisitor, {
           ? ['document', 'objects', 'Reference']
           : ['document', 'objects', 'Parameter'];
         const element = this.toRefractedElement(specPath, item);
+
+        if (isReferenceElement(element)) {
+          element.setMetaProperty('referenced-element', 'parameter');
+        }
 
         this.element.push(element);
       });

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/components/SchemasVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/components/SchemasVisitor.ts
@@ -11,7 +11,7 @@ const SchemasVisitor = stampit(MapVisitor, FallbackVisitor, {
   },
   init() {
     this.element = new ObjectElement();
-    this.element.classes.push('schemas');
+    this.element.classes.push('components-schemas');
   },
 });
 

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/encoding/HeadersVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/encoding/HeadersVisitor.ts
@@ -3,22 +3,32 @@ import { Element, ObjectElement } from 'apidom';
 
 import MapVisitor from '../../generics/MapVisitor';
 import FallbackVisitor from '../../FallbackVisitor';
-import { isHeaderLikeElement, isReferenceLikeElement } from '../../../predicates';
+import { isReferenceLikeElement } from '../../../predicates';
+import { isReferenceElement } from '../../../../predicates';
+import ReferenceElement from '../../../../elements/Reference';
 
 const HeadersVisitor = stampit(MapVisitor, FallbackVisitor, {
   props: {
-    specPath: (element: Element) => {
-      // eslint-disable-next-line no-nested-ternary
-      return isReferenceLikeElement(element)
+    specPath: (element: Element) =>
+      isReferenceLikeElement(element)
         ? ['document', 'objects', 'Reference']
-        : isHeaderLikeElement(element)
-        ? ['document', 'objects', 'Header']
-        : ['value'];
-    },
+        : ['document', 'objects', 'Header'],
   },
   init() {
     this.element = new ObjectElement();
     this.element.classes.push('encoding-headers');
+  },
+  methods: {
+    ObjectElement(objectElement: ObjectElement) {
+      // @ts-ignore
+      const result = MapVisitor.compose.methods.ObjectElement.call(this, objectElement);
+
+      this.element.filter(isReferenceElement).forEach((referenceElement: ReferenceElement) => {
+        referenceElement.setMetaProperty('referenced-element', 'header');
+      });
+
+      return result;
+    },
   },
 });
 

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/operation/CallbacksVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/operation/CallbacksVisitor.ts
@@ -1,5 +1,5 @@
 import stampit from 'stampit';
-import { Element, isObjectElement, ObjectElement } from 'apidom';
+import { Element, ObjectElement } from 'apidom';
 
 import { isReferenceLikeElement } from '../../../predicates';
 import { isReferenceElement } from '../../../../predicates';
@@ -9,18 +9,14 @@ import FallbackVisitor from '../../FallbackVisitor';
 
 const CallbacksVisitor = stampit(MapVisitor, FallbackVisitor, {
   props: {
-    specPath: (element: Element) => {
-      // eslint-disable-next-line no-nested-ternary
-      return isReferenceLikeElement(element)
+    specPath: (element: Element) =>
+      isReferenceLikeElement(element)
         ? ['document', 'objects', 'Reference']
-        : isObjectElement(element)
-        ? ['document', 'objects', 'Callback']
-        : ['value'];
-    },
+        : ['document', 'objects', 'Callback'],
   },
   init() {
     this.element = new ObjectElement();
-    this.element.classes.push('callbacks');
+    this.element.classes.push('operation-callbacks');
   },
   methods: {
     ObjectElement(objectElement: ObjectElement) {

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/operation/TagsVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/operation/TagsVisitor.ts
@@ -7,7 +7,7 @@ const TagsVisitor = stampit(FallbackVisitor, {
   methods: {
     ArrayElement(arrayElement: ArrayElement) {
       this.element = arrayElement.clone();
-      this.element.classes.push('tags');
+      this.element.classes.push('operation-tags');
 
       return BREAK;
     },

--- a/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server/VariablesVisitor.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/server/VariablesVisitor.ts
@@ -11,7 +11,7 @@ const VariablesVisitor = stampit(MapVisitor, FallbackVisitor, {
   },
   init() {
     this.element = new ObjectElement();
-    this.element.classes.push('variables');
+    this.element.classes.push('server-variables');
   },
 });
 

--- a/apidom/packages/apidom-ns-openapi-3-1/test/refractor/__snapshots__/index.ts.snap
+++ b/apidom/packages/apidom-ns-openapi-3-1/test/refractor/__snapshots__/index.ts.snap
@@ -1,0 +1,7168 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`refractor given generic ApiDOM object in OpenApi 3.1 shape should refract to OpenApi 3.1 Element 1`] = `
+{
+  "element": "openApi3_1",
+  "meta": {
+    "classes": {
+      "element": "array",
+      "content": [
+        {
+          "element": "string",
+          "content": "api"
+        }
+      ]
+    }
+  },
+  "content": [
+    {
+      "element": "member",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "fixed-field"
+            }
+          ]
+        }
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "openapi"
+        },
+        "value": {
+          "element": "openapi",
+          "content": "3.1.0"
+        }
+      }
+    },
+    {
+      "element": "member",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "fixed-field"
+            }
+          ]
+        }
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "info"
+        },
+        "value": {
+          "element": "info",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "info"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "title"
+                },
+                "value": {
+                  "element": "string",
+                  "content": "Sample Pet Store App"
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "summary"
+                },
+                "value": {
+                  "element": "string",
+                  "content": "A pet store manager."
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "description"
+                },
+                "value": {
+                  "element": "string",
+                  "content": "This is a sample server for a pet store."
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "termsOfService"
+                },
+                "value": {
+                  "element": "string",
+                  "content": "https://example.com/terms/"
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "contact"
+                },
+                "value": {
+                  "element": "contact",
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "name"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "API Support"
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "url"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "https://www.example.com/support"
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "email"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "support@example.com"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "license"
+                },
+                "value": {
+                  "element": "license",
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "name"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "Apache 2.0"
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "identifier"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "Apache-2.0"
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "url"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "https://www.apache.org/licenses/LICENSE-2.0.html"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "version"
+                },
+                "value": {
+                  "element": "string",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "version"
+                        }
+                      ]
+                    }
+                  },
+                  "content": "1.0.1"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "element": "member",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "fixed-field"
+            }
+          ]
+        }
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "jsonSchemaDialect"
+        },
+        "value": {
+          "element": "jsonSchemaDialect",
+          "content": "https://spec.openapis.org/oas/3.1/dialect/base"
+        }
+      }
+    },
+    {
+      "element": "member",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "fixed-field"
+            }
+          ]
+        }
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "servers"
+        },
+        "value": {
+          "element": "array",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "servers"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "server",
+              "content": [
+                {
+                  "element": "member",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "fixed-field"
+                        }
+                      ]
+                    }
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "url"
+                    },
+                    "value": {
+                      "element": "string",
+                      "content": "{username}.gigantic-server.com"
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "fixed-field"
+                        }
+                      ]
+                    }
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "description"
+                    },
+                    "value": {
+                      "element": "string",
+                      "content": "Production server"
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "fixed-field"
+                        }
+                      ]
+                    }
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "variables"
+                    },
+                    "value": {
+                      "element": "object",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "server-variables"
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "member",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "patterned-field"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {
+                            "key": {
+                              "element": "string",
+                              "content": "username"
+                            },
+                            "value": {
+                              "element": "serverVariable",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "enum"
+                                    },
+                                    "value": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "demo"
+                                        },
+                                        {
+                                          "element": "string",
+                                          "content": "demo1"
+                                        },
+                                        {
+                                          "element": "string",
+                                          "content": "demo2"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "default"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "demo"
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "description"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "This value is assigned by the service provider, in this example \`gigantic-server.com\`"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "element": "member",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "fixed-field"
+            }
+          ]
+        }
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "paths"
+        },
+        "value": {
+          "element": "paths",
+          "content": [
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "patterned-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "/path1"
+                },
+                "value": {
+                  "element": "pathItem",
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "summary"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "path1 summary"
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "description"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "path1 description"
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "get"
+                        },
+                        "value": {
+                          "element": "operation",
+                          "meta": {
+                            "httpMethod": {
+                              "element": "string",
+                              "content": "GET"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "put"
+                        },
+                        "value": {
+                          "element": "operation",
+                          "meta": {
+                            "httpMethod": {
+                              "element": "string",
+                              "content": "PUT"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "tags"
+                                },
+                                "value": {
+                                  "element": "array",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "operation-tags"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "tag1"
+                                    },
+                                    {
+                                      "element": "string",
+                                      "content": "tag2"
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "summary"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "path2 components item summary"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "description"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "path2 components item description"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "externalDocs"
+                                },
+                                "value": {
+                                  "element": "externalDocumentation",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "description"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "content": "external documentation 1"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "url"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "content": "https://example.com/external-doc1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "operationId"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "path-1-put"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "parameters"
+                                },
+                                "value": {
+                                  "element": "array",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "parameters"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "parameter",
+                                      "content": [
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "fixed-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "name"
+                                            },
+                                            "value": {
+                                              "element": "string",
+                                              "content": "parameter3"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "fixed-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "in"
+                                            },
+                                            "value": {
+                                              "element": "string",
+                                              "content": "query"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "fixed-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "description"
+                                            },
+                                            "value": {
+                                              "element": "string",
+                                              "content": "parameter3 description"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "fixed-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "required"
+                                            },
+                                            "value": {
+                                              "element": "boolean",
+                                              "content": false
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "fixed-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "deprecated"
+                                            },
+                                            "value": {
+                                              "element": "boolean",
+                                              "content": false
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "fixed-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "allowEmptyValue"
+                                            },
+                                            "value": {
+                                              "element": "boolean",
+                                              "content": true
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "element": "reference",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "openapi-reference"
+                                            }
+                                          ]
+                                        },
+                                        "referenced-element": {
+                                          "element": "string",
+                                          "content": "parameter"
+                                        }
+                                      },
+                                      "content": [
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "fixed-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "$ref"
+                                            },
+                                            "value": {
+                                              "element": "string",
+                                              "content": "#/components/parameters/parameter2"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "requestBody"
+                                },
+                                "value": {
+                                  "element": "requestBody",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "description"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "content": "request body description"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "content"
+                                        },
+                                        "value": {
+                                          "element": "object",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "content"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "patterned-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "application/json"
+                                                },
+                                                "value": {
+                                                  "element": "mediaType",
+                                                  "content": [
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "fixed-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "schema"
+                                                        },
+                                                        "value": {
+                                                          "element": "schema",
+                                                          "meta": {
+                                                            "inherited$schema": {
+                                                              "element": "string",
+                                                              "content": "https://spec.openapis.org/oas/3.1/dialect/base"
+                                                            },
+                                                            "inherited$id": {
+                                                              "element": "array"
+                                                            }
+                                                          },
+                                                          "content": [
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "type"
+                                                                },
+                                                                "value": {
+                                                                  "element": "string",
+                                                                  "content": "object"
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "fixed-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "example"
+                                                        },
+                                                        "value": {
+                                                          "element": "object",
+                                                          "content": [
+                                                            {
+                                                              "element": "member",
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "a"
+                                                                },
+                                                                "value": {
+                                                                  "element": "string",
+                                                                  "content": "b"
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "fixed-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "examples"
+                                                        },
+                                                        "value": {
+                                                          "element": "object",
+                                                          "meta": {
+                                                            "classes": {
+                                                              "element": "array",
+                                                              "content": [
+                                                                {
+                                                                  "element": "string",
+                                                                  "content": "examples"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "content": [
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "patterned-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "example1"
+                                                                },
+                                                                "value": {
+                                                                  "element": "example",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "summary"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "string",
+                                                                          "content": "example 1 summary"
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "description"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "string",
+                                                                          "content": "example 1 description"
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "value"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "string",
+                                                                          "content": "c"
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "externalValue"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "string",
+                                                                          "content": "https://example1.com/"
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "patterned-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "example2"
+                                                                },
+                                                                "value": {
+                                                                  "element": "reference",
+                                                                  "meta": {
+                                                                    "classes": {
+                                                                      "element": "array",
+                                                                      "content": [
+                                                                        {
+                                                                          "element": "string",
+                                                                          "content": "openapi-reference"
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    "referenced-element": {
+                                                                      "element": "string",
+                                                                      "content": "example"
+                                                                    }
+                                                                  },
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "$ref"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "string",
+                                                                          "content": "#/components/examples/example3"
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "fixed-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "encoding"
+                                                        },
+                                                        "value": {
+                                                          "element": "object",
+                                                          "meta": {
+                                                            "classes": {
+                                                              "element": "array",
+                                                              "content": [
+                                                                {
+                                                                  "element": "string",
+                                                                  "content": "encoding"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "content": [
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "patterned-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "historyMetadata"
+                                                                },
+                                                                "value": {
+                                                                  "element": "encoding",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "contentType"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "string",
+                                                                          "content": "application/json"
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "headers"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "object",
+                                                                          "meta": {
+                                                                            "classes": {
+                                                                              "element": "array",
+                                                                              "content": [
+                                                                                {
+                                                                                  "element": "string",
+                                                                                  "content": "encoding-headers"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "member",
+                                                                              "meta": {
+                                                                                "classes": {
+                                                                                  "element": "array",
+                                                                                  "content": [
+                                                                                    {
+                                                                                      "element": "string",
+                                                                                      "content": "patterned-field"
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              },
+                                                                              "content": {
+                                                                                "key": {
+                                                                                  "element": "string",
+                                                                                  "content": "X-Rate-Limit-Limit"
+                                                                                },
+                                                                                "value": {
+                                                                                  "element": "header",
+                                                                                  "content": [
+                                                                                    {
+                                                                                      "element": "member",
+                                                                                      "meta": {
+                                                                                        "classes": {
+                                                                                          "element": "array",
+                                                                                          "content": [
+                                                                                            {
+                                                                                              "element": "string",
+                                                                                              "content": "fixed-field"
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      },
+                                                                                      "content": {
+                                                                                        "key": {
+                                                                                          "element": "string",
+                                                                                          "content": "description"
+                                                                                        },
+                                                                                        "value": {
+                                                                                          "element": "string",
+                                                                                          "content": "x-rate limit description"
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "element": "member",
+                                                                                      "meta": {
+                                                                                        "classes": {
+                                                                                          "element": "array",
+                                                                                          "content": [
+                                                                                            {
+                                                                                              "element": "string",
+                                                                                              "content": "fixed-field"
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      },
+                                                                                      "content": {
+                                                                                        "key": {
+                                                                                          "element": "string",
+                                                                                          "content": "schema"
+                                                                                        },
+                                                                                        "value": {
+                                                                                          "element": "schema",
+                                                                                          "meta": {
+                                                                                            "inherited$schema": {
+                                                                                              "element": "string",
+                                                                                              "content": "https://spec.openapis.org/oas/3.1/dialect/base"
+                                                                                            },
+                                                                                            "inherited$id": {
+                                                                                              "element": "array"
+                                                                                            }
+                                                                                          },
+                                                                                          "content": [
+                                                                                            {
+                                                                                              "element": "member",
+                                                                                              "meta": {
+                                                                                                "classes": {
+                                                                                                  "element": "array",
+                                                                                                  "content": [
+                                                                                                    {
+                                                                                                      "element": "string",
+                                                                                                      "content": "fixed-field"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              },
+                                                                                              "content": {
+                                                                                                "key": {
+                                                                                                  "element": "string",
+                                                                                                  "content": "type"
+                                                                                                },
+                                                                                                "value": {
+                                                                                                  "element": "string",
+                                                                                                  "content": "integer"
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "element": "member",
+                                                                              "meta": {
+                                                                                "classes": {
+                                                                                  "element": "array",
+                                                                                  "content": [
+                                                                                    {
+                                                                                      "element": "string",
+                                                                                      "content": "patterned-field"
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              },
+                                                                              "content": {
+                                                                                "key": {
+                                                                                  "element": "string",
+                                                                                  "content": "Content-Type"
+                                                                                },
+                                                                                "value": {
+                                                                                  "element": "reference",
+                                                                                  "meta": {
+                                                                                    "classes": {
+                                                                                      "element": "array",
+                                                                                      "content": [
+                                                                                        {
+                                                                                          "element": "string",
+                                                                                          "content": "openapi-reference"
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    "referenced-element": {
+                                                                                      "element": "string",
+                                                                                      "content": "header"
+                                                                                    }
+                                                                                  },
+                                                                                  "content": [
+                                                                                    {
+                                                                                      "element": "member",
+                                                                                      "meta": {
+                                                                                        "classes": {
+                                                                                          "element": "array",
+                                                                                          "content": [
+                                                                                            {
+                                                                                              "element": "string",
+                                                                                              "content": "fixed-field"
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      },
+                                                                                      "content": {
+                                                                                        "key": {
+                                                                                          "element": "string",
+                                                                                          "content": "$ref"
+                                                                                        },
+                                                                                        "value": {
+                                                                                          "element": "string",
+                                                                                          "content": "#/components/headers/Content-Type"
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "style"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "string",
+                                                                          "content": "simple"
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "explode"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "boolean",
+                                                                          "content": true
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "allowReserved"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "boolean",
+                                                                          "content": true
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "required"
+                                        },
+                                        "value": {
+                                          "element": "boolean",
+                                          "content": true
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "responses"
+                                },
+                                "value": {
+                                  "element": "responses",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "default"
+                                        },
+                                        "value": {
+                                          "element": "response",
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "fixed-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "description"
+                                                },
+                                                "value": {
+                                                  "element": "string",
+                                                  "content": "default response"
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "fixed-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "links"
+                                                },
+                                                "value": {
+                                                  "element": "object",
+                                                  "meta": {
+                                                    "classes": {
+                                                      "element": "array",
+                                                      "content": [
+                                                        {
+                                                          "element": "string",
+                                                          "content": "response-links"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "content": [
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "patterned-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "link1"
+                                                        },
+                                                        "value": {
+                                                          "element": "link",
+                                                          "content": [
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "operationRef"
+                                                                },
+                                                                "value": {
+                                                                  "element": "string",
+                                                                  "content": "https://example.com/external-link"
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "operationId"
+                                                                },
+                                                                "value": {
+                                                                  "element": "string",
+                                                                  "content": "operationId-1"
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "parameters"
+                                                                },
+                                                                "value": {
+                                                                  "element": "object",
+                                                                  "meta": {
+                                                                    "classes": {
+                                                                      "element": "array",
+                                                                      "content": [
+                                                                        {
+                                                                          "element": "string",
+                                                                          "content": "link-parameters"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "patterned-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "parameter1"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "string",
+                                                                          "content": "{$url}"
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "requestBody"
+                                                                },
+                                                                "value": {
+                                                                  "element": "string",
+                                                                  "content": "{$method}"
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "description"
+                                                                },
+                                                                "value": {
+                                                                  "element": "string",
+                                                                  "content": "link 1 description"
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "server"
+                                                                },
+                                                                "value": {
+                                                                  "element": "server"
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "patterned-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "link2"
+                                                        },
+                                                        "value": {
+                                                          "element": "reference",
+                                                          "meta": {
+                                                            "classes": {
+                                                              "element": "array",
+                                                              "content": [
+                                                                {
+                                                                  "element": "string",
+                                                                  "content": "openapi-reference"
+                                                                }
+                                                              ]
+                                                            },
+                                                            "referenced-element": {
+                                                              "element": "string",
+                                                              "content": "link"
+                                                            }
+                                                          },
+                                                          "content": [
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "$ref"
+                                                                },
+                                                                "value": {
+                                                                  "element": "string",
+                                                                  "content": "#/components/links/link3"
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "patterned-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "201"
+                                        },
+                                        "value": {
+                                          "element": "reference",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "openapi-reference"
+                                                }
+                                              ]
+                                            },
+                                            "referenced-element": {
+                                              "element": "string",
+                                              "content": "response"
+                                            }
+                                          },
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "fixed-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "$ref"
+                                                },
+                                                "value": {
+                                                  "element": "string",
+                                                  "content": "#/components/responses/201"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "callbacks"
+                                },
+                                "value": {
+                                  "element": "object",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "operation-callbacks"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "patterned-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "myCallback1"
+                                        },
+                                        "value": {
+                                          "element": "callback",
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "patterned-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "{$request.query.queryUrl}"
+                                                },
+                                                "value": {
+                                                  "element": "pathItem",
+                                                  "content": [
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "fixed-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "post"
+                                                        },
+                                                        "value": {
+                                                          "element": "operation",
+                                                          "meta": {
+                                                            "httpMethod": {
+                                                              "element": "string",
+                                                              "content": "POST"
+                                                            }
+                                                          },
+                                                          "content": [
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "requestBody"
+                                                                },
+                                                                "value": {
+                                                                  "element": "requestBody",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "description"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "string",
+                                                                          "content": "Callback payload"
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "content"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "object",
+                                                                          "meta": {
+                                                                            "classes": {
+                                                                              "element": "array",
+                                                                              "content": [
+                                                                                {
+                                                                                  "element": "string",
+                                                                                  "content": "content"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "member",
+                                                                              "meta": {
+                                                                                "classes": {
+                                                                                  "element": "array",
+                                                                                  "content": [
+                                                                                    {
+                                                                                      "element": "string",
+                                                                                      "content": "patterned-field"
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              },
+                                                                              "content": {
+                                                                                "key": {
+                                                                                  "element": "string",
+                                                                                  "content": "application/json"
+                                                                                },
+                                                                                "value": {
+                                                                                  "element": "mediaType",
+                                                                                  "content": [
+                                                                                    {
+                                                                                      "element": "member",
+                                                                                      "meta": {
+                                                                                        "classes": {
+                                                                                          "element": "array",
+                                                                                          "content": [
+                                                                                            {
+                                                                                              "element": "string",
+                                                                                              "content": "fixed-field"
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      },
+                                                                                      "content": {
+                                                                                        "key": {
+                                                                                          "element": "string",
+                                                                                          "content": "schema"
+                                                                                        },
+                                                                                        "value": {
+                                                                                          "element": "schema",
+                                                                                          "meta": {
+                                                                                            "inherited$schema": {
+                                                                                              "element": "string",
+                                                                                              "content": "https://spec.openapis.org/oas/3.1/dialect/base"
+                                                                                            },
+                                                                                            "inherited$id": {
+                                                                                              "element": "array"
+                                                                                            }
+                                                                                          },
+                                                                                          "content": [
+                                                                                            {
+                                                                                              "element": "member",
+                                                                                              "meta": {
+                                                                                                "classes": {
+                                                                                                  "element": "array",
+                                                                                                  "content": [
+                                                                                                    {
+                                                                                                      "element": "string",
+                                                                                                      "content": "fixed-field"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              },
+                                                                                              "content": {
+                                                                                                "key": {
+                                                                                                  "element": "string",
+                                                                                                  "content": "type"
+                                                                                                },
+                                                                                                "value": {
+                                                                                                  "element": "string",
+                                                                                                  "content": "object"
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "responses"
+                                                                },
+                                                                "value": {
+                                                                  "element": "responses",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "patterned-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "200"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "response",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "member",
+                                                                              "meta": {
+                                                                                "classes": {
+                                                                                  "element": "array",
+                                                                                  "content": [
+                                                                                    {
+                                                                                      "element": "string",
+                                                                                      "content": "fixed-field"
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              },
+                                                                              "content": {
+                                                                                "key": {
+                                                                                  "element": "string",
+                                                                                  "content": "description"
+                                                                                },
+                                                                                "value": {
+                                                                                  "element": "string",
+                                                                                  "content": "callback successfully processed"
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "patterned-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "myCallback2"
+                                        },
+                                        "value": {
+                                          "element": "reference",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "openapi-reference"
+                                                }
+                                              ]
+                                            },
+                                            "referenced-element": {
+                                              "element": "string",
+                                              "content": "callback"
+                                            }
+                                          },
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "fixed-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "$ref"
+                                                },
+                                                "value": {
+                                                  "element": "string",
+                                                  "content": "#/components/callbacks/callback1"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "deprecated"
+                                },
+                                "value": {
+                                  "element": "boolean",
+                                  "content": false
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "security"
+                                },
+                                "value": {
+                                  "element": "array",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "security"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "securityRequirement",
+                                      "content": [
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "patterned-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "petstore_auth"
+                                            },
+                                            "value": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "write:pets"
+                                                },
+                                                {
+                                                  "element": "string",
+                                                  "content": "read:pets"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "servers"
+                                },
+                                "value": {
+                                  "element": "array",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "servers"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "server",
+                                      "content": [
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "fixed-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "url"
+                                            },
+                                            "value": {
+                                              "element": "string",
+                                              "content": "{username}.gigantic-server.com"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "fixed-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "description"
+                                            },
+                                            "value": {
+                                              "element": "string",
+                                              "content": "Production server"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "fixed-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "variables"
+                                            },
+                                            "value": {
+                                              "element": "object",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "server-variables"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": [
+                                                {
+                                                  "element": "member",
+                                                  "meta": {
+                                                    "classes": {
+                                                      "element": "array",
+                                                      "content": [
+                                                        {
+                                                          "element": "string",
+                                                          "content": "patterned-field"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "content": {
+                                                    "key": {
+                                                      "element": "string",
+                                                      "content": "username"
+                                                    },
+                                                    "value": {
+                                                      "element": "serverVariable",
+                                                      "content": [
+                                                        {
+                                                          "element": "member",
+                                                          "meta": {
+                                                            "classes": {
+                                                              "element": "array",
+                                                              "content": [
+                                                                {
+                                                                  "element": "string",
+                                                                  "content": "fixed-field"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "content": {
+                                                            "key": {
+                                                              "element": "string",
+                                                              "content": "enum"
+                                                            },
+                                                            "value": {
+                                                              "element": "array",
+                                                              "content": [
+                                                                {
+                                                                  "element": "string",
+                                                                  "content": "demo"
+                                                                },
+                                                                {
+                                                                  "element": "string",
+                                                                  "content": "demo1"
+                                                                },
+                                                                {
+                                                                  "element": "string",
+                                                                  "content": "demo2"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "element": "member",
+                                                          "meta": {
+                                                            "classes": {
+                                                              "element": "array",
+                                                              "content": [
+                                                                {
+                                                                  "element": "string",
+                                                                  "content": "fixed-field"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "content": {
+                                                            "key": {
+                                                              "element": "string",
+                                                              "content": "default"
+                                                            },
+                                                            "value": {
+                                                              "element": "string",
+                                                              "content": "demo"
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "element": "member",
+                                                          "meta": {
+                                                            "classes": {
+                                                              "element": "array",
+                                                              "content": [
+                                                                {
+                                                                  "element": "string",
+                                                                  "content": "fixed-field"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "content": {
+                                                            "key": {
+                                                              "element": "string",
+                                                              "content": "description"
+                                                            },
+                                                            "value": {
+                                                              "element": "string",
+                                                              "content": "This value is assigned by the service provider, in this example \`gigantic-server.com\`"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "post"
+                        },
+                        "value": {
+                          "element": "operation",
+                          "meta": {
+                            "httpMethod": {
+                              "element": "string",
+                              "content": "POST"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "requestBody"
+                                },
+                                "value": {
+                                  "element": "reference",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "openapi-reference"
+                                        }
+                                      ]
+                                    },
+                                    "referenced-element": {
+                                      "element": "string",
+                                      "content": "requestBody"
+                                    }
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "$ref"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "content": "#/components/requestBodies/requestBody1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "responses"
+                                },
+                                "value": {
+                                  "element": "responses",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "default"
+                                        },
+                                        "value": {
+                                          "element": "reference",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "openapi-reference"
+                                                }
+                                              ]
+                                            },
+                                            "referenced-element": {
+                                              "element": "string",
+                                              "content": "response"
+                                            }
+                                          },
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "fixed-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "$ref"
+                                                },
+                                                "value": {
+                                                  "element": "string",
+                                                  "content": "#/components/responses/201"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "delete"
+                        },
+                        "value": {
+                          "element": "operation",
+                          "meta": {
+                            "httpMethod": {
+                              "element": "string",
+                              "content": "DELETE"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "options"
+                        },
+                        "value": {
+                          "element": "operation",
+                          "meta": {
+                            "httpMethod": {
+                              "element": "string",
+                              "content": "OPTIONS"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "head"
+                        },
+                        "value": {
+                          "element": "operation",
+                          "meta": {
+                            "httpMethod": {
+                              "element": "string",
+                              "content": "HEAD"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "patch"
+                        },
+                        "value": {
+                          "element": "operation",
+                          "meta": {
+                            "httpMethod": {
+                              "element": "string",
+                              "content": "PATCH"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "trace"
+                        },
+                        "value": {
+                          "element": "operation",
+                          "meta": {
+                            "httpMethod": {
+                              "element": "string",
+                              "content": "TRACE"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "servers"
+                        },
+                        "value": {
+                          "element": "array",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "servers"
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "server",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "url"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "{username}.gigantic-server.com"
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "description"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "Production server"
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "variables"
+                                    },
+                                    "value": {
+                                      "element": "object",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "server-variables"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": [
+                                        {
+                                          "element": "member",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "patterned-field"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "username"
+                                            },
+                                            "value": {
+                                              "element": "serverVariable",
+                                              "content": [
+                                                {
+                                                  "element": "member",
+                                                  "meta": {
+                                                    "classes": {
+                                                      "element": "array",
+                                                      "content": [
+                                                        {
+                                                          "element": "string",
+                                                          "content": "fixed-field"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "content": {
+                                                    "key": {
+                                                      "element": "string",
+                                                      "content": "enum"
+                                                    },
+                                                    "value": {
+                                                      "element": "array",
+                                                      "content": [
+                                                        {
+                                                          "element": "string",
+                                                          "content": "demo"
+                                                        },
+                                                        {
+                                                          "element": "string",
+                                                          "content": "demo1"
+                                                        },
+                                                        {
+                                                          "element": "string",
+                                                          "content": "demo2"
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "element": "member",
+                                                  "meta": {
+                                                    "classes": {
+                                                      "element": "array",
+                                                      "content": [
+                                                        {
+                                                          "element": "string",
+                                                          "content": "fixed-field"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "content": {
+                                                    "key": {
+                                                      "element": "string",
+                                                      "content": "default"
+                                                    },
+                                                    "value": {
+                                                      "element": "string",
+                                                      "content": "demo"
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "element": "member",
+                                                  "meta": {
+                                                    "classes": {
+                                                      "element": "array",
+                                                      "content": [
+                                                        {
+                                                          "element": "string",
+                                                          "content": "fixed-field"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "content": {
+                                                    "key": {
+                                                      "element": "string",
+                                                      "content": "description"
+                                                    },
+                                                    "value": {
+                                                      "element": "string",
+                                                      "content": "This value is assigned by the service provider, in this example \`gigantic-server.com\`"
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "parameters"
+                        },
+                        "value": {
+                          "element": "array",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "parameters"
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "parameter",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "name"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "parameter1"
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "in"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "query"
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "description"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "parameter1 description"
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "required"
+                                    },
+                                    "value": {
+                                      "element": "boolean",
+                                      "content": false
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "deprecated"
+                                    },
+                                    "value": {
+                                      "element": "boolean",
+                                      "content": false
+                                    }
+                                  }
+                                },
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "allowEmptyValue"
+                                    },
+                                    "value": {
+                                      "element": "boolean",
+                                      "content": true
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "element": "reference",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "openapi-reference"
+                                    }
+                                  ]
+                                },
+                                "referenced-element": {
+                                  "element": "string",
+                                  "content": "parameter"
+                                }
+                              },
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "fixed-field"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "$ref"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "#/components/parameters/parameter2"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "patterned-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "/path2"
+                },
+                "value": {
+                  "element": "pathItem",
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "summary"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "path2 summary"
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "description"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "path2 description"
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "$ref"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "#/components/pathItems/path2"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "element": "member",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "fixed-field"
+            }
+          ]
+        }
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "webhooks"
+        },
+        "value": {
+          "element": "object",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "webhooks"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "patterned-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "webhook1"
+                },
+                "value": {
+                  "element": "pathItem",
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "get"
+                        },
+                        "value": {
+                          "element": "operation",
+                          "meta": {
+                            "httpMethod": {
+                              "element": "string",
+                              "content": "GET"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "tags"
+                                },
+                                "value": {
+                                  "element": "array",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "operation-tags"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "tag1"
+                                    },
+                                    {
+                                      "element": "string",
+                                      "content": "tag2"
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "summary"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "path2 components item summary"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "description"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "path2 components item description"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "patterned-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "webhook2"
+                },
+                "value": {
+                  "element": "reference",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "openapi-reference"
+                        }
+                      ]
+                    },
+                    "referenced-element": {
+                      "element": "string",
+                      "content": "pathItem"
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "fixed-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "$ref"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "#/components/pathItems/path2"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "element": "member",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "fixed-field"
+            }
+          ]
+        }
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "components"
+        },
+        "value": {
+          "element": "components",
+          "content": [
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "schemas"
+                },
+                "value": {
+                  "element": "object",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "components-schemas"
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "schema1"
+                        },
+                        "value": {
+                          "element": "schema",
+                          "meta": {
+                            "inherited$schema": {
+                              "element": "string",
+                              "content": "https://spec.openapis.org/oas/3.1/dialect/base"
+                            },
+                            "inherited$id": {
+                              "element": "array"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "object"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "schema2"
+                        },
+                        "value": {
+                          "element": "schema",
+                          "meta": {
+                            "inherited$schema": {
+                              "element": "string",
+                              "content": "https://spec.openapis.org/oas/3.1/dialect/base"
+                            },
+                            "inherited$id": {
+                              "element": "array"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "$ref"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "#/components/schemas/schema1"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "responses"
+                },
+                "value": {
+                  "element": "object",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "components-responses"
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "201"
+                        },
+                        "value": {
+                          "element": "response",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "description"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "201 description"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "headers"
+                                },
+                                "value": {
+                                  "element": "object",
+                                  "meta": {
+                                    "classes": {
+                                      "element": "array",
+                                      "content": [
+                                        {
+                                          "element": "string",
+                                          "content": "response-headers"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "patterned-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "Content-Type"
+                                        },
+                                        "value": {
+                                          "element": "header",
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "fixed-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "description"
+                                                },
+                                                "value": {
+                                                  "element": "string",
+                                                  "content": "The number of allowed requests in the current period"
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "fixed-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "schema"
+                                                },
+                                                "value": {
+                                                  "element": "schema",
+                                                  "meta": {
+                                                    "inherited$schema": {
+                                                      "element": "string",
+                                                      "content": "https://spec.openapis.org/oas/3.1/dialect/base"
+                                                    },
+                                                    "inherited$id": {
+                                                      "element": "array"
+                                                    }
+                                                  },
+                                                  "content": [
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "fixed-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "type"
+                                                        },
+                                                        "value": {
+                                                          "element": "string",
+                                                          "content": "integer"
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "400"
+                        },
+                        "value": {
+                          "element": "reference",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "openapi-reference"
+                                }
+                              ]
+                            },
+                            "referenced-element": {
+                              "element": "string",
+                              "content": "response"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "$ref"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "#/components/responses/201"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "parameters"
+                },
+                "value": {
+                  "element": "object",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "components-parameters"
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "parameter2"
+                        },
+                        "value": {
+                          "element": "parameter",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "name"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "parameter2"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "in"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "query"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "description"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "parameter2 description"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "required"
+                                },
+                                "value": {
+                                  "element": "boolean",
+                                  "content": false
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "deprecated"
+                                },
+                                "value": {
+                                  "element": "boolean",
+                                  "content": false
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "allowEmptyValue"
+                                },
+                                "value": {
+                                  "element": "boolean",
+                                  "content": true
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "parameter3"
+                        },
+                        "value": {
+                          "element": "reference",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "openapi-reference"
+                                }
+                              ]
+                            },
+                            "referenced-element": {
+                              "element": "string",
+                              "content": "parameter"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "$ref"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "#/components/parameters/parameter2"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "examples"
+                },
+                "value": {
+                  "element": "object",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "examples"
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "example3"
+                        },
+                        "value": {
+                          "element": "example",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "summary"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "example 3 summary"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "description"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "example 3 description"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "value"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "c"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "externalValue"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "https://example3.com/"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "example4"
+                        },
+                        "value": {
+                          "element": "reference",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "openapi-reference"
+                                }
+                              ]
+                            },
+                            "referenced-element": {
+                              "element": "string",
+                              "content": "example"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "$ref"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "#/components/examples/example3"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "requestBodies"
+                },
+                "value": {
+                  "element": "object",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "components-request-bodies"
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "requestBody1"
+                        },
+                        "value": {
+                          "element": "requestBody",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "description"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "request body 1 description"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "required"
+                                },
+                                "value": {
+                                  "element": "boolean",
+                                  "content": true
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "requestBody2"
+                        },
+                        "value": {
+                          "element": "reference",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "openapi-reference"
+                                }
+                              ]
+                            },
+                            "referenced-element": {
+                              "element": "string",
+                              "content": "requestBody"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "$ref"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "#/components/requestBodies/requestBody1"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "headers"
+                },
+                "value": {
+                  "element": "object",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "components-headers"
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "Content-Type"
+                        },
+                        "value": {
+                          "element": "header",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "description"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "The number of allowed requests in the current period"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "schema"
+                                },
+                                "value": {
+                                  "element": "schema",
+                                  "meta": {
+                                    "inherited$schema": {
+                                      "element": "string",
+                                      "content": "https://spec.openapis.org/oas/3.1/dialect/base"
+                                    },
+                                    "inherited$id": {
+                                      "element": "array"
+                                    }
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "type"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "content": "integer"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "X-Custom-Header"
+                        },
+                        "value": {
+                          "element": "reference",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "openapi-reference"
+                                }
+                              ]
+                            },
+                            "referenced-element": {
+                              "element": "string",
+                              "content": "header"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "$ref"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "#/components/headers/Content-Type"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "securitySchemes"
+                },
+                "value": {
+                  "element": "object",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "components-security-schemes"
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "securityScheme1"
+                        },
+                        "value": {
+                          "element": "securityScheme",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "http"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "description"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "security scheme description"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "name"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "apiKey"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "in"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "apiKey"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "scheme"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "http"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "flows"
+                                },
+                                "value": {
+                                  "element": "oAuthFlows",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "implicit"
+                                        },
+                                        "value": {
+                                          "element": "oAuthFlow",
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "fixed-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "authorizationUrl"
+                                                },
+                                                "value": {
+                                                  "element": "string",
+                                                  "content": "http://authorization-url.com/"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "securityScheme2"
+                        },
+                        "value": {
+                          "element": "reference",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "openapi-reference"
+                                }
+                              ]
+                            },
+                            "referenced-element": {
+                              "element": "string",
+                              "content": "securityScheme"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "$ref"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "#/components/securitySchemes/securityScheme1"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "links"
+                },
+                "value": {
+                  "element": "object",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "components-links"
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "link3"
+                        },
+                        "value": {
+                          "element": "link",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "description"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "link 3 description"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "link4"
+                        },
+                        "value": {
+                          "element": "reference",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "openapi-reference"
+                                }
+                              ]
+                            },
+                            "referenced-element": {
+                              "element": "string",
+                              "content": "link"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "$ref"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "#/components/links/link4"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "callbacks"
+                },
+                "value": {
+                  "element": "object",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "components-callbacks"
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "callback1"
+                        },
+                        "value": {
+                          "element": "callback",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "patterned-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "{$request.query.queryUrl}"
+                                },
+                                "value": {
+                                  "element": "pathItem",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "put"
+                                        },
+                                        "value": {
+                                          "element": "operation",
+                                          "meta": {
+                                            "httpMethod": {
+                                              "element": "string",
+                                              "content": "PUT"
+                                            }
+                                          },
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "fixed-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "requestBody"
+                                                },
+                                                "value": {
+                                                  "element": "requestBody",
+                                                  "content": [
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "fixed-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "description"
+                                                        },
+                                                        "value": {
+                                                          "element": "string",
+                                                          "content": "Callback payload"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "fixed-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "content"
+                                                        },
+                                                        "value": {
+                                                          "element": "object",
+                                                          "meta": {
+                                                            "classes": {
+                                                              "element": "array",
+                                                              "content": [
+                                                                {
+                                                                  "element": "string",
+                                                                  "content": "content"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "content": [
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "patterned-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "application/json"
+                                                                },
+                                                                "value": {
+                                                                  "element": "mediaType",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "member",
+                                                                      "meta": {
+                                                                        "classes": {
+                                                                          "element": "array",
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "string",
+                                                                              "content": "fixed-field"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "content": {
+                                                                        "key": {
+                                                                          "element": "string",
+                                                                          "content": "schema"
+                                                                        },
+                                                                        "value": {
+                                                                          "element": "schema",
+                                                                          "meta": {
+                                                                            "inherited$schema": {
+                                                                              "element": "string",
+                                                                              "content": "https://spec.openapis.org/oas/3.1/dialect/base"
+                                                                            },
+                                                                            "inherited$id": {
+                                                                              "element": "array"
+                                                                            }
+                                                                          },
+                                                                          "content": [
+                                                                            {
+                                                                              "element": "member",
+                                                                              "meta": {
+                                                                                "classes": {
+                                                                                  "element": "array",
+                                                                                  "content": [
+                                                                                    {
+                                                                                      "element": "string",
+                                                                                      "content": "fixed-field"
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              },
+                                                                              "content": {
+                                                                                "key": {
+                                                                                  "element": "string",
+                                                                                  "content": "type"
+                                                                                },
+                                                                                "value": {
+                                                                                  "element": "string",
+                                                                                  "content": "object"
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "element": "member",
+                                              "meta": {
+                                                "classes": {
+                                                  "element": "array",
+                                                  "content": [
+                                                    {
+                                                      "element": "string",
+                                                      "content": "fixed-field"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "responses"
+                                                },
+                                                "value": {
+                                                  "element": "responses",
+                                                  "content": [
+                                                    {
+                                                      "element": "member",
+                                                      "meta": {
+                                                        "classes": {
+                                                          "element": "array",
+                                                          "content": [
+                                                            {
+                                                              "element": "string",
+                                                              "content": "patterned-field"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "200"
+                                                        },
+                                                        "value": {
+                                                          "element": "response",
+                                                          "content": [
+                                                            {
+                                                              "element": "member",
+                                                              "meta": {
+                                                                "classes": {
+                                                                  "element": "array",
+                                                                  "content": [
+                                                                    {
+                                                                      "element": "string",
+                                                                      "content": "fixed-field"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "content": {
+                                                                "key": {
+                                                                  "element": "string",
+                                                                  "content": "description"
+                                                                },
+                                                                "value": {
+                                                                  "element": "string",
+                                                                  "content": "callback successfully processed"
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "callback2"
+                        },
+                        "value": {
+                          "element": "reference",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "openapi-reference"
+                                }
+                              ]
+                            },
+                            "referenced-element": {
+                              "element": "string",
+                              "content": "callback"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "$ref"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "#/components/callbacks/callback1"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "pathItems"
+                },
+                "value": {
+                  "element": "object",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "components-path-items"
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "path2"
+                        },
+                        "value": {
+                          "element": "pathItem",
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "get"
+                                },
+                                "value": {
+                                  "element": "operation",
+                                  "meta": {
+                                    "httpMethod": {
+                                      "element": "string",
+                                      "content": "GET"
+                                    }
+                                  },
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "tags"
+                                        },
+                                        "value": {
+                                          "element": "array",
+                                          "meta": {
+                                            "classes": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "string",
+                                                  "content": "operation-tags"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "tag1"
+                                            },
+                                            {
+                                              "element": "string",
+                                              "content": "tag2"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "summary"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "content": "path2 components item summary"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "element": "member",
+                                      "meta": {
+                                        "classes": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "fixed-field"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "description"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "content": "path2 components item description"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "meta": {
+                        "classes": {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "patterned-field"
+                            }
+                          ]
+                        }
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "path3"
+                        },
+                        "value": {
+                          "element": "reference",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "openapi-reference"
+                                }
+                              ]
+                            },
+                            "referenced-element": {
+                              "element": "string",
+                              "content": "pathItem"
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "fixed-field"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "$ref"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "#/components/pathItems/path2"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "element": "member",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "fixed-field"
+            }
+          ]
+        }
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "security"
+        },
+        "value": {
+          "element": "array",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "security"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "securityRequirement",
+              "content": [
+                {
+                  "element": "member",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "patterned-field"
+                        }
+                      ]
+                    }
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "api_key"
+                    },
+                    "value": {
+                      "element": "array"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "element": "member",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "fixed-field"
+            }
+          ]
+        }
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "tags"
+        },
+        "value": {
+          "element": "array",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "tags"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "tag",
+              "content": [
+                {
+                  "element": "member",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "fixed-field"
+                        }
+                      ]
+                    }
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "name"
+                    },
+                    "value": {
+                      "element": "string",
+                      "content": "tag1"
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "fixed-field"
+                        }
+                      ]
+                    }
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "description"
+                    },
+                    "value": {
+                      "element": "string",
+                      "content": "tag1 description"
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "classes": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "fixed-field"
+                        }
+                      ]
+                    }
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "externalDocs"
+                    },
+                    "value": {
+                      "element": "externalDocumentation",
+                      "content": [
+                        {
+                          "element": "member",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "fixed-field"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {
+                            "key": {
+                              "element": "string",
+                              "content": "description"
+                            },
+                            "value": {
+                              "element": "string",
+                              "content": "external docs tag description"
+                            }
+                          }
+                        },
+                        {
+                          "element": "member",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "fixed-field"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {
+                            "key": {
+                              "element": "string",
+                              "content": "url"
+                            },
+                            "value": {
+                              "element": "string",
+                              "content": "https://example.com/extenral-docs-tag"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "element": "member",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "fixed-field"
+            }
+          ]
+        }
+      },
+      "content": {
+        "key": {
+          "element": "string",
+          "content": "externalDocs"
+        },
+        "value": {
+          "element": "externalDocumentation",
+          "content": [
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "description"
+                },
+                "value": {
+                  "element": "string",
+                  "content": "external docs top level description"
+                }
+              }
+            },
+            {
+              "element": "member",
+              "meta": {
+                "classes": {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "string",
+                      "content": "fixed-field"
+                    }
+                  ]
+                }
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "url"
+                },
+                "value": {
+                  "element": "string",
+                  "content": "https://example.com/extenral-docs-top-level"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+`;

--- a/apidom/packages/apidom-ns-openapi-3-1/test/refractor/fixtures/openapi.json
+++ b/apidom/packages/apidom-ns-openapi-3-1/test/refractor/fixtures/openapi.json
@@ -1,0 +1,389 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Sample Pet Store App",
+    "summary": "A pet store manager.",
+    "description": "This is a sample server for a pet store.",
+    "termsOfService": "https://example.com/terms/",
+    "contact": {
+      "name": "API Support",
+      "url": "https://www.example.com/support",
+      "email": "support@example.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "identifier": "Apache-2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.1"
+  },
+  "jsonSchemaDialect": "https://spec.openapis.org/oas/3.1/dialect/base",
+  "servers": [
+    {
+      "url": "{username}.gigantic-server.com",
+      "description": "Production server",
+      "variables": {
+        "username": {
+          "enum": ["demo", "demo1", "demo2"],
+          "default": "demo",
+          "description": "This value is assigned by the service provider, in this example `gigantic-server.com`"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/path1": {
+      "summary": "path1 summary",
+      "description": "path1 description",
+      "get": {},
+      "put": {
+        "tags": ["tag1", "tag2"],
+        "summary": "path2 components item summary",
+        "description": "path2 components item description",
+        "externalDocs": {
+          "description": "external documentation 1",
+          "url": "https://example.com/external-doc1"
+        },
+        "operationId": "path-1-put",
+        "parameters": [
+          {
+            "name": "parameter3",
+            "in": "query",
+            "description": "parameter3 description",
+            "required": false,
+            "deprecated": false,
+            "allowEmptyValue": true
+          },
+          {
+            "$ref": "#/components/parameters/parameter2"
+          }
+        ],
+        "requestBody": {
+          "description": "request body description",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              },
+              "example": {
+                "a": "b"
+              },
+              "examples": {
+                "example1": {
+                  "summary": "example 1 summary",
+                  "description": "example 1 description",
+                  "value": "c",
+                  "externalValue": "https://example1.com/"
+                },
+                "example2": {
+                  "$ref": "#/components/examples/example3"
+                }
+              },
+              "encoding": {
+                "historyMetadata": {
+                  "contentType": "application/json",
+                  "headers": {
+                    "X-Rate-Limit-Limit": {
+                      "description": "x-rate limit description",
+                      "schema": {
+                        "type": "integer"
+                      }
+                    },
+                    "Content-Type": {
+                      "$ref": "#/components/headers/Content-Type"
+                    }
+                  },
+                  "style": "simple",
+                  "explode": true,
+                  "allowReserved": true
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "description": "default response",
+            "links": {
+              "link1": {
+                "operationRef": "https://example.com/external-link",
+                "operationId": "operationId-1",
+                "parameters": {
+                  "parameter1": "{$url}"
+                },
+                "requestBody": "{$method}",
+                "description": "link 1 description",
+                "server": {}
+              },
+              "link2": {
+                "$ref": "#/components/links/link3"
+              }
+            }
+          },
+          "201": {
+            "$ref": "#/components/responses/201"
+          }
+        },
+        "callbacks": {
+          "myCallback1": {
+            "{$request.query.queryUrl}": {
+              "post": {
+                "requestBody": {
+                  "description": "Callback payload",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "callback successfully processed"
+                  }
+                }
+              }
+            }
+          },
+          "myCallback2": {
+            "$ref": "#/components/callbacks/callback1"
+          }
+        },
+        "deprecated": false,
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "servers": [
+          {
+            "url": "{username}.gigantic-server.com",
+            "description": "Production server",
+            "variables": {
+              "username": {
+                "enum": ["demo", "demo1", "demo2"],
+                "default": "demo",
+                "description": "This value is assigned by the service provider, in this example `gigantic-server.com`"
+              }
+            }
+          }
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "$ref": "#/components/requestBodies/requestBody1"
+        },
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/201"
+          }
+        }
+      },
+      "delete": {},
+      "options": {},
+      "head": {},
+      "patch": {},
+      "trace": {},
+      "servers": [
+        {
+          "url": "{username}.gigantic-server.com",
+          "description": "Production server",
+          "variables": {
+            "username": {
+              "enum": ["demo", "demo1", "demo2"],
+              "default": "demo",
+              "description": "This value is assigned by the service provider, in this example `gigantic-server.com`"
+            }
+          }
+        }
+      ],
+      "parameters": [
+        {
+          "name": "parameter1",
+          "in": "query",
+          "description": "parameter1 description",
+          "required": false,
+          "deprecated": false,
+          "allowEmptyValue": true
+        },
+        {
+          "$ref": "#/components/parameters/parameter2"
+        }
+      ]
+    },
+    "/path2": {
+      "summary": "path2 summary",
+      "description": "path2 description",
+      "$ref": "#/components/pathItems/path2"
+    }
+  },
+  "webhooks": {
+    "webhook1": {
+      "get": {
+        "tags": ["tag1", "tag2"],
+        "summary": "path2 components item summary",
+        "description": "path2 components item description"
+      }
+    },
+    "webhook2": {
+      "$ref": "#/components/pathItems/path2"
+    }
+  },
+  "components": {
+    "schemas": {
+      "schema1": {
+        "type": "object"
+      },
+      "schema2": {
+        "$ref": "#/components/schemas/schema1"
+      }
+    },
+    "responses": {
+      "201": {
+        "description": "201 description",
+        "headers": {
+          "Content-Type": {
+            "description": "The number of allowed requests in the current period",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "400": {
+        "$ref": "#/components/responses/201"
+      }
+    },
+    "parameters": {
+      "parameter2": {
+        "name": "parameter2",
+        "in": "query",
+        "description": "parameter2 description",
+        "required": false,
+        "deprecated": false,
+        "allowEmptyValue": true
+      },
+      "parameter3": {
+        "$ref": "#/components/parameters/parameter2"
+      }
+    },
+    "examples": {
+      "example3": {
+        "summary": "example 3 summary",
+        "description": "example 3 description",
+        "value": "c",
+        "externalValue": "https://example3.com/"
+      },
+      "example4": {
+        "$ref": "#/components/examples/example3"
+      }
+    },
+    "requestBodies": {
+      "requestBody1": {
+        "description": "request body 1 description",
+        "required": true
+      },
+      "requestBody2": {
+        "$ref": "#/components/requestBodies/requestBody1"
+      }
+    },
+    "headers": {
+      "Content-Type": {
+        "description": "The number of allowed requests in the current period",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "X-Custom-Header": {
+        "$ref": "#/components/headers/Content-Type"
+      }
+    },
+    "securitySchemes": {
+      "securityScheme1": {
+        "type": "http",
+        "description": "security scheme description",
+        "name": "apiKey",
+        "in": "apiKey",
+        "scheme": "http",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://authorization-url.com/"
+          }
+        }
+      },
+      "securityScheme2": {
+        "$ref": "#/components/securitySchemes/securityScheme1"
+      }
+    },
+    "links": {
+      "link3": {
+        "description": "link 3 description"
+      },
+      "link4": {
+        "$ref": "#/components/links/link4"
+      }
+    },
+    "callbacks": {
+      "callback1": {
+        "{$request.query.queryUrl}": {
+          "put": {
+            "requestBody": {
+              "description": "Callback payload",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "callback successfully processed"
+              }
+            }
+          }
+        }
+      },
+      "callback2": {
+        "$ref": "#/components/callbacks/callback1"
+      }
+    },
+    "pathItems": {
+      "path2": {
+        "get": {
+          "tags": ["tag1", "tag2"],
+          "summary": "path2 components item summary",
+          "description": "path2 components item description"
+        }
+      },
+      "path3": {
+        "$ref": "#/components/pathItems/path2"
+      }
+    }
+  },
+  "security": [
+    {
+      "api_key": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "tag1",
+      "description": "tag1 description",
+      "externalDocs": {
+        "description": "external docs tag description",
+        "url": "https://example.com/extenral-docs-tag"
+      }
+    }
+  ],
+  "externalDocs": {
+    "description": "external docs top level description",
+    "url": "https://example.com/extenral-docs-top-level"
+  }
+}

--- a/apidom/packages/apidom-ns-openapi-3-1/test/refractor/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/test/refractor/index.ts
@@ -1,4 +1,6 @@
-import { assert } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import { assert, expect } from 'chai';
 import sinon from 'sinon';
 import { Namespace } from 'minim';
 import { ObjectElement, toValue } from 'apidom';
@@ -7,14 +9,17 @@ import { OpenApi3_1Element, OpenapiElement, isOpenapiElement } from '../../src';
 import * as predicates from '../../src/predicates';
 
 describe('refractor', function () {
-  specify('should refract to OpenApi 3.1 namespace', function () {
-    const genericObjectElement = new ObjectElement({
-      openapi: '3.1.0',
-    });
-    const openApiElement = OpenApi3_1Element.refract(genericObjectElement);
+  context('given generic ApiDOM object in OpenApi 3.1 shape', function () {
+    specify('should refract to OpenApi 3.1 Element', function () {
+      const openApiString = fs
+        .readFileSync(path.join(__dirname, 'fixtures', 'openapi.json'))
+        .toString();
+      const openApiPojo = JSON.parse(openApiString);
+      const genericObjectElement = new ObjectElement(openApiPojo);
+      const openApiElement = OpenApi3_1Element.refract(genericObjectElement);
 
-    // console.log(toString(openApiElement));
-    assert.deepEqual(toValue(openApiElement), { openapi: '3.1.0' });
+      expect(openApiElement).toMatchSnapshot();
+    });
   });
 
   context('supports plugins', function () {


### PR DESCRIPTION
These tests specifically targets refracting stage.
Data and metadata of ApiDOM trees are checked.

Closes #438
Closes #360