### PR TITLE
feat(ls): oas31 docs for header object

### DIFF
--- a/packages/apidom-ls/src/config/openapi/config.ts
+++ b/packages/apidom-ls/src/config/openapi/config.ts
@@ -1,8 +1,8 @@
-import infoMeta from './info/meta';
 import contactMeta from './contact/meta';
-import licenseMeta from './license/meta';
-import tagMeta from './tag/meta';
 import externalDocumentationMeta from './external-documentation/meta';
+import headerMeta from './header/meta';
+import infoMeta from './info/meta';
+import licenseMeta from './license/meta';
 import operationMeta from './operation/meta';
 import parameterMeta from './parameter/meta';
 import pathItemMeta from './path-item/meta';
@@ -11,6 +11,7 @@ import responseMeta from './response/meta';
 import responsesMeta from './responses/meta';
 import serverMeta from './server/meta';
 import serverVariableMeta from './server-variable/meta';
+import tagMeta from './tag/meta';
 import openapi3_1Meta from './openapi3_1/meta';
 import schemaMeta from '../common/schema/meta';
 import ApilintCodes from '../codes';
@@ -28,10 +29,11 @@ export default {
       },
     ],
   },
-  info: infoMeta,
   contact: contactMeta,
+  externalDocumentation: externalDocumentationMeta,
+  header: headerMeta,
+  info: infoMeta,
   license: licenseMeta,
-  schema: schemaMeta,
   operation: operationMeta,
   parameter: parameterMeta,
   parameters: parameterMeta,
@@ -42,6 +44,6 @@ export default {
   server: serverMeta,
   serverVariable: serverVariableMeta,
   tag: tagMeta,
-  externalDocumentation: externalDocumentationMeta,
   openApi3_1: openapi3_1Meta,
+  schema: schemaMeta,
 };

--- a/packages/apidom-ls/src/config/openapi/header/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/header/documentation.ts
@@ -1,0 +1,15 @@
+const documentation = [
+  // todo: copy the paramter targets with the required changes.
+  // but: should we copy & replace `parameter` text with `header`?
+  // and do we remove links, even though there isn't a direct equivalent for the header docs?
+  {
+    // this "raw" doc wouldn't appear anywhere in Docs. always part of a Map
+    // Link expect a link name e.g. `address` # the target link operationId
+    // Media-Type expect something like `application/json`
+    // Callback expect a callback name e.g. `myCallback`
+    // Encoding ok.
+    docs: '#### Header Object\n\nThe Header Object follows the structure of the [Parameter Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterObject) with the following changes:\n\n 1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.\n  2. `in` MUST NOT be specified, it is implicitly in `header`.\n  3. All traits that are affected by the location MUST be applicable to a location of `header` (for example, [`style`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterStyle)).\n\n##### Header Object Example\n\n\\\nA simple header of type `integer`:\n\n\\\nJSON\n```json\n{\n  "description": "The number of allowed requests in the current period",\n  "schema": {\n    "type": "integer"\n  }\n}\n```\n\n\\\nYAML\n```yaml\ndescription: The number of allowed requests in the current period\nschema:\n  type: integer\n```\n',
+  },
+];
+
+export default documentation;

--- a/packages/apidom-ls/src/config/openapi/header/meta.ts
+++ b/packages/apidom-ls/src/config/openapi/header/meta.ts
@@ -1,0 +1,8 @@
+import documentation from './documentation';
+import { FormatMeta } from '../../../apidom-language-types';
+
+const meta: FormatMeta = {
+  documentation,
+};
+
+export default meta;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

OAS3.1 documentation for `Header` Object

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Closes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Ref: #1992 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local

fixture:
```yaml
openapi: 3.1.0
info:
  title: deref
  version: 1.0.0
paths:
  /a:
    get:
      operationId: aget
      responses:
        '200':
          description: a pet to be returned
          headers:
            X-RateLimit-Limit:
              description: Request limit per hour
              schema:
                type: integer
              example: 100
```

### Screenshots (if appropriate):

![ls-pr-2000-header-1](https://user-images.githubusercontent.com/12902658/189742096-0d477338-213e-44fd-9f76-d58258047693.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains...
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
