### PR TITLE
feat(apidom-ls): update ns/format detection

### DIFF
--- a/packages/apidom-ls/src/apidom-language-service.ts
+++ b/packages/apidom-ls/src/apidom-language-service.ts
@@ -56,7 +56,7 @@ export default function getLanguageService(context: LanguageServiceContext): Lan
     metadata = context.metadata;
   }
   const documentCache = getDocumentCache<ParseResultElement>(10, 60, (document) =>
-    parse(document, metadata.metadataMaps),
+    parse(document, metadata.metadataMaps, context.defaultContentLanguage),
   );
 
   const languageSettings: LanguageSettings = {
@@ -67,6 +67,7 @@ export default function getLanguageService(context: LanguageServiceContext): Lan
     documentCache,
     performanceLogs: context.performanceLogs,
     logLevel: context.logLevel,
+    defaultContentLanguage: context.defaultContentLanguage,
   };
   configureServices(languageSettings);
 

--- a/packages/apidom-ls/src/apidom-language-types.ts
+++ b/packages/apidom-ls/src/apidom-language-types.ts
@@ -78,12 +78,20 @@ export interface LanguageServiceContext {
   completionProviders?: CompletionProvider[];
   performanceLogs?: boolean;
   logLevel?: LogLevel;
+  defaultContentLanguage?: ContentLanguage;
 }
 
 export interface NamespaceVersion {
   namespace: string;
   version: string;
 }
+
+export interface ContentLanguage {
+  namespace: string;
+  format?: 'JSON' | 'YAML';
+  version?: string;
+}
+
 export interface ValidationProviderResult {
   diagnostics: Diagnostic[];
   mergeStrategy: MergeStrategy;
@@ -167,6 +175,7 @@ export interface LanguageSettings {
   documentCache?: DocumentCache<ParseResultElement>;
   performanceLogs?: boolean;
   logLevel?: LogLevel;
+  defaultContentLanguage?: ContentLanguage;
 }
 
 // export type SeverityLevel = 'error' | 'warning' | 'ignore';

--- a/packages/apidom-ls/src/index.ts
+++ b/packages/apidom-ls/src/index.ts
@@ -25,8 +25,11 @@ export {
   perfEnd,
   isAsyncDoc,
   isJsonDoc,
+  isAdsDoc,
+  isOpenapiDoc,
   getText,
   isSpecVersionSet,
+  findNamespace,
 } from './utils/utils';
 
 export type {
@@ -49,6 +52,7 @@ export type {
   ApidomCompletionItem,
   CompletionProviderResult,
   ValidationProviderResult,
+  ContentLanguage,
 } from './apidom-language-types';
 
 export {

--- a/packages/apidom-ls/src/parser-factory.ts
+++ b/packages/apidom-ls/src/parser-factory.ts
@@ -9,13 +9,21 @@ import * as openapi3_1Adapter_Yaml from '@swagger-api/apidom-parser-adapter-open
 // @ts-ignore
 import * as asyncapi2Adapter_Yaml from '@swagger-api/apidom-parser-adapter-asyncapi-yaml-2';
 // @ts-ignore
+import * as adsAdapter from '@swagger-api/apidom-parser-adapter-api-design-systems-json';
+// @ts-ignore
+import * as adsAdapter_Yaml from '@swagger-api/apidom-parser-adapter-api-design-systems-yaml';
+// @ts-ignore
+import * as jsonParserAdapter from '@swagger-api/apidom-parser-adapter-json';
+// @ts-ignore
+import * as yamlParserAdapter from '@swagger-api/apidom-parser-adapter-yaml-1-2';
+// @ts-ignore
 import { refractorPluginReplaceEmptyElement } from '@swagger-api/apidom-ns-asyncapi-2';
 import { refractorPluginReplaceEmptyElement as refractorPluginReplaceEmptyElementOas } from '@swagger-api/apidom-ns-openapi-3-1';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { ParseResultElement } from '@swagger-api/apidom-core';
 
-import { isAsyncDoc, isJsonDoc, isSpecVersionSet, setMetadataMap } from './utils/utils';
-import { MetadataMaps } from './apidom-language-types';
+import { setMetadataMap, findNamespace } from './utils/utils';
+import { ContentLanguage, MetadataMaps } from './apidom-language-types';
 
 export interface ParserOptions {
   sourceMap?: boolean;
@@ -23,63 +31,72 @@ export interface ParserOptions {
   parser?: unknown;
 }
 
-export function getParser(document: TextDocument | string): ApiDOMParser {
-  const async = isAsyncDoc(document);
-  const json = isJsonDoc(document);
-  if (async && json) {
+export function getParser(
+  document: TextDocument | string,
+  defaultContentLanguage?: ContentLanguage,
+): ApiDOMParser {
+  const text: string = typeof document === 'string' ? document : document.getText();
+  const contentLanguage = findNamespace(text, defaultContentLanguage);
+  if (contentLanguage.namespace === 'asyncapi' && contentLanguage.format === 'JSON') {
     return ApiDOMParser().use(asyncapi2Adapter);
   }
-  if (async && !json) {
+  if (contentLanguage.namespace === 'asyncapi' && contentLanguage.format === 'YAML') {
     return ApiDOMParser().use(asyncapi2Adapter_Yaml);
   }
-  if (!async && json) {
+  if (contentLanguage.namespace === 'openapi' && contentLanguage.format === 'JSON') {
     return ApiDOMParser().use(openapi3_1Adapter);
   }
-  if (!async && !json) {
+  if (contentLanguage.namespace === 'openapi' && contentLanguage.format === 'YAML') {
     return ApiDOMParser().use(openapi3_1Adapter_Yaml);
   }
-  return ApiDOMParser().use(asyncapi2Adapter);
+  if (contentLanguage.namespace === 'ads' && contentLanguage.format === 'JSON') {
+    return ApiDOMParser().use(adsAdapter);
+  }
+  if (contentLanguage.namespace === 'ads' && contentLanguage.format === 'YAML') {
+    return ApiDOMParser().use(adsAdapter_Yaml);
+  }
+  // fallback
+  return ApiDOMParser();
 }
 
 export async function parse(
   textDocument: TextDocument | string,
   metadataMaps: MetadataMaps | undefined,
+  defaultContentLanguage?: ContentLanguage,
 ): Promise<ParseResultElement> {
   // TODO improve detection mechanism
   const text: string = typeof textDocument === 'string' ? textDocument : textDocument.getText();
-  const async = isAsyncDoc(textDocument);
-  const versionSet = isSpecVersionSet(textDocument);
-  const json = isJsonDoc(textDocument);
   let result;
-  if (async && json) {
+  const contentLanguage = findNamespace(text, defaultContentLanguage);
+  if (contentLanguage.namespace === 'asyncapi' && contentLanguage.format === 'JSON') {
     result = await asyncapi2Adapter.parse(text, { sourceMap: true });
-  } else if (async && !json) {
+  } else if (contentLanguage.namespace === 'asyncapi' && contentLanguage.format === 'YAML') {
     result = await asyncapi2Adapter_Yaml.parse(text, {
       sourceMap: true,
       refractorOpts: { plugins: [refractorPluginReplaceEmptyElement()] },
     });
-  } else if (!versionSet) {
-    result = await asyncapi2Adapter_Yaml.parse(text, {
-      sourceMap: true,
-      refractorOpts: { plugins: [refractorPluginReplaceEmptyElement()] },
-    });
-  } else if (!async && json) {
+  } else if (contentLanguage.namespace === 'openapi' && contentLanguage.format === 'JSON') {
     result = await openapi3_1Adapter.parse(text, { sourceMap: true });
-  } else if (!async && !json) {
+  } else if (contentLanguage.namespace === 'openapi' && contentLanguage.format === 'YAML') {
     result = await openapi3_1Adapter_Yaml.parse(text, {
       sourceMap: true,
       refractorOpts: { plugins: [refractorPluginReplaceEmptyElementOas()] },
     });
+  } else if (contentLanguage.namespace === 'ads' && contentLanguage.format === 'JSON') {
+    result = await adsAdapter.parse(text, { sourceMap: true });
+  } else if (contentLanguage.namespace === 'ads' && contentLanguage.format === 'YAML') {
+    result = await adsAdapter_Yaml.parse(text, { sourceMap: true });
+  } else if (contentLanguage.namespace === 'apidom' && contentLanguage.format === 'JSON') {
+    result = await jsonParserAdapter.parse(text, { sourceMap: true });
+  } else if (contentLanguage.namespace === 'apidom' && contentLanguage.format === 'YAML') {
+    result = await yamlParserAdapter.parse(text, { sourceMap: true });
   } else {
     // fallback
-    result = await asyncapi2Adapter_Yaml.parse(text, {
-      sourceMap: true,
-      refractorOpts: { plugins: [refractorPluginReplaceEmptyElement()] },
-    });
+    result = await jsonParserAdapter.parse(text, { sourceMap: true });
   }
   const { api } = result;
   if (api === undefined) return result;
-  const docNs: string = isAsyncDoc(text) || !versionSet ? 'asyncapi' : 'openapi';
+  const docNs = contentLanguage.namespace;
   // TODO  (francesco@tumanischvili@smartbear.com) use the type related metadata at root level defining the tokenTypes and modifiers
   setMetadataMap(api, docNs, metadataMaps); // TODO (francesco@tumanischvili@smartbear.com)  move to parser/adapter, extending the one standard
   api.freeze(); // !! freeze and add parent !!

--- a/packages/apidom-ls/src/services/completion/completion-service.ts
+++ b/packages/apidom-ls/src/services/completion/completion-service.ts
@@ -56,9 +56,9 @@ import {
   perfEnd,
   debug,
   trace,
-  isAsyncDoc,
   isJsonDoc,
   isSpecVersionSet,
+  findNamespace,
 } from '../../utils/utils';
 import { standardLinterfunctions } from '../validation/linter-functions';
 
@@ -378,7 +378,7 @@ export class DefaultCompletionService implements CompletionService {
     const { api } = result;
     // if we cannot parse nothing to do
     if (api === undefined) return completionList;
-    const docNs: string = isAsyncDoc(text) ? 'asyncapi' : 'openapi';
+    const docNs: string = findNamespace(text, this.settings?.defaultContentLanguage).namespace;
     const specVersion = getSpecVersion(api);
 
     let targetOffset = textModified ? offset - 1 : offset;

--- a/packages/apidom-ls/src/services/definition/definition-service.ts
+++ b/packages/apidom-ls/src/services/definition/definition-service.ts
@@ -81,7 +81,6 @@ export class DefaultDefinitionService implements DefinitionService {
     textDocument: TextDocument,
     referenceParams: ReferenceParams,
   ): Promise<Location[] | null> {
-    // const asyncapi: boolean = isAsyncDoc(textDocument);
     const offset = textDocument.offsetAt(referenceParams.position);
 
     const result = await this.settings!.documentCache?.get(textDocument);

--- a/packages/apidom-ls/src/services/hover/hover-service.ts
+++ b/packages/apidom-ls/src/services/hover/hover-service.ts
@@ -11,8 +11,8 @@ import {
   isArray,
   getSpecVersion,
   correctPartialKeys,
-  isAsyncDoc,
   isJsonDoc,
+  findNamespace,
 } from '../../utils/utils';
 
 export interface HoverService {
@@ -66,7 +66,7 @@ export class DefaultHoverService implements HoverService {
     const { api } = result;
     // no API document has been parsed
     if (api === undefined) return undefined;
-    const docNs: string = isAsyncDoc(text) ? 'asyncapi' : 'openapi';
+    const docNs: string = findNamespace(text, this.settings?.defaultContentLanguage).namespace;
     const specVersion = getSpecVersion(api);
 
     api.freeze(); // !! freeze and add parent !!

--- a/packages/apidom-ls/src/services/validation/validation-service.ts
+++ b/packages/apidom-ls/src/services/validation/validation-service.ts
@@ -19,9 +19,9 @@ import {
 import {
   checkConditions,
   correctPartialKeys,
+  findNamespace,
   getSourceMap,
   getSpecVersion,
-  isAsyncDoc,
   isJsonDoc,
   isMember,
   isObject,
@@ -134,7 +134,7 @@ export class DefaultValidationService implements ValidationService {
     if (!result) return diagnostics;
 
     let processedText;
-    const docNs: string = isAsyncDoc(text) ? 'asyncapi' : 'openapi';
+    const docNs: string = findNamespace(text, this.settings?.defaultContentLanguage).namespace;
     // no API document has been parsed
     if (result.annotations) {
       for (const annotation of result.annotations) {
@@ -576,7 +576,10 @@ export class DefaultValidationService implements ValidationService {
         if (!api) {
           return [];
         }
-        const lang = isAsyncDoc(textDocument) ? 'asyncapi' : 'openapi';
+        const lang: string = findNamespace(
+          textDocument,
+          this.settings?.defaultContentLanguage,
+        ).namespace;
         const codeActions: CodeAction[] = [];
         // TODO deduplicate, action maps elsewhere
         diagnostics.forEach((diag) => {

--- a/packages/apidom-ls/test/detect.ts
+++ b/packages/apidom-ls/test/detect.ts
@@ -1,0 +1,117 @@
+import fs from 'fs';
+import path from 'path';
+import { assert } from 'chai';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+import { parse } from '../src/parser-factory';
+import { findNamespace } from '../src/utils/utils';
+import { ContentLanguage } from '../src/apidom-language-types';
+
+const oasJson = fs.readFileSync(path.join(__dirname, 'fixtures', 'detect', 'oas.json')).toString();
+const oasYaml = fs.readFileSync(path.join(__dirname, 'fixtures', 'detect', 'oas.yaml')).toString();
+const asyncJson = fs
+  .readFileSync(path.join(__dirname, 'fixtures', 'detect', 'async.json'))
+  .toString();
+const asyncYaml = fs
+  .readFileSync(path.join(__dirname, 'fixtures', 'detect', 'async.yaml'))
+  .toString();
+// const adsJson = fs.readFileSync(path.join(__dirname, 'fixtures', 'detect', 'ads.json')).toString();
+// const adsYaml = fs.readFileSync(path.join(__dirname, 'fixtures', 'detect', 'ads.yaml')).toString();
+const apidomJson = fs
+  .readFileSync(path.join(__dirname, 'fixtures', 'detect', 'apidom.json'))
+  .toString();
+const apidomYaml = fs
+  .readFileSync(path.join(__dirname, 'fixtures', 'detect', 'apidom.yaml'))
+  .toString();
+
+describe('apidom-ls-detect', function () {
+  it('test detect', async function () {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const contentLanguage: ContentLanguage = {
+      namespace: 'asyncapi',
+    };
+
+    // valid spec
+    let doc: TextDocument = TextDocument.create('foo://bar/oasJson.json', 'oasJson', 0, oasJson);
+
+    let result = await parse(doc, undefined);
+    assert.deepEqual(result.api?.element, 'openApi3_1');
+    result = await parse(doc, undefined, contentLanguage);
+    assert.deepEqual(result.api?.element, 'openApi3_1');
+
+    let ns = findNamespace(doc);
+    assert.deepEqual(ns.namespace, 'openapi');
+    assert.deepEqual(ns.format, 'JSON');
+    ns = findNamespace(doc, contentLanguage);
+    assert.deepEqual(ns.namespace, 'openapi');
+    assert.deepEqual(ns.format, 'JSON');
+
+    doc = TextDocument.create('foo://bar/oasYaml.yaml', 'oasYaml', 0, oasYaml);
+
+    result = await parse(doc, undefined);
+    assert.deepEqual(result.api?.element, 'openApi3_1');
+    result = await parse(doc, undefined, contentLanguage);
+    assert.deepEqual(result.api?.element, 'openApi3_1');
+
+    ns = findNamespace(doc);
+    assert.deepEqual(ns.namespace, 'openapi');
+    assert.deepEqual(ns.format, 'YAML');
+    ns = findNamespace(doc, contentLanguage);
+    assert.deepEqual(ns.namespace, 'openapi');
+    assert.deepEqual(ns.format, 'YAML');
+
+    doc = TextDocument.create('foo://bar/asyncYaml.yaml', 'asyncYaml', 0, asyncYaml);
+
+    result = await parse(doc, undefined);
+    assert.deepEqual(result.api?.element, 'asyncApi2');
+    result = await parse(doc, undefined, contentLanguage);
+    assert.deepEqual(result.api?.element, 'asyncApi2');
+
+    ns = findNamespace(doc);
+    assert.deepEqual(ns.namespace, 'asyncapi');
+    assert.deepEqual(ns.format, 'YAML');
+    ns = findNamespace(doc, contentLanguage);
+    assert.deepEqual(ns.namespace, 'asyncapi');
+    assert.deepEqual(ns.format, 'YAML');
+
+    doc = TextDocument.create('foo://bar/asyncJson.json', 'asyncJson', 0, asyncJson);
+
+    result = await parse(doc, undefined);
+    assert.deepEqual(result.api?.element, 'asyncApi2');
+    result = await parse(doc, undefined, contentLanguage);
+    assert.deepEqual(result.api?.element, 'asyncApi2');
+
+    ns = findNamespace(doc);
+    assert.deepEqual(ns.namespace, 'asyncapi');
+    assert.deepEqual(ns.format, 'JSON');
+    ns = findNamespace(doc, contentLanguage);
+    assert.deepEqual(ns.namespace, 'asyncapi');
+    assert.deepEqual(ns.format, 'JSON');
+
+    doc = TextDocument.create('foo://bar/apidomJson.json', 'apidomJson', 0, apidomJson);
+
+    result = await parse(doc, undefined);
+    result = await parse(doc, undefined, contentLanguage);
+    assert.deepEqual(result.api?.element, 'asyncApi2');
+
+    ns = findNamespace(doc);
+    assert.deepEqual(ns.namespace, 'apidom');
+    assert.deepEqual(ns.format, 'JSON');
+    ns = findNamespace(doc, contentLanguage);
+    assert.deepEqual(ns.namespace, 'asyncapi');
+    assert.deepEqual(ns.format, 'JSON');
+
+    doc = TextDocument.create('foo://bar/apidomYaml.yaml', 'apidomYaml', 0, apidomYaml);
+
+    result = await parse(doc, undefined);
+    result = await parse(doc, undefined, contentLanguage);
+    assert.deepEqual(result.api?.element, 'asyncApi2');
+
+    ns = findNamespace(doc);
+    assert.deepEqual(ns.namespace, 'apidom');
+    assert.deepEqual(ns.format, 'YAML');
+    ns = findNamespace(doc, contentLanguage);
+    assert.deepEqual(ns.namespace, 'asyncapi');
+    assert.deepEqual(ns.format, 'YAML');
+  });
+});

--- a/packages/apidom-ls/test/fixtures/detect/apidom.json
+++ b/packages/apidom-ls/test/fixtures/detect/apidom.json
@@ -1,0 +1,194 @@
+{
+  "apidom": "3.1.0",
+  "x-top-level": "value",
+  "info": {
+    "title": "Sample API",
+    "unknownFixedField": "value",
+    "description": "Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.",
+    "summary": "example summary",
+    "termsOfService": "Terms of service",
+    "version": "0.1.9",
+    "x-version": "0.1.9-beta",
+    "license": {
+      "name": "Apache License 2.0",
+      "x-fullName": "Apache License 2.0",
+      "identifier": "Apache License 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "contact": {
+      "name": "Vladimir Gorej",
+      "x-username": "char0n",
+      "url": "https://www.linkedin.com/in/vladimirgorej/",
+      "email": "vladimir.gorej@gmail.com"
+    }
+  },
+  "components": {
+    "x-extension": "value",
+    "schemas": {
+      "x-model": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "#/components/schemas/UserProfile",
+            "summary": "user profile reference summary",
+            "description": "user profile reference description"
+          }
+        }
+      },
+      "UserProfile": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "x-nullable": true
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {},
+    {
+      "petstore_auth": [
+        "write:pets",
+        "read:pets"
+      ]
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://api.example.com/v1",
+      "description": "Optional server description, e.g. Main (production) server"
+    },
+    {
+      "url": "http:{port}//staging-api.example.com",
+      "description": "Optional server description, e.g. Internal staging server for testing",
+      "variables": {
+        "port": {
+          "enum": [
+            "8443",
+            "443"
+          ],
+          "default": "8443",
+          "description": "Port description"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/users": {
+      "summary": "path item summary",
+      "description": "path item description",
+      "get": {
+        "tags": ["tag1", "tag2"],
+        "summary": "Returns a list of users.",
+        "description": "Optional extended description in CommonMark or HTML.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://example.com"
+        },
+        "operationId": "getUserList",
+        "parameters": {
+          "name": "userId",
+          "in": "query",
+          "description": "ID of the user",
+          "required": true
+        },
+        "requestBody": {
+          "content": {}
+        },
+        "responses": {
+          "xxx": {"key":  "val"},
+          "200": {
+            "description": "A JSON array of user names",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "A response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        },
+        "callbacks": {
+          "myCallback": {
+            "{$request.query.queryUrl}": {
+              "post": {
+                "requestBody": {
+                  "description": "Callback payload",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/User"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "callback successfully processed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true,
+        "security": [
+          {},
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "servers": [
+          {
+            "url": "http://api.example.com/v3",
+            "description": "Redundant server description, e.g. redundant server"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "http://api.example.com/v2",
+          "description": "Redundant server description, e.g. redundant server"
+        }
+      ],
+      "parameters": {
+        "name": "userId",
+        "in": "query",
+        "description": "ID of the user",
+        "required": true
+      }
+    }
+  }
+}

--- a/packages/apidom-ls/test/fixtures/detect/apidom.yaml
+++ b/packages/apidom-ls/test/fixtures/detect/apidom.yaml
@@ -1,0 +1,132 @@
+---
+apidom: 3.1.0
+x-top-level: value
+info:
+  title: Sample API
+  unknownFixedField: value
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/)
+    or HTML.
+  summary: example summary
+  termsOfService: Terms of service
+  version: 0.1.9
+  x-version: 0.1.9-beta
+  license:
+    name: Apache License 2.0
+    x-fullName: Apache License 2.0
+    identifier: Apache License 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+  contact:
+    name: Vladimir Gorej
+    x-username: char0n
+    url: https://www.linkedin.com/in/vladimirgorej/
+    email: vladimir.gorej@gmail.com
+components:
+  x-extension: value
+  schemas:
+    x-model:
+      type: object
+      properties:
+        id:
+          'type:': integer
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        profile:
+          "$ref": "#/components/schemas/UserProfile"
+          summary: user profile reference summary
+          description: user profile reference description
+    UserProfile:
+      type: object
+      properties:
+        email:
+          type: string
+          x-nullable: true
+security:
+  - {}
+  - petstore_auth:
+      - write:pets
+      - read:pets
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http:{port}//staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+    variables:
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '8443'
+        description: Port description
+paths:
+  "/users":
+    summary: path item summary
+    description: path item description
+    get:
+      tags:
+        - tag1
+        - tag2
+      summary: Returns a list of users.
+      description: Optional extended description in CommonMark or HTML.
+      externalDocs:
+        description: Find more info here
+        url: https://example.com
+      operationId: getUserList
+      parameters:
+        name: userId
+        in: query
+        description: ID of the user
+        required: true
+      requestBody:
+        content: {}
+      responses:
+        '200':
+          description: A JSON array of user names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '201':
+          description: A response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        xxx:
+          key: val
+      callbacks:
+        myCallback:
+          "{$request.query.queryUrl}":
+            post:
+              requestBody:
+                description: Callback payload
+                content:
+                  application/json:
+                    schema:
+                      "$ref": "#/components/schemas/User"
+              responses:
+                '200':
+                  description: callback successfully processed
+      deprecated: true
+      security:
+        - {}
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      servers:
+        - url: http://api.example.com/v3
+          description: Redundant server description, e.g. redundant server
+    servers:
+      - url: http://api.example.com/v2
+        description: Redundant server description, e.g. redundant server
+    parameters:
+      name: userId
+      in: query
+      description: ID of the user
+      required: true

--- a/packages/apidom-ls/test/fixtures/detect/async.json
+++ b/packages/apidom-ls/test/fixtures/detect/async.json
@@ -1,0 +1,151 @@
+{
+  "asyncapi": "2.0.0",
+  "id": "urn:com:smartylighting:streetlights:server",
+  "info": {
+    "title": "AsyncAPI Sample App",
+    "description": "This is a sample server.",
+    "termsOfService": "http://asyncapi.org/terms/",
+    "contact": {
+      "name": "API Support",
+      "url": "http://www.asyncapi.org/support",
+      "email": "support@asyncapi.org"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.1"
+  },
+  "servers": {
+    "production":{
+      "url": "{username}.gigantic-server.com:{port}/{basePath}",
+      "description": "The production API server",
+      "protocol": "secure-mqtt",
+      "protocolVersion": "1.0.0",
+      "variables": {
+        "username": {
+          "default": "demo",
+          "description": "This value is assigned by the service provider, in this example `gigantic-server.com`",
+          "examples": ["value1", "value2"]
+        },
+        "port": {
+          "enum": [
+            "8883",
+            "8884"
+          ],
+          "default": "8883"
+        },
+        "basePath": {
+          "default": "v2"
+        }
+      },
+      "security": [
+        {
+          "user_pass": []
+        }
+      ],
+      "bindings": {}
+    }
+  },
+  "channels": {
+    "user/{userId}/signup": {
+      "description": "This channel is used to exchange messages about users signing up",
+      "parameters": {
+        "userId": {
+          "description": "Id of the user.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      },
+      "subscribe": {
+        "summary": "A user signed up.",
+        "message": {
+          "description": "A longer description of the message",
+          "payload": {
+            "type": "object",
+            "properties": {
+              "user": {
+                "$ref": "#/components/schemas/user"
+              },
+              "signup": {
+                "$ref": "#/components/schemas/signup"
+              }
+            }
+          }
+        }
+      },
+      "bindings": {
+        "amqp": {
+          "is": "queue",
+          "queue": {
+            "exclusive": true
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "x-extension": "value",
+    "schemas": {
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "messages": {
+      "userSignUp": {
+        "summary": "Action to sign a user up.",
+        "description": "Multiline description of what this action does.\nHere you have another line.\n",
+        "tags": [
+          {
+            "name": "user"
+          },
+          {
+            "name": "signup"
+          }
+        ],
+        "headers": {
+          "type": "object",
+          "properties": {
+            "applicationInstanceId": {
+              "description": "Unique identifier for a given instance of the publishing application",
+              "type": "string"
+            }
+          }
+        },
+        "payload": {
+          "type": "object",
+          "properties": {
+            "user": {
+              "$ref": "#/components/schemas/userCreate"
+            },
+            "signup": {
+              "$ref": "#/components/schemas/signup"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-ls/test/fixtures/detect/async.yaml
+++ b/packages/apidom-ls/test/fixtures/detect/async.yaml
@@ -1,0 +1,99 @@
+asyncapi: 2.0.0
+id: urn:com:smartylighting:streetlights:server
+info:
+  title: AsyncAPI Sample App
+  description: This is a sample server.
+  termsOfService: http://asyncapi.org/terms/
+  contact:
+    name: API Support
+    url: http://www.asyncapi.org/support
+    email: support@asyncapi.org
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.1
+servers:
+  production:
+    url: "{username}.gigantic-server.com:{port}/{basePath}"
+    description: The production API server
+    protocol: secure-mqtt
+    protocolVersion: 1.0.0
+    variables:
+      username:
+        default: demo
+        description: This value is assigned by the service provider, in this example
+          `gigantic-server.com`
+        examples:
+          - value1
+          - value2
+      port:
+        enum:
+          - '8883'
+          - '8884'
+        default: '8883'
+      basePath:
+        default: v2
+    security:
+      - user_pass: []
+    bindings: {}
+channels:
+  user/signup:
+    description: This channel is used to exchange messages about users signing up
+    subscribe:
+      summary: A user signed up.
+      message:
+        description: A longer description of the message
+        payload:
+          type: object
+          properties:
+            user:
+              $ref: "#/components/schemas/user"
+            signup:
+              $ref: "#/components/schemas/signup"
+    bindings:
+      amqp:
+        is: queue
+        queue:
+          exclusive: true
+components:
+  x-extension: value
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+  messages:
+    userSignUp:
+      summary: Action to sign a user up.
+      description: |
+        Multiline description of what this action does.
+        Here you have another line.
+      tags:
+        - name: user
+        - name: signup
+      headers:
+        type: object
+        properties:
+          applicationInstanceId:
+            description: Unique identifier for a given instance of the publishing
+              application
+            type: string
+      payload:
+        type: object
+        properties:
+          user:
+            $ref: "#/components/schemas/userCreate"
+          signup:
+            $ref: "#/components/schemas/signup"

--- a/packages/apidom-ls/test/fixtures/detect/oas.json
+++ b/packages/apidom-ls/test/fixtures/detect/oas.json
@@ -1,0 +1,194 @@
+{
+  "openapi": "3.1.0",
+  "x-top-level": "value",
+  "info": {
+    "title": "Sample API",
+    "unknownFixedField": "value",
+    "description": "Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.",
+    "summary": "example summary",
+    "termsOfService": "Terms of service",
+    "version": "0.1.9",
+    "x-version": "0.1.9-beta",
+    "license": {
+      "name": "Apache License 2.0",
+      "x-fullName": "Apache License 2.0",
+      "identifier": "Apache License 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "contact": {
+      "name": "Vladimir Gorej",
+      "x-username": "char0n",
+      "url": "https://www.linkedin.com/in/vladimirgorej/",
+      "email": "vladimir.gorej@gmail.com"
+    }
+  },
+  "components": {
+    "x-extension": "value",
+    "schemas": {
+      "x-model": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "#/components/schemas/UserProfile",
+            "summary": "user profile reference summary",
+            "description": "user profile reference description"
+          }
+        }
+      },
+      "UserProfile": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "x-nullable": true
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {},
+    {
+      "petstore_auth": [
+        "write:pets",
+        "read:pets"
+      ]
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://api.example.com/v1",
+      "description": "Optional server description, e.g. Main (production) server"
+    },
+    {
+      "url": "http:{port}//staging-api.example.com",
+      "description": "Optional server description, e.g. Internal staging server for testing",
+      "variables": {
+        "port": {
+          "enum": [
+            "8443",
+            "443"
+          ],
+          "default": "8443",
+          "description": "Port description"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/users": {
+      "summary": "path item summary",
+      "description": "path item description",
+      "get": {
+        "tags": ["tag1", "tag2"],
+        "summary": "Returns a list of users.",
+        "description": "Optional extended description in CommonMark or HTML.",
+        "externalDocs": {
+          "description": "Find more info here",
+          "url": "https://example.com"
+        },
+        "operationId": "getUserList",
+        "parameters": {
+          "name": "userId",
+          "in": "query",
+          "description": "ID of the user",
+          "required": true
+        },
+        "requestBody": {
+          "content": {}
+        },
+        "responses": {
+          "xxx": {"key":  "val"},
+          "200": {
+            "description": "A JSON array of user names",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "A response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        },
+        "callbacks": {
+          "myCallback": {
+            "{$request.query.queryUrl}": {
+              "post": {
+                "requestBody": {
+                  "description": "Callback payload",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/User"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "callback successfully processed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true,
+        "security": [
+          {},
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "servers": [
+          {
+            "url": "http://api.example.com/v3",
+            "description": "Redundant server description, e.g. redundant server"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "http://api.example.com/v2",
+          "description": "Redundant server description, e.g. redundant server"
+        }
+      ],
+      "parameters": {
+        "name": "userId",
+        "in": "query",
+        "description": "ID of the user",
+        "required": true
+      }
+    }
+  }
+}

--- a/packages/apidom-ls/test/fixtures/detect/oas.yaml
+++ b/packages/apidom-ls/test/fixtures/detect/oas.yaml
@@ -1,0 +1,132 @@
+---
+openapi: 3.1.0
+x-top-level: value
+info:
+  title: Sample API
+  unknownFixedField: value
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/)
+    or HTML.
+  summary: example summary
+  termsOfService: Terms of service
+  version: 0.1.9
+  x-version: 0.1.9-beta
+  license:
+    name: Apache License 2.0
+    x-fullName: Apache License 2.0
+    identifier: Apache License 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+  contact:
+    name: Vladimir Gorej
+    x-username: char0n
+    url: https://www.linkedin.com/in/vladimirgorej/
+    email: vladimir.gorej@gmail.com
+components:
+  x-extension: value
+  schemas:
+    x-model:
+      type: object
+      properties:
+        id:
+          'type:': integer
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        profile:
+          "$ref": "#/components/schemas/UserProfile"
+          summary: user profile reference summary
+          description: user profile reference description
+    UserProfile:
+      type: object
+      properties:
+        email:
+          type: string
+          x-nullable: true
+security:
+  - {}
+  - petstore_auth:
+      - write:pets
+      - read:pets
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http:{port}//staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+    variables:
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '8443'
+        description: Port description
+paths:
+  "/users":
+    summary: path item summary
+    description: path item description
+    get:
+      tags:
+        - tag1
+        - tag2
+      summary: Returns a list of users.
+      description: Optional extended description in CommonMark or HTML.
+      externalDocs:
+        description: Find more info here
+        url: https://example.com
+      operationId: getUserList
+      parameters:
+        name: userId
+        in: query
+        description: ID of the user
+        required: true
+      requestBody:
+        content: {}
+      responses:
+        '200':
+          description: A JSON array of user names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '201':
+          description: A response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        xxx:
+          key: val
+      callbacks:
+        myCallback:
+          "{$request.query.queryUrl}":
+            post:
+              requestBody:
+                description: Callback payload
+                content:
+                  application/json:
+                    schema:
+                      "$ref": "#/components/schemas/User"
+              responses:
+                '200':
+                  description: callback successfully processed
+      deprecated: true
+      security:
+        - {}
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      servers:
+        - url: http://api.example.com/v3
+          description: Redundant server description, e.g. redundant server
+    servers:
+      - url: http://api.example.com/v2
+        description: Redundant server description, e.g. redundant server
+    parameters:
+      name: userId
+      in: query
+      description: ID of the user
+      required: true


### PR DESCRIPTION
refs #1582 

addresses #1582 by not defaulting to `asyncapi` namespace for content not recognized as a "known spec" (currently `openapi`, `asyncapi` or `ads`). Still uses internal detection mechanism, following PR will introduced usage of detection logic provided by apidom parser and adapter packages.

It allows to pass a `defaultContentLanguage` to language context, to force detection of a non recognized spec (therfore defaulting to "apidom" namespace) as a spec of given language. Currently supported values are `openap`, `asyncapi`, `ads`

e.g.:

```typescript
    const contentLanguage: ContentLanguage = {
      namespace: 'asyncapi',
    };

  const context: LanguageServiceContext = {
    metadata: metadata(),
    defaultContentLanguage: contentLanguage,
  };

  const languageService: LanguageService = getLanguageService(context);
```
```