### PR TITLE
fix(ns-openapi-3-0): drop support of extensions from Discriminator

### DIFF
--- a/packages/apidom-ns-openapi-3-0/src/refractor/visitors/open-api-3-0/distriminator/index.ts
+++ b/packages/apidom-ns-openapi-3-0/src/refractor/visitors/open-api-3-0/distriminator/index.ts
@@ -8,7 +8,7 @@ import FixedFieldsVisitor from '../../generics/FixedFieldsVisitor';
 const DiscriminatorVisitor = stampit(FixedFieldsVisitor, FallbackVisitor, {
   props: {
     specPath: always(['document', 'objects', 'Discriminator']),
-    canSupportSpecificationExtensions: true,
+    canSupportSpecificationExtensions: false,
   },
   init() {
     this.element = new DiscriminatorElement();

--- a/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/distriminator/index.ts
+++ b/packages/apidom-ns-openapi-3-1/src/refractor/visitors/open-api-3-1/distriminator/index.ts
@@ -14,6 +14,9 @@ const {
 } = OpenApi3_1Specification;
 
 const DiscriminatorVisitor = stampit(BaseDiscriminatorVisitor, {
+  props: {
+    canSupportSpecificationExtensions: true,
+  },
   init() {
     this.element = new DiscriminatorElement();
   },


### PR DESCRIPTION
OpenAPI 3.0.x Discriminator Object doesn't allow using Specification extension inside it.
OpenAPI 3.1.0 Discriminator Object does allow using Specification extension inside it.

This PR fixes the namespace refractor to reflect this.