### PR TITLE
feat(ls): OpenAPI 3.1.0 lint and completion rules for Server object

### DIFF
--- a/packages/apidom-ls/src/config/openapi/server/completion.ts
+++ b/packages/apidom-ls/src/config/openapi/server/completion.ts
@@ -50,6 +50,20 @@ const completion: ApidomCompletionItem[] = [
       { namespace: 'openapi', version: '3.0.3' },
     ],
   },
+  {
+    label: 'variables',
+    insertText: 'variables',
+    kind: 14,
+    format: CompletionFormat.OBJECT,
+    type: CompletionType.PROPERTY,
+    insertTextFormat: 2,
+    documentation: {
+      kind: 'markdown',
+      value:
+        "Map[`string`, [Server Variable Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#serverVariableObject)]\n\\\n\\\nA map between a variable name and its value. The value is used for substitution in the server's URL template.",
+    },
+    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  },
 ];
 
 export default completion;

--- a/packages/apidom-ls/src/config/openapi/server/lint/variables--values-type.ts
+++ b/packages/apidom-ls/src/config/openapi/server/lint/variables--values-type.ts
@@ -4,7 +4,7 @@ import { LinterMeta } from '../../../../apidom-language-types';
 const variablesValuesTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_O_SERVER_FIELD_VARIABLES_VALUES_TYPE,
   source: 'apilint',
-  message: '"varialbes" members must be Server Variable Object',
+  message: '"variables" members must be Server Variable Object',
   severity: 1,
   linterFunction: 'apilintChildrenOfElementsOrClasses',
   linterParams: [['serverVariable']],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* documentation for `variables` field
* fix typo in lint rule

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Closes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Ref: #2061 
Ref: #2062

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains...
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
