### PR TITLE
feat(apidom-ls): support proper completion format for messageId

### DIFF
--- a/packages/apidom-ls/src/config/asyncapi/message/completion.ts
+++ b/packages/apidom-ls/src/config/asyncapi/message/completion.ts
@@ -34,7 +34,7 @@ const completion: ApidomCompletionItem[] = [
     label: 'messageId',
     insertText: 'messageId',
     kind: 14,
-    format: CompletionFormat.OBJECT,
+    format: CompletionFormat.QUOTED,
     type: CompletionType.PROPERTY,
     insertTextFormat: 2,
     documentation: {

--- a/packages/apidom-ls/src/config/asyncapi/message/lint/content-type.ts
+++ b/packages/apidom-ls/src/config/asyncapi/message/lint/content-type.ts
@@ -4,7 +4,7 @@ import { LinterMeta } from '../../../../apidom-language-types';
 const messageContentTypeLint: LinterMeta = {
   code: ApilintCodes.MESSAGE_CONTENTTYPE,
   source: 'apilint',
-  message: "contentType' value must be a string",
+  message: "'contentType' value must be a string",
   severity: 1,
   linterFunction: 'apilintType',
   linterParams: ['string'],

--- a/packages/apidom-ls/src/config/asyncapi/message/lint/description.ts
+++ b/packages/apidom-ls/src/config/asyncapi/message/lint/description.ts
@@ -4,7 +4,7 @@ import { LinterMeta } from '../../../../apidom-language-types';
 const messageDescriptionLint: LinterMeta = {
   code: ApilintCodes.MESSAGE_DESCRIPTION,
   source: 'apilint',
-  message: "description' value must be a string",
+  message: "'description' value must be a string",
   severity: 1,
   linterFunction: 'apilintType',
   linterParams: ['string'],

--- a/packages/apidom-ls/src/config/asyncapi/message/lint/index.ts
+++ b/packages/apidom-ls/src/config/asyncapi/message/lint/index.ts
@@ -1,3 +1,4 @@
+import messageIdLint from './messageId';
 import messageTagsLint from './tags';
 import messageDescriptionLint from './description';
 import messageSummaryLint from './summary';
@@ -6,7 +7,7 @@ import messageBindingsLint from './bindings';
 import messageTraitsLint from './traits';
 import messageAllowedFields2_0__2_3Lint from './allowed-fields-2-0--2-3';
 import messageAllowedFields2_4Lint from './allowed-fields-2-4';
-import messageHeaders from './headers';
+import messageHeadersLint from './headers';
 import messageCorrelationId from './correlation-id';
 import messageSchemaFormatLint from './schema-format';
 import message$RefLint from './ref';
@@ -17,7 +18,8 @@ import messageTitleLint from './title';
 import messageExamplesLint from './examples';
 
 const lints = [
-  messageHeaders,
+  messageIdLint,
+  messageHeadersLint,
   messageTagsLint,
   messageDescriptionLint,
   messageSummaryLint,

--- a/packages/apidom-ls/src/config/asyncapi/message/lint/messageId.ts
+++ b/packages/apidom-ls/src/config/asyncapi/message/lint/messageId.ts
@@ -1,16 +1,16 @@
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
 
-const messageTitleLint: LinterMeta = {
-  code: ApilintCodes.MESSAGE_TITLE,
+const messageIdLint: LinterMeta = {
+  code: ApilintCodes.MESSAGE_ID,
   source: 'apilint',
-  message: "'title' value must be a string",
+  message: "'messageId' value must be a string",
   severity: 1,
   linterFunction: 'apilintType',
   linterParams: ['string'],
   marker: 'value',
-  target: 'title',
+  target: 'messageId',
   data: {},
 };
 
-export default messageTitleLint;
+export default messageIdLint;

--- a/packages/apidom-ls/src/config/asyncapi/message/lint/name.ts
+++ b/packages/apidom-ls/src/config/asyncapi/message/lint/name.ts
@@ -4,7 +4,7 @@ import { LinterMeta } from '../../../../apidom-language-types';
 const messageNameLint: LinterMeta = {
   code: ApilintCodes.MESSAGE_NAME,
   source: 'apilint',
-  message: "name' value must be a string",
+  message: "'name' value must be a string",
   severity: 1,
   linterFunction: 'apilintType',
   linterParams: ['string'],

--- a/packages/apidom-ls/src/config/asyncapi/message/lint/schema-format.ts
+++ b/packages/apidom-ls/src/config/asyncapi/message/lint/schema-format.ts
@@ -4,7 +4,7 @@ import { LinterMeta } from '../../../../apidom-language-types';
 const messageSchemaFormatLint: LinterMeta = {
   code: ApilintCodes.MESSAGE_SCHEMAFORMAT,
   source: 'apilint',
-  message: "schemaFormat' value must be a string",
+  message: "'schemaFormat' value must be a string",
   severity: 1,
   linterFunction: 'apilintType',
   linterParams: ['string'],

--- a/packages/apidom-ls/src/config/asyncapi/message/lint/summary.ts
+++ b/packages/apidom-ls/src/config/asyncapi/message/lint/summary.ts
@@ -4,7 +4,7 @@ import { LinterMeta } from '../../../../apidom-language-types';
 const messageSummaryLint: LinterMeta = {
   code: ApilintCodes.MESSAGE_SUMMARY,
   source: 'apilint',
-  message: "summary' value must be a string",
+  message: "'summary' value must be a string",
   severity: 1,
   linterFunction: 'apilintType',
   linterParams: ['string'],

--- a/packages/apidom-ls/src/config/codes.ts
+++ b/packages/apidom-ls/src/config/codes.ts
@@ -263,6 +263,7 @@ enum ApilintCodes {
   COMPONENTS_SERVER_VARIABLES,
   SERVER_REF,
   SERVER_REF_SIBLINGS,
+  MESSAGE_ID,
 }
 
 export default ApilintCodes;


### PR DESCRIPTION
This is specific to AsyncAPI 2.4 and Message.messageId
field.

Closes #1429