### PR TITLE
feat(reference): add support for file allow list for FileResolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9945,8 +9945,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -30482,6 +30481,7 @@
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.50.0",
         "@types/ramda": "=0.28.17",
         "axios": "=1.1.3",
+        "minimatch": "=5.1.0",
         "process": "=0.11.10",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.3.0",
@@ -30489,6 +30489,25 @@
       },
       "devDependencies": {
         "axios-mock-adapter": "=1.21.2"
+      }
+    },
+    "packages/apidom-reference/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/apidom-reference/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     }
   },
@@ -36074,10 +36093,29 @@
         "@types/ramda": "=0.28.17",
         "axios": "=1.1.3",
         "axios-mock-adapter": "=1.21.2",
+        "minimatch": "=5.1.0",
         "process": "=0.11.10",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.3.0",
         "stampit": "=4.3.2"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@testing-library/dom": {
@@ -38115,8 +38153,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",

--- a/packages/apidom-ls/src/services/definition/definition-service.ts
+++ b/packages/apidom-ls/src/services/definition/definition-service.ts
@@ -92,7 +92,12 @@ export class DefaultDefinitionService implements DefinitionService {
           );
           const dereferenced = await dereferenceApiDOM(node.parent.parent, {
             parse: { mediaType, parserOpts: { sourceMap: true } },
-            resolve: { baseURI: textDocument.uri },
+            resolve: {
+              baseURI: textDocument.uri,
+              resolverOpts: {
+                fileAllowList: ['*'],
+              },
+            },
           });
           debug(
             'definitionService - go to external ref',

--- a/packages/apidom-ls/src/services/deref/deref-service.ts
+++ b/packages/apidom-ls/src/services/deref/deref-service.ts
@@ -70,7 +70,12 @@ export class DefaultDerefService implements DerefService {
 
     // dereference
     const dereferenced = await dereferenceApiDOM(api, {
-      resolve: { baseURI },
+      resolve: {
+        baseURI,
+        resolverOpts: {
+          fileAllowList: ['*'],
+        },
+      },
     });
     const dereferencedValue = toValue(dereferenced);
 

--- a/packages/apidom-ls/src/services/hover/hover-service.ts
+++ b/packages/apidom-ls/src/services/hover/hover-service.ts
@@ -190,7 +190,12 @@ export class DefaultHoverService implements HoverService {
               );
               const dereferenced = await dereferenceApiDOM(node.parent.parent, {
                 parse: { mediaType, parserOpts: { sourceMap: true } },
-                resolve: { baseURI: textDocument.uri },
+                resolve: {
+                  baseURI: textDocument.uri,
+                  resolverOpts: {
+                    fileAllowList: ['*'],
+                  },
+                },
               });
               if (dereferenced) {
                 debug(

--- a/packages/apidom-reference/README.md
+++ b/packages/apidom-reference/README.md
@@ -521,6 +521,46 @@ This resolver plugin is responsible for resolving a local file.
 It detects if the provided URI represents a filesystem path and if so,
 reads the file and provides its content.
 
+**WARNING**: use this plugin with caution, as it can read files from a local file system.
+By default, this plugin will reject to read any files from the local file system, unless
+explicitly provided by **fileAllowList** option.
+
+###### Providing file allow list
+
+File allow list can be provided **globally** as an option to `FileResolver` in form
+of array of *glob patterns* or *regular expressions*.
+
+```js
+import { options, FileResolver, HttpResolverAxios } from '@swagger-api/apidom-reference';
+
+options.resolve.resolvers = [
+  FileResolver({
+    fileAllowList: [
+      '*.json',
+      /\.json$/,
+    ]
+  }),
+  HttpResolverAxios({ timeout: 5000, redirects: 5, withCredentials: false }),
+]
+```
+
+File allow list can also be provided on ad-hoc basis:
+
+```js
+import { resolve } from '@swagger-api/apidom-reference';
+
+await resolve('/home/user/oas.json', {
+  resolve: {
+    resolverOpts: {
+      fileAllowList: [
+        '*.json',
+        /\.json$/,
+      ]
+    },
+  },
+});
+```
+
 ##### [HttpResolverAxios](https://github.com/swagger-api/apidom/blob/main/packages/apidom-reference/src/resolve/resolvers/HttpResolverAxios.ts)
 
 This resolver plugin is responsible for resolving a remove file represented by HTTP(s) URL.

--- a/packages/apidom-reference/package.json
+++ b/packages/apidom-reference/package.json
@@ -62,6 +62,7 @@
     "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.50.0",
     "@types/ramda": "=0.28.17",
     "axios": "=1.1.3",
+    "minimatch": "=5.1.0",
     "process": "=0.11.10",
     "ramda": "=0.28.0",
     "ramda-adjunct": "=3.3.0",

--- a/packages/apidom-reference/src/resolve/resolvers/HttpResolverAxios.ts
+++ b/packages/apidom-reference/src/resolve/resolvers/HttpResolverAxios.ts
@@ -7,7 +7,11 @@ import ResolverError from '../../util/errors/ResolverError';
 import { HttpResolver as IHttpResolver, File as IFile } from '../../types';
 import HttpResolver from './HttpResolver';
 
-const HttpResolverAxios: stampit.Stamp<IHttpResolver> = stampit(HttpResolver).init(
+interface IHttpResolverAxios extends IHttpResolver {
+  getHttpClient(): AxiosInstance;
+}
+
+const HttpResolverAxios: stampit.Stamp<IHttpResolverAxios> = stampit(HttpResolver).init(
   function HttpResolverAxios() {
     /**
      * Private Api.

--- a/packages/apidom-reference/src/resolve/util.ts
+++ b/packages/apidom-reference/src/resolve/util.ts
@@ -13,7 +13,12 @@ import { ResolverError, UnmatchedResolverError } from '../util/errors';
  */
 // eslint-disable-next-line import/prefer-default-export
 export const readFile = async (file: IFile, options: IReferenceOptions): Promise<Buffer> => {
-  const resolvers: IResolver[] = await plugins.filter('canRead', file, options.resolve.resolvers);
+  const optsBoundResolvers: IResolver[] = options.resolve.resolvers.map((resolver) => {
+    const clonedResolver = Object.create(resolver);
+    return Object.assign(clonedResolver, options.resolve.resolverOpts);
+  });
+
+  const resolvers: IResolver[] = await plugins.filter('canRead', file, optsBoundResolvers);
 
   // we couldn't find any resolver for this File
   if (isEmpty(resolvers)) {
@@ -21,10 +26,6 @@ export const readFile = async (file: IFile, options: IReferenceOptions): Promise
   }
 
   try {
-    const optsBoundResolvers = resolvers.map((resolver) => {
-      const clonedResolver = Object.create(resolver);
-      return Object.assign(clonedResolver, options.resolve.resolverOpts);
-    });
     const { result } = await plugins.run('read', [file], optsBoundResolvers);
     return result;
   } catch (error: any) {

--- a/packages/apidom-reference/src/types.ts
+++ b/packages/apidom-reference/src/types.ts
@@ -9,10 +9,14 @@ export interface File {
 }
 
 export interface Resolver {
-  type: string;
+  // name: string; - causing issues with stamps
 
   canRead(file: File): boolean;
   read(file: File): Promise<Buffer>;
+}
+
+export interface FileResolver extends Resolver {
+  fileAllowList: (string | RegExp)[];
 }
 
 export interface HttpResolver extends Resolver {
@@ -24,6 +28,7 @@ export interface HttpResolver extends Resolver {
 }
 
 export interface Parser {
+  // name: string; - causing issues with stamps
   allowEmpty: boolean;
   sourceMap: boolean;
   fileExtensions: string[];

--- a/packages/apidom-reference/test/mocha-bootstrap.cjs
+++ b/packages/apidom-reference/test/mocha-bootstrap.cjs
@@ -5,7 +5,13 @@ const { jestSnapshotPlugin, addSerializer } = require('mocha-chai-jest-snapshot'
 
 const jestApiDOMSerializer = require('../../../scripts/jest-serializer-apidom.cjs');
 const jestStringSerializer = require('../../../scripts/jest-serializer-string.cjs');
+const { options } = require('../src');
 
+// setup snapshot testing
 chai.use(jestSnapshotPlugin());
 addSerializer(jestApiDOMSerializer);
 addSerializer(jestStringSerializer);
+
+// setup allow list for file resolution
+const [fileResolver] = options.resolve.resolvers;
+fileResolver.fileAllowList = ['*'];

--- a/packages/apidom-reference/test/resolve/index.ts
+++ b/packages/apidom-reference/test/resolve/index.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { assert } from 'chai';
 import { mediaTypes } from '@swagger-api/apidom-ns-openapi-3-1';
 
-import { resolve, resolveApiDOM, parse } from '../../src';
+import { resolve, resolveApiDOM, parse, FileResolver } from '../../src';
 import { UnmatchedResolveStrategyError, ResolverError, ParserError } from '../../src/util/errors';
 import OpenApiJson3_1Parser from '../../src/parse/parsers/apidom-reference-parser-openapi-json-3-1';
 
@@ -134,6 +134,31 @@ describe('resolve', function () {
       } catch (error) {
         assert.instanceOf(error, ResolverError);
       }
+    });
+  });
+
+  context('given file allow list is provided as resolver option', function () {
+    specify('should resolve the file', async function () {
+      const uri = path.join(
+        __dirname,
+        'strategies',
+        'openapi-3-1',
+        'reference-object',
+        'fixtures',
+        'external-indirections',
+        'root.json',
+      );
+      const refSet = await resolve(uri, {
+        parse: { mediaType: mediaTypes.latest('json') },
+        resolve: {
+          resolvers: [FileResolver()],
+          resolverOpts: {
+            fileAllowList: ['*'],
+          },
+        },
+      });
+
+      assert.strictEqual(refSet.size, 4);
     });
   });
 

--- a/packages/apidom-reference/test/resolve/resolvers/FileResolver.ts
+++ b/packages/apidom-reference/test/resolve/resolvers/FileResolver.ts
@@ -11,7 +11,7 @@ describe('resolve', function () {
       let resolver: any;
 
       beforeEach(function () {
-        resolver = FileResolver();
+        resolver = FileResolver({ fileAllowList: ['*'] });
       });
 
       context('canRead', function () {
@@ -41,6 +41,54 @@ describe('resolve', function () {
             assert.isFalse(resolver.canRead(File({ uri: 'https://swagger.io/' })));
             assert.isFalse(resolver.canRead(File({ uri: 'http://swagger.io/' })));
             assert.isFalse(resolver.canRead(File({ uri: 'ftp://swagger.io/' })));
+          });
+        });
+
+        context('given paths covered by fileAllowList - glob pattern', function () {
+          specify('should consider it a file system path', function () {
+            resolver = FileResolver({ fileAllowList: ['*.json', '*.yaml'] });
+
+            assert.isTrue(resolver.canRead(File({ uri: '/home/user/file1.json' })));
+            assert.isTrue(resolver.canRead(File({ uri: '/home/user/file2.json' })));
+            assert.isTrue(resolver.canRead(File({ uri: '/home/user/file1.yaml' })));
+            assert.isTrue(resolver.canRead(File({ uri: '/home/user/file2.yaml' })));
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file.txt' })));
+          });
+        });
+
+        context('given paths covered by fileAllowList - regular expression', function () {
+          specify('should consider it a file system path', function () {
+            resolver = FileResolver({ fileAllowList: [/\.json$/, /\.yaml$/] });
+
+            assert.isTrue(resolver.canRead(File({ uri: '/home/user/file1.json' })));
+            assert.isTrue(resolver.canRead(File({ uri: '/home/user/file2.json' })));
+            assert.isTrue(resolver.canRead(File({ uri: '/home/user/file1.yaml' })));
+            assert.isTrue(resolver.canRead(File({ uri: '/home/user/file2.yaml' })));
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file.txt' })));
+          });
+        });
+
+        context('given empty fileAllowList', function () {
+          specify('should not consider anything a file system path', function () {
+            resolver = FileResolver({ fileAllowList: [] });
+
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file1.json' })));
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file2.json' })));
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file1.yaml' })));
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file2.yaml' })));
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file.txt' })));
+          });
+        });
+
+        context('given no fileAllowList provided', function () {
+          specify('should not consider anything a file system path', function () {
+            resolver = FileResolver();
+
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file1.json' })));
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file2.json' })));
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file1.yaml' })));
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file2.yaml' })));
+            assert.isFalse(resolver.canRead(File({ uri: '/home/user/file.txt' })));
           });
         });
       });


### PR DESCRIPTION
Refs #2154

BREAKING CHANGE: FileResolver will not detect and process any local file unless explicitly allowed by fileAllowList option
