### PR TITLE
refactor(core): make refractor plugin naming consistent

### DIFF
--- a/packages/apidom-core/README.md
+++ b/packages/apidom-core/README.md
@@ -146,15 +146,15 @@ If multiple plugins with the same visitor method are defined, they run in parall
 
 #### Element identity plugin
 
-`apidom` package comes with `elementIdentityRefractorPlugin`. When used, this plugin will
+`apidom` package comes with `refractorPluginElementIdentity`. When used, this plugin will
 assign unique ID to all elements in ApiDOM tree.
 
 ```js
-import { elementIdentityRefractorPlugin, ObjectElement } from '@swagger-api/apidom-core';
+import { refractorPluginElementIdentity, ObjectElement } from '@swagger-api/apidom-core';
 
 const objectElement = ObjectElement.refract({ a: 'b' }, {
   plugins: [
-    elementIdentityRefractorPlugin(),
+    refractorPluginElementIdentity(),
   ]
 });
 
@@ -166,11 +166,11 @@ objectElement.getMember('a').value.id; // rFGVFP
 You can configure the plugin to generate unique IDs in the specific length:
 
 ```js
-import { elementIdentityRefractorPlugin, ObjectElement } from '@swagger-api/apidom-core';
+import { refractorPluginElementIdentity, ObjectElement } from '@swagger-api/apidom-core';
 
 const objectElement = ObjectElement.refract({ a: 'b' }, {
   plugins: [
-    elementIdentityRefractorPlugin({ length: 36}),
+    refractorPluginElementIdentity({ length: 36}),
   ]
 });
 
@@ -181,18 +181,18 @@ objectElement.getMember('a').value.id; // Ki4tWmf9xw9Lwb8MxkXJq1uONmJrmhXifmsI
 
 #### Semantic element identity plugin
 
-`apidom` package comes with `semanticElementIdentityRefractorPlugin`. When used, this plugin will
+`apidom` package comes with `refractorPluginSemanticElementIdentity`. When used, this plugin will
 assign unique ID to all non-primitive elements in ApiDOM tree. Primitive elements include
 `ObjectElement`, `ArrayElement`, `StringElement`, `BooleanElement`, `NullElement` and `NumberElement`.
 
 ```js
-import { semanticElementIdentityRefractorPlugin, ObjectElement } from '@swagger-api/apidom-core';
+import { refractorPluginSemanticElementIdentity, ObjectElement } from '@swagger-api/apidom-core';
 import { InfoElement } from '@swagger-api/apidom-ns-openapi-3-1';
 
 const infoElement = InfoElement.refract({ title: 'title' });
 const objectElement = ObjectElement.refract({ a: 'b', info: infoElement }, {
   plugins: [
-    semanticElementIdentityRefractorPlugin(),
+    refractorPluginSemanticElementIdentity(),
   ]
 });
 
@@ -206,13 +206,13 @@ objectElement.getMember('info').value.id; // '8RaWF9'
 You can configure the plugin to generate unique IDs in the specific length:
 
 ```js
-import { semanticElementIdentityRefractorPlugin, ObjectElement } from '@swagger-api/apidom-core';
+import { refractorPluginSemanticElementIdentity, ObjectElement } from '@swagger-api/apidom-core';
 import { InfoElement } from '@swagger-api/apidom-ns-openapi-3-1';
 
 const infoElement = InfoElement.refract({ title: 'title' });
 const objectElement = ObjectElement.refract({ a: 'b', info: infoElement }, {
   plugins: [
-    semanticElementIdentityRefractorPlugin({ length: 36 }),
+    refractorPluginSemanticElementIdentity({ length: 36 }),
   ]
 });
 

--- a/packages/apidom-core/src/index.ts
+++ b/packages/apidom-core/src/index.ts
@@ -5,8 +5,8 @@ import { Element, Namespace as INamespace } from 'minim';
 import './refractor/registration';
 import defaultNamespaceInstance from './namespace';
 
-export { default as elementIdentityRefractorPlugin } from './refractor/plugins/element-identity';
-export { default as semanticElementIdentityRefractorPlugin } from './refractor/plugins/semantic-element-identity';
+export { default as refractorPluginElementIdentity } from './refractor/plugins/element-identity';
+export { default as refractorPluginSemanticElementIdentity } from './refractor/plugins/semantic-element-identity';
 
 export {
   Element,

--- a/packages/apidom-core/test/refractor/plugins/element-identity.ts
+++ b/packages/apidom-core/test/refractor/plugins/element-identity.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { ObjectElement, elementIdentityRefractorPlugin } from '../../../src';
+import { ObjectElement, refractorPluginElementIdentity } from '../../../src';
 
 describe('refractor', function () {
   context('plugins', function () {
@@ -8,7 +8,7 @@ describe('refractor', function () {
       specify('should add unique ID to all elements in ApiDOM tree', function () {
         const objectElement = ObjectElement.refract(
           { a: 'b' },
-          { plugins: [elementIdentityRefractorPlugin()] },
+          { plugins: [refractorPluginElementIdentity()] },
         ) as any;
         const defaultLength = 6;
 
@@ -23,7 +23,7 @@ describe('refractor', function () {
           const length = 3;
           const objectElement = ObjectElement.refract(
             { a: 'b' },
-            { plugins: [elementIdentityRefractorPlugin({ length })] },
+            { plugins: [refractorPluginElementIdentity({ length })] },
           ) as any;
 
           assert.lengthOf(objectElement.id, length);

--- a/packages/apidom-core/test/refractor/plugins/semantic-element-identity.ts
+++ b/packages/apidom-core/test/refractor/plugins/semantic-element-identity.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import { InfoElement } from '@swagger-api/apidom-ns-openapi-3-1';
 
-import { ObjectElement, semanticElementIdentityRefractorPlugin } from '../../../src';
+import { ObjectElement, refractorPluginSemanticElementIdentity } from '../../../src';
 
 describe('refractor', function () {
   context('plugins', function () {
@@ -14,7 +14,7 @@ describe('refractor', function () {
         });
         const objectElement: any = ObjectElement.refract(
           { a: 'b', info: infoElement },
-          { plugins: [semanticElementIdentityRefractorPlugin()] },
+          { plugins: [refractorPluginSemanticElementIdentity()] },
         );
 
         assert.lengthOf(objectElement.id, 0);
@@ -31,7 +31,7 @@ describe('refractor', function () {
         });
         const objectElement: any = ObjectElement.refract(
           { a: 'b', info: infoElement },
-          { plugins: [semanticElementIdentityRefractorPlugin()] },
+          { plugins: [refractorPluginSemanticElementIdentity()] },
         );
         const defaultLength = 6;
 
@@ -50,7 +50,7 @@ describe('refractor', function () {
           });
           const objectElement: any = ObjectElement.refract(
             { a: 'b', info: infoElement },
-            { plugins: [semanticElementIdentityRefractorPlugin({ length })] },
+            { plugins: [refractorPluginSemanticElementIdentity({ length })] },
           );
 
           assert.lengthOf(objectElement.getMember('info').value.id, length);


### PR DESCRIPTION
This is a technically a breaking change, as we're chaning
how two symbols are exported from the core package.

Refs #812