### PR TITLE
test(reference): add swagger-client JSON parser plugin

### DIFF
--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/parsers/json/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/parsers/json/index.ts
@@ -1,0 +1,49 @@
+import stampit from 'stampit';
+import { ParseResultElement, from } from '@swagger-api/apidom-core';
+
+import { Parser as IParser, File as IFile } from '../../../../../../src/types';
+import Parser from '../../../../../../src/parse/parsers/Parser';
+import { ParserError } from '../../../../../../src';
+
+const JsonParser: stampit.Stamp<IParser> = stampit(Parser, {
+  props: {
+    name: 'json-swagger-client',
+    fileExtensions: ['.json'],
+    mediaTypes: ['application/json'],
+  },
+  methods: {
+    async canParse(file: IFile): Promise<boolean> {
+      const hasSupportedFileExtension =
+        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+      if (!hasSupportedFileExtension) return false;
+      if (hasSupportedMediaType) return true;
+      if (!hasSupportedMediaType) {
+        try {
+          JSON.parse(file.toString());
+          return true;
+        } catch {
+          return false;
+        }
+      }
+      return false;
+    },
+    async parse(file: IFile): Promise<ParseResultElement> {
+      const source = file.toString();
+
+      try {
+        const element = from(JSON.parse(source));
+        const parseResultElement = new ParseResultElement();
+
+        element.classes.push('result');
+        parseResultElement.push(element);
+        return parseResultElement;
+      } catch (error: any) {
+        throw new ParserError(`Error parsing "${file.uri}"`, error);
+      }
+    },
+  },
+});
+
+export default JsonParser;


### PR DESCRIPTION
This plugin mimics the JSON parsing mechanism of swagger-client.

Refs #2317
