### PR TITLE
feat(ls): docs for OpenApi 3.1.0 Discriminator object

### DIFF
--- a/packages/apidom-ls/src/config/openapi/config.ts
+++ b/packages/apidom-ls/src/config/openapi/config.ts
@@ -1,6 +1,7 @@
 import callbackMeta from './callback/meta';
 import componentsMeta from './components/meta';
 import contactMeta from './contact/meta';
+import discriminatorMeta from './discriminator/meta';
 import encodingMeta from './encoding/meta';
 import exampleMeta from './example/meta';
 import externalDocumentationMeta from './external-documentation/meta';
@@ -44,6 +45,7 @@ export default {
   callback: callbackMeta,
   components: componentsMeta,
   contact: contactMeta,
+  discriminator: discriminatorMeta,
   encoding: encodingMeta,
   example: exampleMeta,
   externalDocumentation: externalDocumentationMeta,

--- a/packages/apidom-ls/src/config/openapi/discriminator/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/discriminator/documentation.ts
@@ -1,0 +1,23 @@
+const documentation = [
+  {
+    target: 'propertyName',
+    docs: '**REQUIRED**. The name of the property in the payload that will hold the discriminator value.',
+  },
+  {
+    target: 'mapping',
+    docs: 'Map[`string`, `string`]\n\\\n\\\nAn object to hold mappings between payload values and schema names or references.',
+  },
+  {
+    /**
+     * The original documentation has been trimmed in this implementation for readability purposes
+     * A new custom section `Additional documentation topics` has been added,
+     * which refers the reader to the source documentation for additional explanations
+     * Also note, we are cherry picking the documentation section about
+     * `Composition and Inheritance (Polymorphism)`from outside of the Discriminator Object
+     * source documentation.
+     */
+    docs: '#### [Discriminator Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#discriminator-object)\n\nWhen request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the document of an alternative schema based on the value associated with it.\n\n\\\nWhen using the discriminator, _inline_ schemas will not be considered.\n\n##### Fixed Fields\nField Name | Type | Description\n---|:---:|---\npropertyName | `string` | **REQUIRED**. The name of the property in the payload that will hold the discriminator value.\nmapping | Map[`string`, `string`] | An object to hold mappings between payload values and schema names or references.\n\n\\\nThis object MAY be extended with [Specification Extensions](#specificationExtensihttps://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions).\n\n\\\nThe discriminator object is legal only when using one of the composite keywords `oneOf`, `anyOf`, `allOf`.\n\n##### [Composition and Inheritance (Polymorphism)](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#composition-and-inheritance-polymorphism)\n\nThe OpenAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.\n`allOf` takes an array of object definitions that are validated *independently* but together compose a single object.\n\n\\\nWhile composition offers model extensibility, it does not imply a hierarchy between the models.\nTo support polymorphism, the OpenAPI Specification adds the `discriminator` field.\nWhen used, the `discriminator` will be the name of the property that decides which schema definition validates the structure of the model.\nAs such, the `discriminator` field MUST be a required field.\nThere are two ways to define the value of a discriminator for an inheriting instance.\n- Use the schema name.\n- Override the schema name by overriding the property with a new value. If a new value exists, this takes precedence over the schema name.\nAs such, inline schema definitions, which do not have a given id, *cannot* be used in polymorphism.\n\n#### Additional documentation topics\n\nFurther explanations of usage can be found in the source documentation for the [Discriminator Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#discriminator-object)\n',
+  },
+];
+
+export default documentation;

--- a/packages/apidom-ls/src/config/openapi/discriminator/meta.ts
+++ b/packages/apidom-ls/src/config/openapi/discriminator/meta.ts
@@ -1,0 +1,8 @@
+import documentation from './documentation';
+import { FormatMeta } from '../../../apidom-language-types';
+
+const meta: FormatMeta = {
+  documentation,
+};
+
+export default meta;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

- Add documentation for OpenApi 3.1.0 Discriminator Object.
- add custom section for `Additional documentation topics` that provide external links for further reading.

- documentation trimmed per recommendations from https://github.com/swagger-api/apidom/issues/2041#issuecomment-1251822763

@frantuma 
possible todo: add additional context reasoning comments, per https://github.com/swagger-api/apidom/issues/2041#issuecomment-1252058475 

@char0n 
Related issue 1: the `parent` screenshot below required changing this [line](https://github.com/swagger-api/apidom/blob/1bc927e8772711fdbd90f731ff4f330fc6946a3e/packages/apidom-ls/src/config/common/schema/documentation.ts#L175) to include `targetSpec` for AsyncApi

Also another issue 2: visible in the `target` screenshot below, is that the current linter incorrectly states that the `discriminator` must be a string. However at least for OpenAPI 3.1.0, it's supposed to be an object, not a string.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Closes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Ref: #2041 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local.

fixture:

```yaml
openapi: 3.1.0
info:
  title: deref
  version: 1.0.0
components:
  schemas:
    Pet:
      type: object
      required:
      - petType
      properties:
        petType:
          type: string
      discriminator:
        propertyName: petType
        mapping:
          dog: Dog
```

### Screenshots (if appropriate):

parent (after fix mentioned in above description):

![ls-pr-2051-discriminator-1](https://user-images.githubusercontent.com/12902658/191379238-1b216462-4c74-4214-ad5b-5f8a18eefea3.png)


target:

![ls-pr-2051-discriminator-2-target](https://user-images.githubusercontent.com/12902658/191379253-6a886eec-a267-4a35-b4d1-909148b70d2a.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains...
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
