### PR TITLE
test(reference): add tests for dereference over HTTP

### DIFF
--- a/packages/apidom-reference/test/dereference/strategies/asyncapi-2/reference-object/dereference-apidom.ts
+++ b/packages/apidom-reference/test/dereference/strategies/asyncapi-2/reference-object/dereference-apidom.ts
@@ -8,44 +8,149 @@ import {
 import { evaluate } from '@swagger-api/apidom-json-pointer';
 
 import { parse, dereferenceApiDOM } from '../../../../../src';
+import { ServerTerminable, createHTTPServer } from '../../../../helpers';
 
 describe('dereference', function () {
   context('strategies', function () {
     context('asyncapi-2', function () {
       context('Reference Object', function () {
         context('given single ReferenceElement passed to dereferenceApiDOM', function () {
-          const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+          context('given dereferencing using local file system', function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
 
-          specify('should dereference', async function () {
-            const parseResult = await parse(fixturePath, {
-              parse: { mediaType: mediaTypes.latest('json') },
-            });
-            const referenceElement = evaluate(
-              '/components/parameters/externalRef',
-              parseResult.api as AsyncApi2Element,
-            );
-            const dereferenced = await dereferenceApiDOM(referenceElement, {
-              parse: { mediaType: mediaTypes.latest('json') },
-              resolve: { baseURI: fixturePath },
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as AsyncApi2Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: fixturePath },
+              });
+
+              assert.isTrue(isParameterElement(dereferenced));
             });
 
-            assert.isTrue(isParameterElement(dereferenced));
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as AsyncApi2Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: fixturePath },
+              });
+
+              assert.match(
+                dereferenced.meta.get('ref-origin').toValue(),
+                /external-only\/ex\.json$/,
+              );
+            });
           });
 
-          specify('should dereference and contain metadata about origin', async function () {
-            const parseResult = await parse(fixturePath, {
-              parse: { mediaType: mediaTypes.latest('json') },
-            });
-            const referenceElement = evaluate(
-              '/components/parameters/externalRef',
-              parseResult.api as AsyncApi2Element,
-            );
-            const dereferenced = await dereferenceApiDOM(referenceElement, {
-              parse: { mediaType: mediaTypes.latest('json') },
-              resolve: { baseURI: fixturePath },
+          context('given dereferencing using HTTP protocol', function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+            const httpPort = 8123;
+            let httpServer: ServerTerminable;
+
+            beforeEach(function () {
+              const cwd = path.join(__dirname, 'fixtures', 'external-only');
+              httpServer = createHTTPServer({ port: httpPort, cwd });
             });
 
-            assert.match(dereferenced.meta.get('ref-origin').toValue(), /external-only\/ex\.json$/);
+            afterEach(async function () {
+              await httpServer.terminate();
+            });
+
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as AsyncApi2Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.isTrue(isParameterElement(dereferenced));
+            });
+
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as AsyncApi2Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
+            });
+          });
+
+          context('given dereferencing using HTTP protocol and absolute URLs', function () {
+            const fixturePath = path.join(
+              __dirname,
+              'fixtures',
+              'external-only-absolute-url',
+              'root.json',
+            );
+            const httpPort = 8123;
+            let httpServer: ServerTerminable;
+
+            beforeEach(function () {
+              const cwd = path.join(__dirname, 'fixtures', 'external-only-absolute-url');
+              httpServer = createHTTPServer({ port: httpPort, cwd });
+            });
+
+            afterEach(async function () {
+              await httpServer.terminate();
+            });
+
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as AsyncApi2Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.isTrue(isParameterElement(dereferenced));
+            });
+
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as AsyncApi2Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
+            });
           });
         });
       });

--- a/packages/apidom-reference/test/dereference/strategies/asyncapi-2/reference-object/fixtures/external-only-absolute-url/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/asyncapi-2/reference-object/fixtures/external-only-absolute-url/dereferenced.json
@@ -1,0 +1,15 @@
+[
+  {
+    "asyncapi": "2.4.0",
+    "components": {
+      "parameters": {
+        "externalRef": {
+          "description": "external parameter",
+          "schema": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/asyncapi-2/reference-object/fixtures/external-only-absolute-url/ex.json
+++ b/packages/apidom-reference/test/dereference/strategies/asyncapi-2/reference-object/fixtures/external-only-absolute-url/ex.json
@@ -1,0 +1,8 @@
+{
+  "externalParameter": {
+    "description": "external parameter",
+    "schema": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/asyncapi-2/reference-object/fixtures/external-only-absolute-url/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/asyncapi-2/reference-object/fixtures/external-only-absolute-url/root.json
@@ -1,0 +1,10 @@
+{
+  "asyncapi": "2.4.0",
+  "components": {
+    "parameters": {
+      "externalRef": {
+        "$ref": "http://localhost:8123/ex.json#/externalParameter"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/reference-object/dereference-apidom.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/reference-object/dereference-apidom.ts
@@ -8,44 +8,149 @@ import {
 import { evaluate } from '@swagger-api/apidom-json-pointer';
 
 import { parse, dereferenceApiDOM } from '../../../../../src';
+import { ServerTerminable, createHTTPServer } from '../../../../helpers';
 
 describe('dereference', function () {
   context('strategies', function () {
-    context('openapi-3-0', function () {
+    context('openapi-3-o', function () {
       context('Reference Object', function () {
         context('given single ReferenceElement passed to dereferenceApiDOM', function () {
-          const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+          context('given dereferencing using local file system', function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
 
-          specify('should dereference', async function () {
-            const parseResult = await parse(fixturePath, {
-              parse: { mediaType: mediaTypes.latest('json') },
-            });
-            const referenceElement = evaluate(
-              '/components/parameters/externalRef',
-              parseResult.api as OpenApi3_0Element,
-            );
-            const dereferenced = await dereferenceApiDOM(referenceElement, {
-              parse: { mediaType: mediaTypes.latest('json') },
-              resolve: { baseURI: fixturePath },
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_0Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: fixturePath },
+              });
+
+              assert.isTrue(isParameterElement(dereferenced));
             });
 
-            assert.isTrue(isParameterElement(dereferenced));
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_0Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: fixturePath },
+              });
+
+              assert.match(
+                dereferenced.meta.get('ref-origin').toValue(),
+                /external-only\/ex\.json$/,
+              );
+            });
           });
 
-          specify('should dereference and contain metadata about origin', async function () {
-            const parseResult = await parse(fixturePath, {
-              parse: { mediaType: mediaTypes.latest('json') },
-            });
-            const referenceElement = evaluate(
-              '/components/parameters/externalRef',
-              parseResult.api as OpenApi3_0Element,
-            );
-            const dereferenced = await dereferenceApiDOM(referenceElement, {
-              parse: { mediaType: mediaTypes.latest('json') },
-              resolve: { baseURI: fixturePath },
+          context('given dereferencing using HTTP protocol', function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+            const httpPort = 8123;
+            let httpServer: ServerTerminable;
+
+            beforeEach(function () {
+              const cwd = path.join(__dirname, 'fixtures', 'external-only');
+              httpServer = createHTTPServer({ port: httpPort, cwd });
             });
 
-            assert.match(dereferenced.meta.get('ref-origin').toValue(), /external-only\/ex\.json$/);
+            afterEach(async function () {
+              await httpServer.terminate();
+            });
+
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_0Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.isTrue(isParameterElement(dereferenced));
+            });
+
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_0Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
+            });
+          });
+
+          context('given dereferencing using HTTP protocol and absolute URLs', function () {
+            const fixturePath = path.join(
+              __dirname,
+              'fixtures',
+              'external-only-absolute-url',
+              'root.json',
+            );
+            const httpPort = 8123;
+            let httpServer: ServerTerminable;
+
+            beforeEach(function () {
+              const cwd = path.join(__dirname, 'fixtures', 'external-only-absolute-url');
+              httpServer = createHTTPServer({ port: httpPort, cwd });
+            });
+
+            afterEach(async function () {
+              await httpServer.terminate();
+            });
+
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_0Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.isTrue(isParameterElement(dereferenced));
+            });
+
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_0Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
+            });
           });
         });
       });

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/reference-object/fixtures/external-only-absolute-url/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/reference-object/fixtures/external-only-absolute-url/dereferenced.json
@@ -1,0 +1,15 @@
+[
+  {
+    "openapi": "3.0.3",
+    "components": {
+      "parameters": {
+        "externalRef": {
+          "name": "externalParameter",
+          "in": "query",
+          "description": "this is parameter stored in external file",
+          "required": true
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/reference-object/fixtures/external-only-absolute-url/ex.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/reference-object/fixtures/external-only-absolute-url/ex.json
@@ -1,0 +1,8 @@
+{
+  "externalParameter": {
+    "name": "externalParameter",
+    "in": "query",
+    "description": "this is parameter stored in external file",
+    "required": true
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/reference-object/fixtures/external-only-absolute-url/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/reference-object/fixtures/external-only-absolute-url/root.json
@@ -1,0 +1,10 @@
+{
+  "openapi": "3.0.3",
+  "components": {
+    "parameters": {
+       "externalRef": {
+        "$ref": "http://localhost:8123/ex.json#/externalParameter"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/dereference-apidom.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/dereference-apidom.ts
@@ -8,44 +8,149 @@ import {
 import { evaluate } from '@swagger-api/apidom-json-pointer';
 
 import { parse, dereferenceApiDOM } from '../../../../../src';
+import { ServerTerminable, createHTTPServer } from '../../../../helpers';
 
 describe('dereference', function () {
   context('strategies', function () {
     context('openapi-3-1', function () {
       context('Reference Object', function () {
         context('given single ReferenceElement passed to dereferenceApiDOM', function () {
-          const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+          context('given dereferencing using local file system', function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
 
-          specify('should dereference', async function () {
-            const parseResult = await parse(fixturePath, {
-              parse: { mediaType: mediaTypes.latest('json') },
-            });
-            const referenceElement = evaluate(
-              '/components/parameters/externalRef',
-              parseResult.api as OpenApi3_1Element,
-            );
-            const dereferenced = await dereferenceApiDOM(referenceElement, {
-              parse: { mediaType: mediaTypes.latest('json') },
-              resolve: { baseURI: fixturePath },
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_1Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: fixturePath },
+              });
+
+              assert.isTrue(isParameterElement(dereferenced));
             });
 
-            assert.isTrue(isParameterElement(dereferenced));
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_1Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: fixturePath },
+              });
+
+              assert.match(
+                dereferenced.meta.get('ref-origin').toValue(),
+                /external-only\/ex\.json$/,
+              );
+            });
           });
 
-          specify('should dereference and contain metadata about origin', async function () {
-            const parseResult = await parse(fixturePath, {
-              parse: { mediaType: mediaTypes.latest('json') },
-            });
-            const referenceElement = evaluate(
-              '/components/parameters/externalRef',
-              parseResult.api as OpenApi3_1Element,
-            );
-            const dereferenced = await dereferenceApiDOM(referenceElement, {
-              parse: { mediaType: mediaTypes.latest('json') },
-              resolve: { baseURI: fixturePath },
+          context('given dereferencing using HTTP protocol', function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+            const httpPort = 8123;
+            let httpServer: ServerTerminable;
+
+            beforeEach(function () {
+              const cwd = path.join(__dirname, 'fixtures', 'external-only');
+              httpServer = createHTTPServer({ port: httpPort, cwd });
             });
 
-            assert.match(dereferenced.meta.get('ref-origin').toValue(), /external-only\/ex\.json$/);
+            afterEach(async function () {
+              await httpServer.terminate();
+            });
+
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_1Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.isTrue(isParameterElement(dereferenced));
+            });
+
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_1Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
+            });
+          });
+
+          context('given dereferencing using HTTP protocol and absolute URLs', function () {
+            const fixturePath = path.join(
+              __dirname,
+              'fixtures',
+              'external-only-absolute-url',
+              'root.json',
+            );
+            const httpPort = 8123;
+            let httpServer: ServerTerminable;
+
+            beforeEach(function () {
+              const cwd = path.join(__dirname, 'fixtures', 'external-only-absolute-url');
+              httpServer = createHTTPServer({ port: httpPort, cwd });
+            });
+
+            afterEach(async function () {
+              await httpServer.terminate();
+            });
+
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_1Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.isTrue(isParameterElement(dereferenced));
+            });
+
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const referenceElement = evaluate(
+                '/components/parameters/externalRef',
+                parseResult.api as OpenApi3_1Element,
+              );
+              const dereferenced = await dereferenceApiDOM(referenceElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+              });
+
+              assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
+            });
           });
         });
       });

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/fixtures/external-only-absolute-url/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/fixtures/external-only-absolute-url/dereferenced.json
@@ -1,0 +1,15 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "parameters": {
+        "externalRef": {
+          "name": "externalParameter",
+          "in": "query",
+          "description": "external ref",
+          "required": true
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/fixtures/external-only-absolute-url/ex.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/fixtures/external-only-absolute-url/ex.json
@@ -1,0 +1,8 @@
+{
+  "externalParameter": {
+    "name": "externalParameter",
+    "in": "query",
+    "description": "this is parameter stored in external file",
+    "required": true
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/fixtures/external-only-absolute-url/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/fixtures/external-only-absolute-url/root.json
@@ -1,0 +1,11 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "parameters": {
+       "externalRef": {
+        "$ref": "http://localhost:8123/ex.json#/externalParameter",
+        "description": "external ref"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/helpers.ts
+++ b/packages/apidom-reference/test/helpers.ts
@@ -1,5 +1,37 @@
 import fs from 'node:fs';
+import http, { Server } from 'node:http';
+import path from 'node:path';
+import process from 'node:process';
+
+export type ServerTerminable = Server & {
+  terminate: () => Promise<ServerTerminable>;
+};
 
 export const loadFile = (uri: string) => fs.readFileSync(uri).toString();
 
 export const loadJsonFile = (uri: string) => JSON.parse(loadFile(uri));
+
+export const createHTTPServer = ({ port = 8123, cwd = process.cwd() } = {}): ServerTerminable => {
+  const server: ServerTerminable = http.createServer((req, res) => {
+    const filePath = path.join(cwd, req.url || '/favicon.ico');
+
+    if (!fs.existsSync(filePath)) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not found');
+      return;
+    }
+
+    const data = fs.readFileSync(filePath).toString();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(data);
+  }) as ServerTerminable;
+
+  server.listen(port);
+
+  server.terminate = () =>
+    new Promise((resolve) => {
+      server.close(() => resolve(server));
+    });
+
+  return server;
+};


### PR DESCRIPTION
Test are created for Reference Object from
following specifications:

- OpenAPI 3.0.x
- OpenAPI 3.1.x
- AsyncAPI 2.x.y

Refs #1969
