### PR TITLE
fix(editor): 2nd pane scrolling

### DIFF
--- a/experiments/generic-editor/src/plugins/generic-editor/_editor.scss
+++ b/experiments/generic-editor/src/plugins/generic-editor/_editor.scss
@@ -2,6 +2,10 @@
   height: #{"calc(100% - 51px)"} !important;
 }
 
+.Pane2 {
+  overflow-y: scroll;
+}
+
 .dropzone {
   height: 100%;
   width: 100%;


### PR DESCRIPTION
note: in swagger-editor@3, this css class was defined in an index.html instead of a .scss/.less file. Probably to keep separate from a possible 3-pane mode implementation.