### PR TITLE
fix(apidom): add 'typeRoots' to tsconfig

### DIFF
--- a/apidom/tsconfig.json
+++ b/apidom/tsconfig.json
@@ -13,7 +13,8 @@
     // Disallow features that require cross-file information for emit.
     "isolatedModules": true,
     // Import non-ES modules as default imports.
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "typeRoots": ["./node_modules/@types"]
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
When apidom monorepo is located within a directory structure with parent directories including `node_modules`, these are traversed as well while compiling, causing errors. This happens e.g. in [apidom-editor](https://github.com/swagger-api/apidom-editor) which has `apidom` as submodule.

As detailed in https://github.com/Microsoft/TypeScript/issues/13992 and [docs](https://www.typescriptlang.org/tsconfig#typeRoots), adding `typeRoots` to `tsconfig.json` solves the issue
