### PR TITLE
feat(editor): use same generator baseUrl for oas3 and oas3_1

### DIFF
--- a/experiments/generic-editor/src/plugins/topbar/actions/generator.actions.js
+++ b/experiments/generic-editor/src/plugins/topbar/actions/generator.actions.js
@@ -72,17 +72,21 @@ const getSpecVersionString = ({ isOAS3, isSwagger2, isOAS3_1, isAsyncApi2 }) => 
 };
 
 const validateHttpGeneratorsExists = ({ specVersion }) => {
-  if (specVersion === 'OAS_3_0' || specVersion === 'SWAGGER_2') {
+  if (specVersion === 'OAS_3_0' || specVersion === 'SWAGGER_2' || specVersion === 'OAS_3_1') {
     return true;
   }
   return false;
 };
 
-const fetchOasGeneratorLists = async ({ isOAS3 }) => {
-  const generatorClientsUrl = isOAS3
+const fetchOasGeneratorLists = async ({ isOAS3, isOAS3_1 }) => {
+  let isAnyVersionOAS3 = false;
+  if (isOAS3 || isOAS3_1) {
+    isAnyVersionOAS3 = true;
+  }
+  const generatorClientsUrl = isAnyVersionOAS3
     ? defaultFixtures.oas3GeneratorClientsUrl
     : defaultFixtures.oas2GeneratorServersUrl;
-  const generatorServersUrl = isOAS3
+  const generatorServersUrl = isAnyVersionOAS3
     ? defaultFixtures.oas3GeneratorServersUrl
     : defaultFixtures.oas2GeneratorServersUrl;
 
@@ -109,8 +113,7 @@ export const instantiateGeneratorClient = () => async (system) => {
       specVersion,
     });
   }
-
-  const generatorServersClients = await fetchOasGeneratorLists({ isOAS3 });
+  const generatorServersClients = await fetchOasGeneratorLists({ isOAS3, isOAS3_1 });
   // console.log('...instantiateGeneratorClient generatorServersClients:', generatorServersClients);
   if (generatorServersClients.error) {
     return Promise.resolve({

--- a/experiments/generic-editor/src/plugins/topbar/components/GeneratorMenuDropdown.jsx
+++ b/experiments/generic-editor/src/plugins/topbar/components/GeneratorMenuDropdown.jsx
@@ -59,6 +59,7 @@ export default class GeneratorMenuDropdown extends Component {
     });
     if (downloadData.error) {
       // display the error message
+      console.log('generator download error:', downloadData.error);
     }
   };
 


### PR DESCRIPTION
If an OAS3.1 definition is used, Topbar will now render the "Generate Servers" and "Generate Clients" dropdown menus. However, while the user can click on a dropdown menu item, actual generation is not yet available for OAS3.1. So for the moment, there will be an error message in the developer console informing with `"unable to create generator url"`. I.e. no actually http request for download was made, because a download url was not provided.

In future, we could build out a modal to display to the user.