### PR TITLE
fix(ls): provide spec extension lint rule for Discriminator

### DIFF
--- a/packages/apidom-ls/src/config/openapi/discriminator/lint/allowed-fields-3-1.ts
+++ b/packages/apidom-ls/src/config/openapi/discriminator/lint/allowed-fields-3-1.ts
@@ -1,0 +1,16 @@
+import ApilintCodes from '../../../codes';
+import { LinterMeta } from '../../../../apidom-language-types';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const allowedFields3_1Lint: LinterMeta = {
+  code: ApilintCodes.NOT_ALLOWED_FIELDS,
+  source: 'apilint',
+  message: 'Object includes not allowed fields',
+  severity: 1,
+  linterFunction: 'allowedFields',
+  linterParams: [['propertyName', 'mapping'], 'x-'],
+  marker: 'key',
+  targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+};
+
+export default allowedFields3_1Lint;

--- a/packages/apidom-ls/src/config/openapi/discriminator/lint/index.ts
+++ b/packages/apidom-ls/src/config/openapi/discriminator/lint/index.ts
@@ -1,4 +1,5 @@
 import allowedFields3_0Lint from './allowed-fields-3-0';
+import allowedFields3_1Lint from './allowed-fields-3-1';
 import propertyNameTypeLint from './property-name--type';
 import propertyNameRequiredLint from './property-name--required';
 import mappingTypeLint from './mapping--type';
@@ -8,6 +9,7 @@ const lints = [
   propertyNameRequiredLint,
   mappingTypeLint,
   allowedFields3_0Lint,
+  allowedFields3_1Lint,
 ];
 
 export default lints;


### PR DESCRIPTION
This change is specific to OpenAPI 3.1.0.

Refs #2061
