### PR TITLE
refactor(apidom-ls): use AsyncAPIVersion completion

### DIFF
--- a/packages/apidom-ls/src/config/asyncapi/async-api-version/meta.ts
+++ b/packages/apidom-ls/src/config/asyncapi/async-api-version/meta.ts
@@ -1,10 +1,10 @@
 import lint from './lint';
-// import completion from './completion';
+import completion from './completion';
 import { FormatMeta } from '../../../apidom-language-types';
 
 const meta: FormatMeta = {
   lint,
-  // completion,
+  completion,
 };
 
 export default meta;

--- a/packages/apidom-ls/src/config/asyncapi/asyncapi2/completion.ts
+++ b/packages/apidom-ls/src/config/asyncapi/asyncapi2/completion.ts
@@ -122,42 +122,6 @@ const completion: ApidomCompletionItem[] = [
         '[External Documentation Object](https://www.asyncapi.com/docs/specifications/v2.3.0#externalDocumentationObject)\n\\\n\\\nAdditional external documentation. Allows referencing an external resource for extended documentation.',
     },
   },
-  {
-    target: 'asyncapi',
-    label: '2.0.0',
-    insertText: '2.0.0',
-    kind: 12,
-    format: CompletionFormat.QUOTED_FORCED,
-    type: CompletionType.VALUE,
-    insertTextFormat: 2,
-  },
-  {
-    target: 'asyncapi',
-    label: '2.1.0',
-    insertText: '2.1.0',
-    kind: 12,
-    format: CompletionFormat.QUOTED_FORCED,
-    type: CompletionType.VALUE,
-    insertTextFormat: 2,
-  },
-  {
-    target: 'asyncapi',
-    label: '2.2.0',
-    insertText: '2.2.0',
-    kind: 12,
-    format: CompletionFormat.QUOTED_FORCED,
-    type: CompletionType.VALUE,
-    insertTextFormat: 2,
-  },
-  {
-    target: 'asyncapi',
-    label: '2.3.0',
-    insertText: '2.3.0',
-    kind: 12,
-    format: CompletionFormat.QUOTED_FORCED,
-    type: CompletionType.VALUE,
-    insertTextFormat: 2,
-  },
 ];
 
 export default completion;


### PR DESCRIPTION
Before AsyncAPI2 completion was used instead.

Refs #1355
