### PR TITLE
feat(reference): add configurable interceptors for HttpResolverAxios

### DIFF
--- a/packages/apidom-reference/README.md
+++ b/packages/apidom-reference/README.md
@@ -707,7 +707,7 @@ await resolve('/home/user/oas.json', {
 }); // Promise<ReferenceSet>
 ```
 
-**Externally resolving a HTTP(S) URL located on an internet:**
+**Externally resolving an HTTP(S) URL located on an internet:**
 
 ```js
 import { resolve } from '@swagger-api/apidom-reference';


### PR DESCRIPTION
###  Simple request interceptor

```js
import { resolve } from '@swagger-api/apidom-reference';

const requestInterceptor = (config) => config;

await resolve('https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/webhook-example.json', {
  parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
  resolve: {
    resolverOpts: {
      axiosConfig: {
        timeout: 10
        interceptors: { 
          request: requestInterceptor,
        },
      },
    },
  },
}); // Promise<ReferenceSet>
```

###  Request interceptor with error handling

```js
import { resolve } from '@swagger-api/apidom-reference';

const requestInterceptorSuccess = (config) => config;
const requestInterceptorError = async (error) => Promise.reject(error);

await resolve('https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/webhook-example.json', {
  parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
  resolve: {
    resolverOpts: {
      axiosConfig: {
        timeout: 10
        interceptors: { 
          request: [requestInterceptorSuccess, requestInterceptorError],
        },
      },
    },
  },
}); // Promise<ReferencSeSet>
```

###  Simple response interceptor

```js
import { resolve } from '@swagger-api/apidom-reference';

const responseInterceptor = (response) => response;

await resolve('https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/webhook-example.json', {
  parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
  resolve: {
    resolverOpts: {
      axiosConfig: {
        timeout: 10
        interceptors: { 
          response: responseInterceptor,
        },
      },
    },
  },
}); // Promise<ReferenceSet>
```

###  Response interceptor with error handling

```js
import { resolve } from '@swagger-api/apidom-reference';

const responseInterceptorSuccess = (response) => response;
const responseInterceptorError = async (error) => Promise.reject(error);

await resolve('https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/webhook-example.json', {
  parse: { mediaType: 'application/vnd.oai.openapi+json;version=3.1.0' },
  resolve: {
    resolverOpts: {
      axiosConfig: {
        timeout: 10
        interceptors: { 
          response: [responseInterceptorSuccess, responseInterceptorError],
        },
      },
    },
  },
}); // Promise<ReferencSeSet>
```

