### PR TITLE
feat(reference): add support for unkonwn URIs

### DIFF
--- a/apidom/packages/apidom-ns-openapi-3-1/src/index.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/index.ts
@@ -39,7 +39,6 @@ export {
   isResponseElement,
   isResponsesElement,
   isSchemaElement,
-  isSchemaElementExternal,
   isBooleanJsonSchemaElement,
   isSecurityRequirementElement,
   isServerElement,

--- a/apidom/packages/apidom-ns-openapi-3-1/src/predicates.ts
+++ b/apidom/packages/apidom-ns-openapi-3-1/src/predicates.ts
@@ -320,19 +320,6 @@ export const isSchemaElement = createPredicate(
   },
 );
 
-export const isSchemaElementExternal = (keyword: string, element: any) => {
-  if (!isSchemaElement(element)) {
-    return false;
-  }
-  if (!isStringElement(element.get(keyword))) {
-    return false;
-  }
-
-  const value = element.get(keyword).toValue();
-
-  return isNonEmptyString(value) && !startsWith('#', value);
-};
-
 export const isBooleanJsonSchemaElement = (element: any) => {
   return isBooleanElement(element) && element.classes.includes('boolean-json-schema');
 };

--- a/apidom/packages/apidom-reference/src/dereference/strategies/openapi-3-1/selectors/errors/EvaluationJsonSchemaUriError.ts
+++ b/apidom/packages/apidom-reference/src/dereference/strategies/openapi-3-1/selectors/errors/EvaluationJsonSchemaUriError.ts
@@ -1,0 +1,1 @@
+export default class EvaluationJsonSchemaUriError extends Error {}

--- a/apidom/packages/apidom-reference/src/dereference/strategies/openapi-3-1/selectors/errors/index.ts
+++ b/apidom/packages/apidom-reference/src/dereference/strategies/openapi-3-1/selectors/errors/index.ts
@@ -1,2 +1,3 @@
 export { default as EvaluationJsonSchema$anchorError } from './EvaluationJsonSchema$anchorError';
 export { default as InvalidJsonSchema$anchorError } from './InvalidJsonSchema$anchorError';
+export { default as EvaluationJsonSchemaUriError } from './EvaluationJsonSchemaUriError';

--- a/apidom/packages/apidom-reference/src/dereference/strategies/openapi-3-1/selectors/uri.ts
+++ b/apidom/packages/apidom-reference/src/dereference/strategies/openapi-3-1/selectors/uri.ts
@@ -1,0 +1,41 @@
+import { isUndefined } from 'ramda-adjunct';
+import { Element, find, isStringElement } from 'apidom';
+import { isSchemaElement } from 'apidom-ns-openapi-3-1';
+
+import * as url from '../../../../util/url';
+import { EvaluationJsonSchemaUriError } from './errors';
+import { uriToPointer, evaluate as jsonPointerEvaluate } from '../../../../selectors/json-pointer';
+import { isAnchor, uriToAnchor, evaluate as $anchorEvaluate } from './$anchor';
+
+// evaluates JSON Schema $ref containing unknown URI against ApiDOM fragment
+// eslint-disable-next-line import/prefer-default-export
+export const evaluate = <T extends Element>(uri: string, element: T): Element | undefined => {
+  const uriStrippedHash = url.stripHash(uri);
+  const result = find(
+    // @ts-ignore
+    (e) =>
+      isSchemaElement(e) &&
+      isStringElement(e.$id) &&
+      url.stripHash(e.$id.toValue()) === uriStrippedHash,
+    element,
+  );
+
+  if (isUndefined(result)) {
+    throw new EvaluationJsonSchemaUriError(`Evaluation failed on URI: "${uri}"`);
+  }
+
+  let fragmentEvaluate;
+  let selector;
+  if (isAnchor(uriToAnchor(uri))) {
+    // we're dealing with JSON Schema $anchor here
+    fragmentEvaluate = $anchorEvaluate;
+    selector = uriToAnchor(uri);
+  } else {
+    // we're assuming here that we're dealing with JSON Pointer here
+    fragmentEvaluate = jsonPointerEvaluate;
+    selector = uriToPointer(uri);
+  }
+
+  // @ts-ignore
+  return fragmentEvaluate(selector, result);
+};

--- a/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-$anchor/dereferenced.json
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-$anchor/dereferenced.json
@@ -1,0 +1,34 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "login": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "profile": {
+              "$anchor": "avatar",
+              "type": "string"
+            }
+          }
+        },
+        "UserProfile": {
+          "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f",
+          "type": "object",
+          "properties": {
+            "avatar": {
+              "$anchor": "avatar",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-$anchor/root.json
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-$anchor/root.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "login": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#avatar"
+          }
+        }
+      },
+      "UserProfile": {
+        "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f",
+        "type": "object",
+        "properties": {
+          "avatar": {
+            "$anchor": "avatar",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-pointer/dereferenced.json
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-pointer/dereferenced.json
@@ -1,0 +1,32 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "login": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "profile": {
+              "type": "string"
+            }
+          }
+        },
+        "UserProfile": {
+          "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f",
+          "type": "object",
+          "properties": {
+            "avatar": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-pointer/root.json
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-pointer/root.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "login": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#/properties/avatar"
+          }
+        }
+      },
+      "UserProfile": {
+        "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f",
+        "type": "object",
+        "properties": {
+          "avatar": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-unresolvable/root.json
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-unresolvable/root.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "login": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "urn:uuid:3"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn/dereferenced.json
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn/dereferenced.json
@@ -1,0 +1,38 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "login": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "profile": {
+              "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f",
+              "type": "object",
+              "properties": {
+                "avatar": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "UserProfile": {
+          "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f",
+          "type": "object",
+          "properties": {
+            "avatar": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn/root.json
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-urn/root.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "login": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f"
+          }
+        }
+      },
+      "UserProfile": {
+        "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f",
+        "type": "object",
+        "properties": {
+          "avatar": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/index.ts
+++ b/apidom/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/index.ts
@@ -12,7 +12,10 @@ import {
 } from '../../../../../src/util/errors';
 import { loadJsonFile } from '../../../../helpers';
 import { evaluate } from '../../../../../src/selectors/json-pointer';
-import { EvaluationJsonSchema$anchorError } from '../../../../../src/dereference/strategies/openapi-3-1/selectors/errors';
+import {
+  EvaluationJsonSchema$anchorError,
+  EvaluationJsonSchemaUriError,
+} from '../../../../../src/dereference/strategies/openapi-3-1/selectors/errors';
 
 const rootFixturePath = path.join(__dirname, 'fixtures');
 
@@ -401,6 +404,77 @@ describe('dereference', function () {
             }
           });
         });
+
+        context(
+          'given Schema Objects with $ref keyword containing Uniform Resource Name',
+          function () {
+            const fixturePath = path.join(rootFixturePath, '$ref-urn');
+
+            specify('should dereference', async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const actual = await dereference(rootFilePath, {
+                parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
+              });
+              const expected = loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+              assert.deepEqual(toValue(actual), expected);
+            });
+          },
+        );
+
+        context(
+          'given Schema Objects with $ref keyword containing Uniform Resource Name and JSON Pointer fragment',
+          function () {
+            const fixturePath = path.join(rootFixturePath, '$ref-urn-pointer');
+
+            specify('should dereference', async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const actual = await dereference(rootFilePath, {
+                parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
+              });
+              const expected = loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+              assert.deepEqual(toValue(actual), expected);
+            });
+          },
+        );
+
+        context(
+          'given Schema Objects with $ref keyword containing Uniform Resource Name and $anchor',
+          function () {
+            const fixturePath = path.join(rootFixturePath, '$ref-urn-$anchor');
+
+            specify('should dereference', async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const actual = await dereference(rootFilePath, {
+                parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
+              });
+              const expected = loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+              assert.deepEqual(toValue(actual), expected);
+            });
+          },
+        );
+
+        context(
+          'given Schema Objects with $ref keyword containing unresolvable Uniform Resource Name',
+          function () {
+            const fixturePath = path.join(rootFixturePath, '$ref-urn-unresolvable');
+
+            specify('should throw error', async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              try {
+                await dereference(rootFilePath, {
+                  parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
+                });
+                assert.fail('should throw DereferenceError');
+              } catch (error) {
+                assert.instanceOf(error, DereferenceError);
+                assert.instanceOf(error.cause.cause, EvaluationJsonSchemaUriError);
+              }
+            });
+          },
+        );
 
         context(
           'given Schema Objects with $anchor keyword pointing to internal schema',

--- a/apidom/packages/apidom-reference/test/resolve/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-$anchor/root.json
+++ b/apidom/packages/apidom-reference/test/resolve/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-$anchor/root.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "login": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#avatar"
+          }
+        }
+      },
+      "UserProfile": {
+        "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f",
+        "type": "object",
+        "properties": {
+          "avatar": {
+            "$anchor": "avatar",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apidom/packages/apidom-reference/test/resolve/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-pointer/root.json
+++ b/apidom/packages/apidom-reference/test/resolve/strategies/openapi-3-1/schema-object/fixtures/$ref-urn-pointer/root.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "login": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#/properties/avatar"
+          }
+        }
+      },
+      "UserProfile": {
+        "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f",
+        "type": "object",
+        "properties": {
+          "avatar": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apidom/packages/apidom-reference/test/resolve/strategies/openapi-3-1/schema-object/fixtures/$ref-urn/root.json
+++ b/apidom/packages/apidom-reference/test/resolve/strategies/openapi-3-1/schema-object/fixtures/$ref-urn/root.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "login": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f"
+          }
+        }
+      },
+      "UserProfile": {
+        "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f",
+        "type": "object",
+        "properties": {
+          "avatar": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apidom/packages/apidom-reference/test/resolve/strategies/openapi-3-1/schema-object/index.ts
+++ b/apidom/packages/apidom-reference/test/resolve/strategies/openapi-3-1/schema-object/index.ts
@@ -250,6 +250,54 @@ describe('resolve', function () {
         });
 
         context(
+          'given Schema Objects with $ref keyword containing Uniform Resource Name',
+          function () {
+            const fixturePath = path.join(rootFixturePath, '$ref-urn');
+
+            specify('should resolve', async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const refSet = await resolve(rootFilePath, {
+                parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
+              });
+
+              assert.strictEqual(refSet.size, 1);
+            });
+          },
+        );
+
+        context(
+          'given Schema Objects with $ref keyword containing Uniform Resource Name and JSON Pointer fragment',
+          function () {
+            const fixturePath = path.join(rootFixturePath, '$ref-urn-pointer');
+
+            specify('should dereference', async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const refSet = await resolve(rootFilePath, {
+                parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
+              });
+
+              assert.strictEqual(refSet.size, 1);
+            });
+          },
+        );
+
+        context(
+          'given Schema Objects with $ref keyword containing Uniform Resource Name and $anchor',
+          function () {
+            const fixturePath = path.join(rootFixturePath, '$ref-urn-$anchor');
+
+            specify('should dereference', async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const refSet = await resolve(rootFilePath, {
+                parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
+              });
+
+              assert.strictEqual(refSet.size, 1);
+            });
+          },
+        );
+
+        context(
           'given Schema Objects with $anchor keyword pointing to internal schema',
           function () {
             const fixturePath = path.join(rootFixturePath, '$anchor-internal');

--- a/apidom/packages/apidom-reference/test/util/url.ts
+++ b/apidom/packages/apidom-reference/test/util/url.ts
@@ -200,6 +200,10 @@ describe('util', function () {
       context('given from and to parameters', function () {
         specify('should resolve URI', function () {
           assert.strictEqual(resolve('/one/two/three', 'four'), '/one/two/four');
+          assert.strictEqual(resolve('file:///one/two/three', 'four'), 'file:///one/two/four');
+          assert.strictEqual(resolve('file:///one/two/three', './four'), 'file:///one/two/four');
+          assert.strictEqual(resolve('file:///one/two/three', '../four'), 'file:///one/four');
+          assert.strictEqual(resolve('file:///one/two/three', 'file:four'), 'file:///one/two/four');
           assert.strictEqual(resolve('http://example.com/', ''), 'http://example.com/');
           assert.strictEqual(resolve('http://example.com/', '/one'), 'http://example.com/one');
           assert.strictEqual(resolve('http://example.com/one', '/two'), 'http://example.com/two');


### PR DESCRIPTION
This allows to use arbitrary URIs without location mapping
to canonically reference Schema Objects.

Closes #473