### PR TITLE
chore(deps): update dependencies that failed to automerge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27730,8 +27730,9 @@
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.4",
-      "license": "MIT"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
+      "integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg=="
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.16.0",
@@ -29057,8 +29058,8 @@
         "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2",
         "vscode-languageserver-protocol": "^3.16.0",
-        "vscode-languageserver-textdocument": "^1.0.1",
-        "vscode-languageserver-types": "^3.16.0",
+        "vscode-languageserver-textdocument": "^1.0.5",
+        "vscode-languageserver-types": "^3.17.2",
         "yaml-js": "^0.3.0"
       }
     },
@@ -29086,6 +29087,11 @@
     "packages/apidom-ls/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "packages/apidom-ls/node_modules/vscode-languageserver-types": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
     },
     "packages/apidom-ns-api-design-systems": {
       "name": "@swagger-api/apidom-ns-api-design-systems",
@@ -35317,8 +35323,8 @@
         "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2",
         "vscode-languageserver-protocol": "^3.16.0",
-        "vscode-languageserver-textdocument": "^1.0.1",
-        "vscode-languageserver-types": "^3.16.0",
+        "vscode-languageserver-textdocument": "^1.0.5",
+        "vscode-languageserver-types": "3.17.2",
         "yaml-js": "^0.3.0"
       },
       "dependencies": {
@@ -35337,6 +35343,11 @@
         },
         "json-schema-traverse": {
           "version": "1.0.0"
+        },
+        "vscode-languageserver-types": {
+          "version": "3.17.2",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+          "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
         }
       }
     },
@@ -48345,7 +48356,9 @@
       }
     },
     "vscode-languageserver-textdocument": {
-      "version": "1.0.4"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
+      "integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg=="
     },
     "vscode-languageserver-types": {
       "version": "3.16.0"

--- a/packages/apidom-ls/package.json
+++ b/packages/apidom-ls/package.json
@@ -58,8 +58,8 @@
     "ramda-adjunct": "=3.2.0",
     "stampit": "=4.3.2",
     "vscode-languageserver-protocol": "^3.16.0",
-    "vscode-languageserver-textdocument": "^1.0.1",
-    "vscode-languageserver-types": "^3.16.0",
+    "vscode-languageserver-textdocument": "^1.0.5",
+    "vscode-languageserver-types": "^3.17.2",
     "yaml-js": "^0.3.0"
   },
   "files": [


### PR DESCRIPTION
These include:
- vscode-languageserver-textdocument@1.0.5
- vscode-languageserver-types@3.17.2

Closes #1778
Closes #1777

