### PR TITLE
feat(ls): docs for OpenApi 3.1.0 OAuth Flow and OAuth Flows objects

### DIFF
--- a/packages/apidom-ls/src/config/openapi/config.ts
+++ b/packages/apidom-ls/src/config/openapi/config.ts
@@ -6,6 +6,8 @@ import headerMeta from './header/meta';
 import infoMeta from './info/meta';
 import licenseMeta from './license/meta';
 import linkMeta from './link/meta';
+import oauthFlowMeta from './oauth-flow/meta';
+import oauthFlowsMeta from './oauth-flows/meta';
 import operationMeta from './operation/meta';
 import parameterMeta from './parameter/meta';
 import pathItemMeta from './path-item/meta';
@@ -40,6 +42,8 @@ export default {
   info: infoMeta,
   license: licenseMeta,
   link: linkMeta,
+  oAuthFlow: oauthFlowMeta,
+  oAuthFlows: oauthFlowsMeta,
   operation: operationMeta,
   parameter: parameterMeta,
   parameters: parameterMeta,

--- a/packages/apidom-ls/src/config/openapi/oauth-flow/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/oauth-flow/documentation.ts
@@ -1,0 +1,24 @@
+const documentation = [
+  {
+    target: 'authorizationUrl',
+    docs: '#### Applies To\n`oauth2` (`"implicit"`, `"authorizationCode"`)\n\n\\\n**REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.',
+  },
+  {
+    target: 'tokenUrl',
+    docs: '#### Applies To\n`oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`)\n\n\\\n**REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.',
+  },
+  {
+    target: 'refreshUrl',
+    docs: '#### Applies To\n`oauth2`\n\n\\\nThe URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.',
+  },
+  {
+    target: 'scopes',
+    docs: 'Map[`string`, `string`]\n#### Applies To\noauth2\n\n\\\n**REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. The map MAY be empty.',
+  },
+  {
+    docs: '#### OAuth Flow Object\nConfiguration details for a supported OAuth Flow\n##### Fixed Fields\nField Name | Type | Applies To | Description\n---|:---:|---|:---\nauthorizationUrl | `string` | `oauth2` (`"implicit"`, `"authorizationCode"`) | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.\ntokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.\nrefreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2 standard requires the use of TLS.\nscopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it. The map MAY be empty.\n\n\\\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions).\n##### OAuth Flow Object Examples\n\n\\\nJSON\n```json\n{\n  "type": "oauth2",\n  "flows": {\n    "implicit": {\n      "authorizationUrl": "https://example.com/api/oauth/dialog",\n      "scopes": {\n        "write:pets": "modify pets in your account",\n        "read:pets": "read your pets"\n      }\n    },\n    "authorizationCode": {\n      "authorizationUrl": "https://example.com/api/oauth/dialog",\n      "tokenUrl": "https://example.com/api/oauth/token",\n      "scopes": {\n        "write:pets": "modify pets in your account",\n        "read:pets": "read your pets"\n      }\n    }\n  }\n}\n```\n\n\n\\\nYAML\n```yaml\ntype: oauth2\nflows: \n  implicit:\n    authorizationUrl: https://example.com/api/oauth/dialog\n    scopes:\n      write:pets: modify pets in your account\n      read:pets: read your pets\n  authorizationCode:\n    authorizationUrl: https://example.com/api/oauth/dialog\n    tokenUrl: https://example.com/api/oauth/token\n    scopes:\n      write:pets: modify pets in your account\n      read:pets: read your pets\n```\n',
+    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  },
+];
+
+export default documentation;

--- a/packages/apidom-ls/src/config/openapi/oauth-flow/meta.ts
+++ b/packages/apidom-ls/src/config/openapi/oauth-flow/meta.ts
@@ -1,0 +1,8 @@
+import documentation from './documentation';
+import { FormatMeta } from '../../../apidom-language-types';
+
+const meta: FormatMeta = {
+  documentation,
+};
+
+export default meta;

--- a/packages/apidom-ls/src/config/openapi/oauth-flows/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/oauth-flows/documentation.ts
@@ -1,0 +1,32 @@
+const documentation = [
+  /**
+   * The following Fixed Fields are provided as reference, but are more
+   * comprehensively described by parent OAuth Flow Object meta documentation
+   */
+  // {
+  //   target: 'implicit',
+  //   docs: 'Configuration for the OAuth Implicit flow',
+  //   targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  // },
+  // {
+  //   target: 'password',
+  //   docs: 'Configuration for the OAuth Resource Owner Password flow',
+  //   targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  // },
+  // {
+  //   target: 'clientCredentials',
+  //   docs: 'Configuration for the OAuth Client Credentials flow. Previously called `application` in OpenAPI 2.0.',
+  //   targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  // },
+  // {
+  //   target: 'authorizationCode',
+  //   docs: 'Configuration for the OAuth Authorization Code flow. Previously called `accessCode` in OpenAPI 2.0.',
+  //   targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  // },
+  {
+    docs: '#### OAuth Flows Object\nAllows configuration of the supported OAuth Flows.\n\n##### Fixed Fields\n\nField Name | Type | Description\n---|:---:|---\nimplicit | [OAuth Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oauthFlowObject) | Configuration for the OAuth Implicit flow\npassword | [OAuth Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oauthFlowObject) | Configuration for the OAuth Resource Owner Password flow\nclientCredentials | [OAuth Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oauthFlowObject) | Configuration for the OAuth Client Credentials flow. Previously called `application` in OpenAPI 2.0.\nauthorizationCode | [OAuth Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oauthFlowObject) | Configuration for the OAuth Authorization Code flow. Previously called `accessCode` in OpenAPI 2.0.\n\n\\\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions).\n',
+    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  },
+];
+
+export default documentation;

--- a/packages/apidom-ls/src/config/openapi/oauth-flows/meta.ts
+++ b/packages/apidom-ls/src/config/openapi/oauth-flows/meta.ts
@@ -1,0 +1,8 @@
+import documentation from './documentation';
+import { FormatMeta } from '../../../apidom-language-types';
+
+const meta: FormatMeta = {
+  documentation,
+};
+
+export default meta;


### PR DESCRIPTION
Ref: #1995,  #1996 
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Documentation for OpenApi 3.1.0 `OAuth Flows` Object and `OAuth Flow` Object

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Closes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Ref: #1995 
Ref: #1996 


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local.

fixture:

```yaml
openapi: 3.1.0
info:
  title: deref
  version: 1.0.0
components:
  securitySchemes:
    oauth2-server:
      type: oauth2
      flows:
        authorizationCode:
          authorizationUrl: 'https://some-url.com/auth'
          tokenUrl: 'https://some-url/token'
          refreshUrl: 'https://some-url/token'
          scopes:
            user: allows user resources
            admin: allows admin resources
```

### Screenshots (if appropriate):

`OAuth Flows`:
![ls-pr-2011-oauth-flows-1](https://user-images.githubusercontent.com/12902658/190262258-619658d6-13f7-4f38-ad44-15b8223942f7.png)

`OAuth Flow`
![ls-pr-2011-oauth-flow-1](https://user-images.githubusercontent.com/12902658/190262244-788b08ad-5175-4f3d-a119-44af1e727fab.png)

`OAuth Flow` target:
![ls-pr-2011-oauth-flow-2-target](https://user-images.githubusercontent.com/12902658/190262230-b936e6d5-4e83-432d-9a68-e8c9f907f0d6.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains...
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
