### PR TITLE
feat(build): build UMD fragments with new browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,9 @@
 [production]
-defaults
-not IE 11
+last 3 chrome versions
+last 3 edge version
+last 3 firefox versions
+last 3 safari versions
+opera >= 90
 
 [development]
 last 1 Chrome versions

--- a/packages/apidom-ast/config/webpack/browser.config.js
+++ b/packages/apidom-ast/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 800000,
+    maxAssetSize: 800000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-core/config/webpack/browser.config.js
+++ b/packages/apidom-core/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1100000,
+    maxAssetSize: 1100000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-json-path/config/webpack/browser.config.js
+++ b/packages/apidom-json-path/config/webpack/browser.config.js
@@ -7,8 +7,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1200000,
+    maxAssetSize: 1200000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-json-pointer/config/webpack/browser.config.js
+++ b/packages/apidom-json-pointer/config/webpack/browser.config.js
@@ -7,8 +7,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1200000,
+    maxAssetSize: 1200000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-ls/config/webpack/browser.config.js
+++ b/packages/apidom-ls/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 7000000,
+    maxAssetSize: 7000000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -50,6 +50,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/index.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 2300000,
+    maxAssetSize: 2300000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-ls.browser.min.js',

--- a/packages/apidom-ns-api-design-systems/config/webpack/browser.config.js
+++ b/packages/apidom-ns-api-design-systems/config/webpack/browser.config.js
@@ -7,8 +7,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 2100000,
+    maxAssetSize: 2100000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -41,6 +41,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/index.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 280000,
+    maxAssetSize: 280000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-ns-api-design-systems.browser.min.js',

--- a/packages/apidom-ns-asyncapi-2/config/webpack/browser.config.js
+++ b/packages/apidom-ns-asyncapi-2/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 2200000,
+    maxAssetSize: 2200000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -40,6 +40,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/index.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 310000,
+    maxAssetSize: 310000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-ns-asyncapi-2.browser.min.js',

--- a/packages/apidom-ns-json-schema-draft-4/config/webpack/browser.config.js
+++ b/packages/apidom-ns-json-schema-draft-4/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1300000,
+    maxAssetSize: 1300000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-ns-json-schema-draft-6/config/webpack/browser.config.js
+++ b/packages/apidom-ns-json-schema-draft-6/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1400000,
+    maxAssetSize: 1400000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-ns-json-schema-draft-7/config/webpack/browser.config.js
+++ b/packages/apidom-ns-json-schema-draft-7/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1400000,
+    maxAssetSize: 1400000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-ns-openapi-3-0/config/webpack/browser.config.js
+++ b/packages/apidom-ns-openapi-3-0/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1800000,
+    maxAssetSize: 1800000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-ns-openapi-3-1/config/webpack/browser.config.js
+++ b/packages/apidom-ns-openapi-3-1/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 2000000,
+    maxAssetSize: 2000000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -40,6 +40,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/index.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 280000,
+    maxAssetSize: 280000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-ns-openapi-3-1.browser.min.js',

--- a/packages/apidom-parser-adapter-api-design-systems-json/config/webpack/browser.config.js
+++ b/packages/apidom-parser-adapter-api-design-systems-json/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/adapter.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 2200000,
+    maxAssetSize: 2200000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -49,6 +49,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/adapter.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 330000,
+    maxAssetSize: 330000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-parser-adapter-api-design-systems-json.browser.min.js',

--- a/packages/apidom-parser-adapter-api-design-systems-yaml/config/webpack/browser.config.js
+++ b/packages/apidom-parser-adapter-api-design-systems-yaml/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/adapter.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 2200000,
+    maxAssetSize: 2200000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -49,6 +49,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/adapter.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 330000,
+    maxAssetSize: 330000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-parser-adapter-api-design-systems-yaml.browser.min.js',

--- a/packages/apidom-parser-adapter-asyncapi-json-2/config/webpack/browser.config.js
+++ b/packages/apidom-parser-adapter-asyncapi-json-2/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/adapter.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 2300000,
+    maxAssetSize: 2300000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -49,6 +49,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/adapter.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 350000,
+    maxAssetSize: 350000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-parser-adapter-asyncapi-json-2.browser.min.js',

--- a/packages/apidom-parser-adapter-asyncapi-yaml-2/config/webpack/browser.config.js
+++ b/packages/apidom-parser-adapter-asyncapi-yaml-2/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/adapter.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 2300000,
+    maxAssetSize: 2300000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -49,6 +49,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/adapter.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 350000,
+    maxAssetSize: 350000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-parser-adapter-asyncapi-yaml-2.browser.min.js',

--- a/packages/apidom-parser-adapter-json/config/webpack/browser.config.js
+++ b/packages/apidom-parser-adapter-json/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/adapter-browser.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1300000,
+    maxAssetSize: 1300000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-parser-adapter-openapi-json-3-0/config/webpack/browser.config.js
+++ b/packages/apidom-parser-adapter-openapi-json-3-0/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/adapter.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1800000,
+    maxAssetSize: 1800000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -49,6 +49,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/adapter.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 280000,
+    maxAssetSize: 280000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-parser-adapter-openapi-json-3-0.browser.min.js',

--- a/packages/apidom-parser-adapter-openapi-json-3-1/config/webpack/browser.config.js
+++ b/packages/apidom-parser-adapter-openapi-json-3-1/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/adapter.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 2100000,
+    maxAssetSize: 2100000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -49,6 +49,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/adapter.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 310000,
+    maxAssetSize: 310000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-parser-adapter-openapi-json-3-1.browser.min.js',

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/config/webpack/browser.config.js
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/adapter.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1800000,
+    maxAssetSize: 1800000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -49,6 +49,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/adapter.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 280000,
+    maxAssetSize: 280000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-parser-adapter-openapi-yaml-3-0.browser.min.js',

--- a/packages/apidom-parser-adapter-openapi-yaml-3-1/config/webpack/browser.config.js
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-1/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/adapter.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 2100000,
+    maxAssetSize: 2100000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -49,6 +49,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/adapter.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 310000,
+    maxAssetSize: 310000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-parser-adapter-openapi-yaml-3-1.browser.min.js',

--- a/packages/apidom-parser-adapter-yaml-1-2/config/webpack/browser.config.js
+++ b/packages/apidom-parser-adapter-yaml-1-2/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/adapter-browser.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1300000,
+    maxAssetSize: 1300000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-parser/config/webpack/browser.config.js
+++ b/packages/apidom-parser/config/webpack/browser.config.js
@@ -6,8 +6,8 @@ const browser = {
   entry: ['./src/parser.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 1200000,
+    maxAssetSize: 1200000,
   },
   output: {
     path: path.resolve('./dist'),

--- a/packages/apidom-reference/config/webpack/browser.config.js
+++ b/packages/apidom-reference/config/webpack/browser.config.js
@@ -8,8 +8,8 @@ const browser = {
   entry: ['./src/index.ts'],
   target: 'web',
   performance: {
-    maxEntrypointSize: 712000,
-    maxAssetSize: 712000,
+    maxEntrypointSize: 3500000,
+    maxAssetSize: 3500000,
   },
   output: {
     path: path.resolve('./dist'),
@@ -51,6 +51,10 @@ const browserMin = {
   mode: 'production',
   entry: ['./src/index.ts'],
   target: 'web',
+  performance: {
+    maxEntrypointSize: 600000,
+    maxAssetSize: 600000,
+  },
   output: {
     path: path.resolve('./dist'),
     filename: 'apidom-reference.browser.min.js',
@@ -118,4 +122,4 @@ const fileResolverReplacer = new webpack.NormalModuleReplacementPlugin(
 browser.plugins.push(binaryParserReplacer, fileResolverReplacer);
 browserMin.plugins.push(binaryParserReplacer, fileResolverReplacer);
 
-export default [browser];
+export default [browser, browserMin];


### PR DESCRIPTION
Along with new browserslist, eliminate all the webpack performance warnings.

Refs #1414
