### PR TITLE
fix: amend browser patches

### DIFF
--- a/packages/apidom-parser-adapter-json/src/lexical-analysis/browser-patch.ts
+++ b/packages/apidom-parser-adapter-json/src/lexical-analysis/browser-patch.ts
@@ -9,7 +9,7 @@ const realFetch = globalThis.fetch;
 if (isFunction(realFetch)) {
   globalThis.fetch = (...args) => {
     // @ts-ignore
-    if (isString(args[0]) && args[0].endsWith('/tree-sitter.wasm')) {
+    if (isString(args[0]) && args[0].endsWith('tree-sitter.wasm')) {
       // @ts-ignore
       return realFetch.apply(globalThis, [treeSitterWasm, tail(args)]);
     }

--- a/packages/apidom-parser-adapter-yaml-1-2/src/lexical-analysis/browser-patch.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/src/lexical-analysis/browser-patch.ts
@@ -9,7 +9,7 @@ const realFetch = globalThis.fetch;
 if (isFunction(realFetch)) {
   globalThis.fetch = (...args) => {
     // @ts-ignore
-    if (isString(args[0]) && args[0].endsWith('/tree-sitter.wasm')) {
+    if (isString(args[0]) && args[0].endsWith('tree-sitter.wasm')) {
       // @ts-ignore
       return realFetch.apply(globalThis, [treeSitterWasm, tail(args)]);
     }


### PR DESCRIPTION
This change allows to properly apply the patches
in situations where the WASM file is served on domain
without path.

Refs #1035