### PR TITLE
feat(apidom-ls): add extended docs for Server Variable Object

### DIFF
--- a/packages/apidom-ls/src/config/asyncapi/server-variable/documentation.ts
+++ b/packages/apidom-ls/src/config/asyncapi/server-variable/documentation.ts
@@ -16,7 +16,7 @@ const documentation = [
     docs: 'An array of examples of the server variable.',
   },
   {
-    docs: 'An object representing a Server Variable for server URL template substitution.\n\\\n\\\nThis object **MAY** be extended with [Specification Extensions](https://www.asyncapi.com/docs/specifications/v2.4.0#specificationExtensions).',
+    docs: '#### [Server Variable Object](https://www.asyncapi.com/docs/specifications/v2.4.0#serverVariableObject)\n\nAn object representing a Server Variable for server URL template substitution.\n\n##### Fixed Fields\n\nField Name | Type | Description\n---|:---:|---\nenum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.\ndefault | `string` | The default value to use for substitution, and to send, if an alternate value is _not_ supplied.\ndescription | `string` | An optional description for the server variable. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.\nexamples | [`string`] | An array of examples of the server variable.\n\nThis object MAY be extended with [Specification Extensions](https://www.asyncapi.com/docs/specifications/v2.4.0#specificationExtensions).',
   },
 ];
 export default documentation;


### PR DESCRIPTION
This change is specific to AsyncAPI 2.4 spec.

Closes #1423
