### PR TITLE
fix(reference): bound options during resolution and parsing

### DIFF
--- a/packages/apidom-reference/src/resolve/util.ts
+++ b/packages/apidom-reference/src/resolve/util.ts
@@ -26,7 +26,7 @@ export const readFile = async (file: IFile, options: IReferenceOptions): Promise
   }
 
   try {
-    const { result } = await plugins.run('read', [file], optsBoundResolvers);
+    const { result } = await plugins.run('read', [file], resolvers);
     return result;
   } catch (error: any) {
     throw new ResolverError(`Error while reading file "${file.uri}"`, error);


### PR DESCRIPTION
Bounding options now happens before filtering resolver and parser plugins.