### PR TITLE
fix(apidom-ls): fix OAS example value/externalValue rule

### DIFF
--- a/packages/apidom-ls/src/config/openapi/example/lint/value--mutually-exclusive.ts
+++ b/packages/apidom-ls/src/config/openapi/example/lint/value--mutually-exclusive.ts
@@ -6,9 +6,10 @@ const valueMutuallyExclusiveLint: LinterMeta = {
   source: 'apilint',
   message: 'The value field and externalValue field are mutually exclusive.',
   severity: 1,
-  linterFunction: 'allowedFields',
-  linterParams: [['summary', 'description', 'externalValue'], 'x-'],
+  linterFunction: 'missingFields',
+  linterParams: [['value']],
   marker: 'key',
+  markerTarget: 'value',
   conditions: [
     {
       function: 'existFields',

--- a/packages/apidom-ls/test/fixtures/validation/oas/issue2141.yaml
+++ b/packages/apidom-ls/test/fixtures/validation/oas/issue2141.yaml
@@ -1,0 +1,38 @@
+openapi: 3.1.0
+info:
+  title: deref
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+    url: http://should.not.exist.with.identifier.com
+
+paths:
+  /a:
+    get:
+      operationId: aget
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                confirmation-success:
+                  summary: short confirmation success
+                  value: testString
+                  externalValue: outsideLink
+                confirmation-error:
+                  summary: short confirmation success
+                  value: 
+                    test: object
+                  externalValue: outsideLink                  
+                confirmation-errors:
+                  summary: short confirmation success
+                  value:
+                    - test1
+                    - test2
+                  externalValue: outsideLink
+                confirmation-noerror:
+                  summary: short confirmation success
+                  value: testString

--- a/packages/apidom-ls/test/validate.ts
+++ b/packages/apidom-ls/test/validate.ts
@@ -97,6 +97,12 @@ describe('apidom-ls-validate', function () {
     logLevel,
   };
 
+  const contextNoSchema: LanguageServiceContext = {
+    metadata: metadata(),
+    performanceLogs: logPerformance,
+    logLevel,
+  };
+
   it('test validation for asyncapi and openapi', async function () {
     const validationContext: ValidationContext = {
       comments: DiagnosticSeverity.Error,
@@ -2839,6 +2845,77 @@ describe('apidom-ls-validate', function () {
           },
         },
         severity: 1,
+        source: 'apilint',
+      },
+    ];
+    assert.deepEqual(result, expected as Diagnostic[]);
+
+    languageService.terminate();
+  });
+
+  it('oas / yaml - test issue 2141 / example value', async function () {
+    const validationContext: ValidationContext = {
+      comments: DiagnosticSeverity.Error,
+      maxNumberOfProblems: 100,
+      relatedInformation: false,
+    };
+
+    const spec = fs
+      .readFileSync(path.join(__dirname, 'fixtures', 'validation', 'oas', 'issue2141.yaml'))
+      .toString();
+
+    const doc: TextDocument = TextDocument.create('foo://bar/issue2141.yaml', 'yaml', 0, spec);
+
+    const languageService: LanguageService = getLanguageService(contextNoSchema);
+
+    const result = await languageService.doValidation(doc, validationContext);
+    const expected: Diagnostic[] = [
+      {
+        range: {
+          start: {
+            line: 22,
+            character: 18,
+          },
+          end: {
+            line: 22,
+            character: 23,
+          },
+        },
+        message: 'The value field and externalValue field are mutually exclusive.',
+        severity: 1,
+        code: 5200300,
+        source: 'apilint',
+      },
+      {
+        range: {
+          start: {
+            line: 26,
+            character: 18,
+          },
+          end: {
+            line: 26,
+            character: 23,
+          },
+        },
+        message: 'The value field and externalValue field are mutually exclusive.',
+        severity: 1,
+        code: 5200300,
+        source: 'apilint',
+      },
+      {
+        range: {
+          start: {
+            line: 31,
+            character: 18,
+          },
+          end: {
+            line: 31,
+            character: 23,
+          },
+        },
+        message: 'The value field and externalValue field are mutually exclusive.',
+        severity: 1,
+        code: 5200300,
         source: 'apilint',
       },
     ];


### PR DESCRIPTION
fixes #2141, updating #2146

the following function is better suited for such cases (check for absence of specific field)

```
linterFunction: 'missingFields',
linterParams: [['value']],
```

the following places the marker on the `value` key (not on the parent)

```
  markerTarget: 'value',
```

also added test