### PR TITLE
fix(adapters): force forward compatible dection to be valid as well

### DIFF
--- a/packages/apidom-parser-adapter-asyncapi-json-2/src/adapter.ts
+++ b/packages/apidom-parser-adapter-asyncapi-json-2/src/adapter.ts
@@ -6,7 +6,8 @@ import asyncApiNamespace, { AsyncApi2Element } from '@swagger-api/apidom-ns-asyn
 
 export { default as mediaTypes } from './media-types';
 
-export const detectionRegExp = /"asyncapi"\s*:\s*"(?<version_json>2\.\d+\.\d+)"/;
+export const detectionRegExp =
+  /"asyncapi"\s*:\s*"(?<version_json>2\.(?:[1-9]\d*|0)\.(?:[1-9]\d*|0))"/;
 
 export const detect = async (source: string): Promise<boolean> =>
   detectionRegExp.test(source) && (await detectJSON(source));

--- a/packages/apidom-parser-adapter-asyncapi-json-2/test/adapter.ts
+++ b/packages/apidom-parser-adapter-asyncapi-json-2/test/adapter.ts
@@ -71,4 +71,29 @@ describe('adapter', function () {
       assert.isTrue(parseResult.isEmpty);
     });
   });
+
+  context('detectionRegExp', function () {
+    specify('should detect version ranges in forward compatible way', function () {
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.0.0"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.0.145"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.1.0"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.1.145"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.2.0"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.2.145"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.3.0"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.3.1"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.4.0"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.4.1"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.5.0"'));
+      assert.isTrue(adapter.detectionRegExp.test('"asyncapi": "2.5.1"'));
+    });
+
+    specify('should reject invalid version ranges', function () {
+      assert.isFalse(adapter.detectionRegExp.test('"asyncapi": "3.0.0"'));
+      assert.isFalse(adapter.detectionRegExp.test('"asyncapi": "3.1.0"'));
+      assert.isFalse(adapter.detectionRegExp.test('"asyncapi": "3.1.1"'));
+      assert.isFalse(adapter.detectionRegExp.test('"asyncapi": "2.01.0"'));
+      assert.isFalse(adapter.detectionRegExp.test('"asyncapi": "2.1.01"'));
+    });
+  });
 });

--- a/packages/apidom-parser-adapter-asyncapi-yaml-2/src/adapter.ts
+++ b/packages/apidom-parser-adapter-asyncapi-yaml-2/src/adapter.ts
@@ -10,7 +10,7 @@ import asyncApiNamespace, { AsyncApi2Element } from '@swagger-api/apidom-ns-asyn
 export { default as mediaTypes } from './media-types';
 
 export const detectionRegExp =
-  /(?<YAML>^(["']?)asyncapi\2\s*:\s*(["']?)(?<version_yaml>2\.\d+\.\d+)\3)|(?<JSON>"asyncapi"\s*:\s*"(?<version_json>2\.\d+\.\d+)")/m;
+  /(?<YAML>^(["']?)asyncapi\2\s*:\s*(["']?)(?<version_yaml>2\.(?:[1-9]\d*|0)\.(?:[1-9]\d*|0))\3(?:\s+|$))|(?<JSON>"asyncapi"\s*:\s*"(?<version_json>2\.(?:[1-9]\d*|0)\.(?:[1-9]\d*|0))")/m;
 
 export const detect = async (source: string): Promise<boolean> =>
   detectionRegExp.test(source) && (await detectYAML(source));

--- a/packages/apidom-parser-adapter-asyncapi-yaml-2/test/adapter.ts
+++ b/packages/apidom-parser-adapter-asyncapi-yaml-2/test/adapter.ts
@@ -92,4 +92,30 @@ describe('adapter', function () {
       assert.isTrue(positionEnd.equals(expectedEmptyPosition));
     });
   });
+
+  context('detectionRegExp', function () {
+    specify('should detect version ranges in forward compatible way', function () {
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.0.0'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.0.145'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.1.0'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.1.145'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.2.0'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.2.145'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.3.0'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.3.1'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.4.0'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.4.1'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.5.0'));
+      assert.isTrue(adapter.detectionRegExp.test('asyncapi: 2.5.1'));
+    });
+
+    specify('should reject invalid version ranges', function () {
+      assert.isFalse(adapter.detectionRegExp.test('asyncapi: 3.0.0'));
+      assert.isFalse(adapter.detectionRegExp.test('asyncapi: 3.1.0'));
+      assert.isFalse(adapter.detectionRegExp.test('asyncapi: 3.1.1'));
+      assert.isFalse(adapter.detectionRegExp.test('asyncapi: 2.01.0'));
+      assert.isFalse(adapter.detectionRegExp.test('asyncapi: 2.1.013'));
+      assert.isFalse(adapter.detectionRegExp.test('asyncapi: 2.1.013 '));
+    });
+  });
 });

--- a/packages/apidom-parser-adapter-openapi-json-3-1/src/adapter.ts
+++ b/packages/apidom-parser-adapter-openapi-json-3-1/src/adapter.ts
@@ -6,7 +6,7 @@ import openApiNamespace, { OpenApi3_1Element } from '@swagger-api/apidom-ns-open
 
 export { default as mediaTypes } from './media-types';
 
-export const detectionRegExp = /"openapi"\s*:\s*"(?<version_json>3\.1\.\d+)"/;
+export const detectionRegExp = /"openapi"\s*:\s*"(?<version_json>3\.1\.(?:[1-9]\d*|0))"/;
 
 export const detect = async (source: string): Promise<boolean> =>
   detectionRegExp.test(source) && (await detectJSON(source));

--- a/packages/apidom-parser-adapter-openapi-json-3-1/test/adapter.ts
+++ b/packages/apidom-parser-adapter-openapi-json-3-1/test/adapter.ts
@@ -71,4 +71,19 @@ describe('adapter', function () {
       assert.isTrue(parseResult.isEmpty);
     });
   });
+
+  context('detectionRegExp', function () {
+    specify('should detect version ranges in forward compatible way', function () {
+      assert.isTrue(adapter.detectionRegExp.test('"openapi": "3.1.0"'));
+      assert.isTrue(adapter.detectionRegExp.test('"openapi": "3.1.1"'));
+      assert.isTrue(adapter.detectionRegExp.test('"openapi": "3.1.145"'));
+    });
+
+    specify('should reject invalid version ranges', function () {
+      assert.isFalse(adapter.detectionRegExp.test('"openapi": "3.0.0"'));
+      assert.isFalse(adapter.detectionRegExp.test('"openapi": "3.0.1"'));
+      assert.isFalse(adapter.detectionRegExp.test('"openapi": "3.01.0"'));
+      assert.isFalse(adapter.detectionRegExp.test('"openapi": "3.1.01"'));
+    });
+  });
 });

--- a/packages/apidom-parser-adapter-openapi-yaml-3-1/src/adapter.ts
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-1/src/adapter.ts
@@ -10,7 +10,7 @@ import openApiNamespace, { OpenApi3_1Element } from '@swagger-api/apidom-ns-open
 export { default as mediaTypes } from './media-types';
 
 export const detectionRegExp =
-  /(?<YAML>^(["']?)openapi\2\s*:\s*(["']?)(?<version_yaml>3\.1\.\d+)\3)|(?<JSON>"openapi"\s*:\s*"(?<version_json>3\.1\.\d+)")/m;
+  /(?<YAML>^(["']?)openapi\2\s*:\s*(["']?)(?<version_yaml>3\.1\.(?:[1-9]\d*|0))\3(?:\s+|$))|(?<JSON>"openapi"\s*:\s*"(?<version_json>3\.1\.\d+)")/m;
 
 export const detect = async (source: string): Promise<boolean> =>
   detectionRegExp.test(source) && (await detectYAML(source));

--- a/packages/apidom-parser-adapter-openapi-yaml-3-1/test/adapter.ts
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-1/test/adapter.ts
@@ -87,4 +87,19 @@ describe('adapter', function () {
       assert.instanceOf(subMappingValue.meta.get('sourceMap'), SourceMapElement);
     });
   });
+
+  context('detectionRegExp', function () {
+    specify('should detect version ranges in forward compatible way', function () {
+      assert.isTrue(adapter.detectionRegExp.test('openapi: 3.1.0'));
+      assert.isTrue(adapter.detectionRegExp.test('openapi: 3.1.1'));
+      assert.isTrue(adapter.detectionRegExp.test('openapi: 3.1.15'));
+    });
+
+    specify('should reject invalid version ranges', function () {
+      assert.isFalse(adapter.detectionRegExp.test('openapi: 3.0.0'));
+      assert.isFalse(adapter.detectionRegExp.test('openapi: 3.0.1'));
+      assert.isFalse(adapter.detectionRegExp.test('openapi: 3.01.0'));
+      assert.isFalse(adapter.detectionRegExp.test('openapi: 3.1.01'));
+    });
+  });
 });


### PR DESCRIPTION
This relates for following adapters:
- asyncapi-json-2
- asyncapi-yaml-2
- openapi-json-3-1
- openapi-yaml-3-1

Refs #1741