### PR TITLE
feat(editor): custom monaco light/dark themes

### DIFF
--- a/experiments/generic-editor/src/plugins/monaco/components/MonacoEditor.jsx
+++ b/experiments/generic-editor/src/plugins/monaco/components/MonacoEditor.jsx
@@ -134,24 +134,63 @@ export default class MonacoEditor extends Component {
 
   // eslint-disable-next-line no-unused-vars
   setupTheme = (editor) => {
+    // monaco.editor.setTheme('vs-dark');
     // eslint-disable-next-line no-underscore-dangle
-    // const testTheme = editor._themeService._theme.getTokenStyleMetadata;
-    // console.log('testTheme:', testTheme);
-    monaco.editor.setTheme('vs-dark');
+    // editor._themeService._theme.getTokenStyleMetadata = getStyleMetadataDark;
+    monaco.editor.setTheme('my-vs-dark');
     // eslint-disable-next-line no-underscore-dangle
     editor._themeService._theme.getTokenStyleMetadata = getStyleMetadataDark;
+    // monaco.editor.setTheme('vs-light');
     // eslint-disable-next-line no-underscore-dangle
-    // const testThemeDark = editor._themeService._theme.getTokenStyleMetadata;
-    // console.log('testThemeDark:', testThemeDark);
-    monaco.editor.setTheme('vs-light');
+    // editor._themeService._theme.getTokenStyleMetadata = getStyleMetadataLight;
+    monaco.editor.setTheme('my-vs-light');
     // eslint-disable-next-line no-underscore-dangle
     editor._themeService._theme.getTokenStyleMetadata = getStyleMetadataLight;
-    // eslint-disable-next-line no-underscore-dangle
-    // const testThemeLight = editor._themeService._theme.getTokenStyleMetadata;
-    // console.log('testThemeLight:', testThemeLight);
+
+    monaco.editor.defineTheme('my-vs-dark', {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [
+        { token: 'keyword', foreground: '#C678DD', fontStyle: 'bold' }, // atom purple; e.g. externalDocs, tags, paths, swagger
+        { token: 'identifier', foreground: '#D19A66', fontStyle: 'italic' }, // atom orange
+        // add various identifier.nestedKey
+        // response codes, comments, colons/slashes, are interpreted as 'invalid'
+        { token: 'type', foreground: '#61AFEF', fontStyle: 'italic' }, // atom blue
+        { token: 'pathItem', foreground: '66afce', fontStyle: 'italic' }, // light blue
+        { token: 'operation', foreground: '66afce', fontStyle: 'underline' }, // light blue
+        { token: 'comment', foreground: '5c6370', fontStyle: 'italic' }, // atom grey
+      ],
+      colors: {
+        'editor.background': '#282c34',
+        'editor.foreground': '#abb2bf',
+        'editorLineNumber.foreground': '#636D83',
+        'editorLineNumber.activeForeground': '#ABB2BF',
+      },
+    });
+
+    monaco.editor.defineTheme('my-vs-light', {
+      base: 'vs', // can also be vs-dark or hc-black
+      inherit: true, // can also be false to completely replace the builtin rules
+      rules: [
+        { token: 'keyword', foreground: '#C678DD', fontStyle: 'bold' }, // atom purple; e.g. externalDocs, tags, paths, swagger
+        { token: 'identifier', foreground: '#D19A66', fontStyle: 'italic' }, // atom orange
+        // add various identifier.nestedKey
+        // response codes, comments, colons/slashes, are interpreted as 'invalid'
+        { token: 'type', foreground: '#61AFEF', fontStyle: 'bold' }, // atom blue
+        { token: 'pathItem', foreground: '66afce', fontStyle: 'bold italic' }, // light blue
+        { token: 'operation', foreground: '66afce', fontStyle: 'bold underline' }, // light blue
+        { token: 'comment', foreground: '5c6370', fontStyle: 'italic' }, // atom grey
+        { token: 'String', foreground: '#50A14F' }, // atom
+      ],
+      colors: {
+        'editor.background': '#FAFAFA',
+        'editor.foreground': '#383a42',
+        'editorLineNumber.foreground': '#9D9D9F',
+        'editorLineNumber.activeForeground': '#383A42',
+      },
+    });
   };
 
-  // eslint-disable-next-line no-unused-vars
   changeTheme = (newThemeValue) => {
     // console.log('editor component... changeTheme, newThemeValue:', newThemeValue);
     if (newThemeValue === 'vs-dark') {
@@ -161,6 +200,14 @@ export default class MonacoEditor extends Component {
     if (newThemeValue === 'vs-light' || newThemeValue === 'vs') {
       // console.log('editor component... changeTheme, vs-light:');
       monaco.editor.setTheme('vs');
+    }
+    if (newThemeValue === 'my-vs-dark') {
+      // console.log('editor component... changeTheme, my-vs-dark:');
+      monaco.editor.setTheme('my-vs-dark');
+    }
+    if (newThemeValue === 'my-vs-light') {
+      // console.log('editor component... changeTheme, my-vs-light:');
+      monaco.editor.setTheme('my-vs-light');
     }
   };
 

--- a/experiments/generic-editor/src/plugins/monaco/components/MonacoEditorContainer.jsx
+++ b/experiments/generic-editor/src/plugins/monaco/components/MonacoEditorContainer.jsx
@@ -17,7 +17,7 @@ export default class MonacoEditorContainer extends PureComponent {
     super(props);
     this.state = {
       language: 'apidom',
-      theme: 'vs',
+      theme: 'my-vs-light',
     };
     this.editorDidMount = this.editorDidMount.bind(this);
   }
@@ -31,8 +31,8 @@ export default class MonacoEditorContainer extends PureComponent {
   }
 
   onChangeThemeValue = async (val) => {
-    console.log('onChangeThemeValue, val:', val);
-    const defaultThemeList = ['vs', 'vs-light', 'vs-dark'];
+    // console.log('onChangeThemeValue, val:', val);
+    const defaultThemeList = ['vs', 'vs-light', 'vs-dark', 'my-vs-light', 'my-vs-dark'];
     if (!defaultThemeList.includes(val)) {
       return;
     }

--- a/experiments/generic-editor/src/plugins/monaco/components/ThemeSelection.jsx
+++ b/experiments/generic-editor/src/plugins/monaco/components/ThemeSelection.jsx
@@ -10,10 +10,10 @@ export default class ThemeSelection extends PureComponent {
 
     return (
       <div>
-        <button type="button" onClick={() => onChange('vs')}>
-          vs
+        <button type="button" onClick={() => onChange('my-vs-light')}>
+          vs-light
         </button>
-        <button type="button" onClick={() => onChange('vs-dark')}>
+        <button type="button" onClick={() => onChange('my-vs-dark')}>
           vs-dark
         </button>
       </div>

--- a/experiments/generic-editor/src/plugins/monaco/components/ThemeSelectionIcon.jsx
+++ b/experiments/generic-editor/src/plugins/monaco/components/ThemeSelectionIcon.jsx
@@ -11,12 +11,12 @@ export default class ThemeSelectionIcon extends PureComponent {
 
     return (
       <div>
-        {theme === 'vs' || theme === 'vs-light' ? (
-          <button type="button" onClick={() => onChange('vs-dark')}>
+        {theme === 'vs' || theme === 'vs-light' || theme === 'my-vs-light' ? (
+          <button type="button" className="btn" onClick={() => onChange('my-vs-dark')}>
             <MoonIcon size="small" aria-label="dark theme icon" />
           </button>
         ) : (
-          <button type="button" onClick={() => onChange('vs')}>
+          <button type="button" className="btn" onClick={() => onChange('my-vs-light')}>
             <SunIcon size="small" aria-label="light theme icon" />
           </button>
         )}


### PR DESCRIPTION
First pass at custom themes. Will need to build out theme rules, and move to individual files. Atom One Light and Atom One Dark were used as templates.

note: there is an initialization bug (to be a separate issue), where the custom `my-vs-light` theme doesn't apply until one clicks on the `vs-light` button, or toggles the `sun/moon` button to dark, then light.