### PR TITLE
test(ns-api-design-systems): fix tests

### DIFF
--- a/packages/apidom-ns-api-design-systems/test/validator/openapi-3-1/http-request-header-content-type/index.ts
+++ b/packages/apidom-ns-api-design-systems/test/validator/openapi-3-1/http-request-header-content-type/index.ts
@@ -48,7 +48,7 @@ describe('given API Design Systems and OpenAPI 3.1 definitions', function () {
     const statusCodeAnnotation = annotations.find((annotation: AnnotationElement) => {
       return (
         annotation.toValue() ===
-        '"application/test" not allowed for subject ["http","request","header","Content-Type"] on line 7, column 12'
+        '"application/test" not allowed for subject ["http","request","header","Content-Type"]'
       );
     });
 

--- a/packages/apidom-ns-api-design-systems/test/validator/openapi-3-1/http-request-header/index.ts
+++ b/packages/apidom-ns-api-design-systems/test/validator/openapi-3-1/http-request-header/index.ts
@@ -48,7 +48,7 @@ describe('given API Design Systems and OpenAPI 3.1 definitions', function () {
     const statusCodeAnnotation = annotations.find((annotation: AnnotationElement) => {
       return (
         annotation.toValue() ===
-        '"X-Custom-Header" not allowed for subject ["http","request","header"] on line 11, column 20'
+        '"X-Custom-Header" not allowed for subject ["http","request","header"]'
       );
     });
 
@@ -60,7 +60,7 @@ describe('given API Design Systems and OpenAPI 3.1 definitions', function () {
     const statusCodeAnnotation = annotations.find((annotation: AnnotationElement) => {
       return (
         annotation.toValue() ===
-        '"X-Custom-Header-2" not allowed for subject ["http","request","header"] on line 30, column 18'
+        '"X-Custom-Header-2" not allowed for subject ["http","request","header"]'
       );
     });
 

--- a/packages/apidom-ns-api-design-systems/test/validator/openapi-3-1/http-request-method/index.ts
+++ b/packages/apidom-ns-api-design-systems/test/validator/openapi-3-1/http-request-method/index.ts
@@ -40,10 +40,7 @@ describe('given API Design Systems and OpenAPI 3.1 definitions', function () {
   it('should produce annotation about trace method', function () {
     const annotations = validateOpenAPI3_1(mainElement, openapiElement);
     const traceAnnotation = annotations.find((annotation: AnnotationElement) => {
-      return (
-        annotation.toValue() ===
-        '"trace" not allowed for subject ["http","request","method"] on line 6, column 6'
-      );
+      return annotation.toValue() === '"trace" not allowed for subject ["http","request","method"]';
     });
 
     assert.isTrue(traceAnnotation instanceof AnnotationElement);
@@ -53,8 +50,7 @@ describe('given API Design Systems and OpenAPI 3.1 definitions', function () {
     const annotations = validateOpenAPI3_1(mainElement, openapiElement);
     const traceAnnotation = annotations.find((annotation: AnnotationElement) => {
       return (
-        annotation.toValue() ===
-        '"options" not allowed for subject ["http","request","method"] on line 7, column 6'
+        annotation.toValue() === '"options" not allowed for subject ["http","request","method"]'
       );
     });
 

--- a/packages/apidom-ns-api-design-systems/test/validator/openapi-3-1/http-response-status-code/index.ts
+++ b/packages/apidom-ns-api-design-systems/test/validator/openapi-3-1/http-response-status-code/index.ts
@@ -47,8 +47,7 @@ describe('given API Design Systems and OpenAPI 3.1 definitions', function () {
     const annotations = validateOpenAPI3_1(mainElement, openapiElement);
     const statusCodeAnnotation = annotations.find((annotation: AnnotationElement) => {
       return (
-        annotation.toValue() ===
-        '"201" not allowed for subject ["http","response","status_code"] on line 7, column 10'
+        annotation.toValue() === '"201" not allowed for subject ["http","response","status_code"]'
       );
     });
 
@@ -59,8 +58,7 @@ describe('given API Design Systems and OpenAPI 3.1 definitions', function () {
     const annotations = validateOpenAPI3_1(mainElement, openapiElement);
     const statusCodeAnnotation = annotations.find((annotation: AnnotationElement) => {
       return (
-        annotation.toValue() ===
-        '"305" not allowed for subject ["http","response","status_code"] on line 8, column 10'
+        annotation.toValue() === '"305" not allowed for subject ["http","response","status_code"]'
       );
     });
 


### PR DESCRIPTION
We dropped the location information from the annotation message, as the location information can be easily computed from the annotation value sourcemap:

```js
annotation.attributes.get('value').meta.get('sourceMap')
```