### PR TITLE
fix(apidom-ls): fix completion format for Operation.security

### DIFF
--- a/packages/apidom-ls/src/config/asyncapi/operation/completion.ts
+++ b/packages/apidom-ls/src/config/asyncapi/operation/completion.ts
@@ -47,7 +47,7 @@ const completion: ApidomCompletionItem[] = [
     label: 'security',
     insertText: 'security',
     kind: 14,
-    format: CompletionFormat.QUOTED,
+    format: CompletionFormat.ARRAY,
     type: CompletionType.PROPERTY,
     insertTextFormat: 2,
     documentation: {


### PR DESCRIPTION
This change is specific to AsyncAPI 2.4 spec.

Closes #1434