### PR TITLE
fix(ls): enable completion for AsyncAPI binding objects

### DIFF
--- a/packages/apidom-ls/src/config/asyncapi/bindings/amqp/message-binding/meta.ts
+++ b/packages/apidom-ls/src/config/asyncapi/bindings/amqp/message-binding/meta.ts
@@ -1,9 +1,11 @@
 import lint from './lint';
+import completion from './completion';
 import documentation from './documentation';
 import { FormatMeta } from '../../../../../apidom-language-types';
 
 const meta: FormatMeta = {
   lint,
+  completion,
   documentation,
 };
 

--- a/packages/apidom-ls/src/config/asyncapi/bindings/amqp/operation-binding/meta.ts
+++ b/packages/apidom-ls/src/config/asyncapi/bindings/amqp/operation-binding/meta.ts
@@ -1,9 +1,11 @@
 import lint from './lint';
+import completion from './completion';
 import documentation from './documentation';
 import { FormatMeta } from '../../../../../apidom-language-types';
 
 const meta: FormatMeta = {
   lint,
+  completion,
   documentation,
 };
 

--- a/packages/apidom-ls/src/config/asyncapi/bindings/kafka/server-binding/meta.ts
+++ b/packages/apidom-ls/src/config/asyncapi/bindings/kafka/server-binding/meta.ts
@@ -1,9 +1,11 @@
 import lint from './lint';
+import completion from './completion';
 import documentation from './documentation';
 import { FormatMeta } from '../../../../../apidom-language-types';
 
 const meta: FormatMeta = {
   lint,
+  completion,
   documentation,
 };
 


### PR DESCRIPTION
Some of the completions where not connected to meta objects.