### PR TITLE
feat(reference): unify spec/format detection with adapters

### DIFF
--- a/packages/apidom-reference/src/parse/parsers/Parser.ts
+++ b/packages/apidom-reference/src/parse/parsers/Parser.ts
@@ -16,10 +16,28 @@ const Parser = stampit({
      * Whether to generate source map during parsing.
      */
     sourceMap: false,
+    /**
+     * List of supported file extensions.
+     */
+    fileExtensions: [],
+    /**
+     * List of supported media types.
+     */
+    mediaTypes: [],
   },
-  init(this: IParser, { allowEmpty = this.allowEmpty, sourceMap = this.sourceMap } = {}) {
+  init(
+    this: IParser,
+    {
+      allowEmpty = this.allowEmpty,
+      sourceMap = this.sourceMap,
+      fileExtensions = this.fileExtensions,
+      mediaTypes = this.mediaTypes,
+    } = {},
+  ) {
     this.allowEmpty = allowEmpty;
     this.sourceMap = sourceMap;
+    this.fileExtensions = fileExtensions;
+    this.mediaTypes = mediaTypes;
   },
   methods: {
     canParse(): boolean {

--- a/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-api-design-systems-json/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-api-design-systems-json/index.ts
@@ -10,10 +10,14 @@ import Parser from '../Parser';
 const ApiDesignSystemsJsonParser: stampit.Stamp<IParser> = stampit(Parser, {
   props: {
     name: 'api-design-systems-json',
+    fileExtensions: ['.json'],
+    mediaTypes,
   },
   methods: {
     canParse(file: IFile): boolean {
-      return mediaTypes.includes(file.mediaType) && file.extension === '.json';
+      return (
+        this.mediaTypes.includes(file.mediaType) && this.fileExtensions.includes(file.extension)
+      );
     },
     async parse(file: IFile): Promise<ParseResultElement> {
       const source = ArrayBuffer.isView(file.data) ? file.data.toString() : file.data;

--- a/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-api-design-systems-yaml/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-api-design-systems-yaml/index.ts
@@ -10,10 +10,14 @@ import Parser from '../Parser';
 const ApiDesignSystemsYamlParser: stampit.Stamp<IParser> = stampit(Parser, {
   props: {
     name: 'api-design-systems-yaml',
+    fileExtensions: ['.yaml', '.yml'],
+    mediaTypes,
   },
   methods: {
     canParse(file: IFile): boolean {
-      return mediaTypes.includes(file.mediaType) && ['.yaml', '.yml'].includes(file.extension);
+      return (
+        this.mediaTypes.includes(file.mediaType) && this.fileExtensions.includes(file.extension)
+      );
     },
     async parse(file: IFile): Promise<ParseResultElement> {
       const source = ArrayBuffer.isView(file.data) ? file.data.toString() : file.data;

--- a/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-asyncapi-json-2/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-asyncapi-json-2/index.ts
@@ -10,10 +10,14 @@ import Parser from '../Parser';
 const AsyncApiJson2Parser: stampit.Stamp<IParser> = stampit(Parser, {
   props: {
     name: 'asyncapi-json-2',
+    fileExtensions: ['.json'],
+    mediaTypes,
   },
   methods: {
     canParse(file: IFile): boolean {
-      return mediaTypes.includes(file.mediaType) && file.extension === '.json';
+      return (
+        this.mediaTypes.includes(file.mediaType) && this.fileExtensions.includes(file.extension)
+      );
     },
     async parse(file: IFile): Promise<ParseResultElement> {
       const source = ArrayBuffer.isView(file.data) ? file.data.toString() : file.data;

--- a/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-asyncapi-yaml-2/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-asyncapi-yaml-2/index.ts
@@ -10,10 +10,14 @@ import Parser from '../Parser';
 const AsyncApiYaml2Parser: stampit.Stamp<IParser> = stampit(Parser, {
   props: {
     name: 'asyncapi-yaml-2',
+    fileExtensions: ['.yaml', '.yml'],
+    mediaTypes,
   },
   methods: {
     canParse(file: IFile): boolean {
-      return mediaTypes.includes(file.mediaType) && ['.yaml', '.yml'].includes(file.extension);
+      return (
+        this.mediaTypes.includes(file.mediaType) && this.fileExtensions.includes(file.extension)
+      );
     },
     async parse(file: IFile): Promise<ParseResultElement> {
       const source = ArrayBuffer.isView(file.data) ? file.data.toString() : file.data;

--- a/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-json/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-json/index.ts
@@ -1,7 +1,7 @@
 import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse } from '@swagger-api/apidom-parser-adapter-json';
+import { parse, mediaTypes } from '@swagger-api/apidom-parser-adapter-json';
 
 import { ParserError } from '../../../util/errors';
 import { Parser as IParser, File as IFile } from '../../../types';
@@ -10,10 +10,14 @@ import Parser from '../Parser';
 const JsonParser: stampit.Stamp<IParser> = stampit(Parser, {
   props: {
     name: 'json',
+    fileExtensions: ['.json'],
+    mediaTypes,
   },
   methods: {
     canParse(file: IFile): boolean {
-      return file.mediaType === 'application/json' || file.extension === '.json';
+      return (
+        this.mediaTypes.includes(file.mediaType) || this.fileExtensions.includes(file.extension)
+      );
     },
     async parse(file: IFile): Promise<ParseResultElement> {
       const source = ArrayBuffer.isView(file.data) ? file.data.toString() : file.data;

--- a/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-openapi-json-3-1/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-openapi-json-3-1/index.ts
@@ -11,10 +11,14 @@ import Parser from '../Parser';
 const OpenApiJson3_1Parser: stampit.Stamp<IParser> = stampit(Parser, {
   props: {
     name: 'openapi-json-3-1',
+    fileExtensions: ['.json'],
+    mediaTypes,
   },
   methods: {
     canParse(file: IFile): boolean {
-      return mediaTypes.includes(file.mediaType) && file.extension === '.json';
+      return (
+        this.mediaTypes.includes(file.mediaType) && this.fileExtensions.includes(file.extension)
+      );
     },
     async parse(file: IFile): Promise<ParseResultElement> {
       const source = ArrayBuffer.isView(file.data) ? file.data.toString() : file.data;

--- a/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-openapi-yaml-3-1/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-openapi-yaml-3-1/index.ts
@@ -11,10 +11,14 @@ import Parser from '../Parser';
 const OpenApiYaml3_1Parser: stampit.Stamp<IParser> = stampit(Parser, {
   props: {
     name: 'openapi-yaml-3-1',
+    fileExtensions: ['.yaml', '.yml'],
+    mediaTypes,
   },
   methods: {
     canParse(file: IFile): boolean {
-      return mediaTypes.includes(file.mediaType) && ['.yaml', '.yml'].includes(file.extension);
+      return (
+        this.mediaTypes.includes(file.mediaType) && this.fileExtensions.includes(file.extension)
+      );
     },
     async parse(file: IFile): Promise<ParseResultElement> {
       const source = ArrayBuffer.isView(file.data) ? file.data.toString() : file.data;

--- a/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-yaml-1-2/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/apidom-reference-parser-yaml-1-2/index.ts
@@ -1,6 +1,6 @@
 import stampit from 'stampit';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse } from '@swagger-api/apidom-parser-adapter-yaml-1-2';
+import { parse, mediaTypes } from '@swagger-api/apidom-parser-adapter-yaml-1-2';
 
 import { ParserError } from '../../../util/errors';
 import { File as IFile, Parser as IParser } from '../../../types';
@@ -9,12 +9,13 @@ import Parser from '../Parser';
 const YamlParser: stampit.Stamp<IParser> = stampit(Parser, {
   props: {
     name: 'yaml-1-2',
+    fileExtensions: ['.yaml', '.yml'],
+    mediaTypes,
   },
   methods: {
     canParse(file: IFile): boolean {
       return (
-        ['text/yaml', 'application/yaml'].includes(file.mediaType) ||
-        ['.yaml', '.yml'].includes(file.extension)
+        this.mediaTypes.includes(file.mediaType) || this.fileExtensions.includes(file.extension)
       );
     },
     async parse(file: IFile): Promise<ParseResultElement> {

--- a/packages/apidom-reference/src/types.ts
+++ b/packages/apidom-reference/src/types.ts
@@ -26,6 +26,8 @@ export interface HttpResolver extends Resolver {
 export interface Parser {
   allowEmpty: boolean;
   sourceMap: boolean;
+  fileExtensions: string[];
+  mediaTypes: string[];
 
   canParse(file: File): boolean;
   parse(file: File): Promise<ParseResultElement>;


### PR DESCRIPTION
On top of that, allow API consumers to configure
extesions and media types for parser plugins.

Refs #1604