### PR TITLE
test(reference): add swagger-client OpenAPI 3.1 YAML parser plugin

### DIFF
--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/helpers/parsers/openapi-yaml-3-1/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/helpers/parsers/openapi-yaml-3-1/index.ts
@@ -1,16 +1,18 @@
 import stampit from 'stampit';
 // @ts-ignore
 import YAML from 'js-yaml'; // js-yaml comes with swagger-client
-import { ParseResultElement, from } from '@swagger-api/apidom-core';
-import { mediaTypes } from '@swagger-api/apidom-parser-adapter-yaml-1-2';
+import { ParseResultElement } from '@swagger-api/apidom-core';
+import { OpenApi3_1Element } from '@swagger-api/apidom-ns-openapi-3-1';
+import { mediaTypes, detectionRegExp } from '@swagger-api/apidom-parser-adapter-openapi-yaml-3-1';
 
 import { ParserError } from '../../../../../../../src/util/errors';
 import { File as IFile, Parser as IParser } from '../../../../../../../src/types';
 import Parser from '../../../../../../../src/parse/parsers/Parser';
 
-const YamlParser: stampit.Stamp<IParser> = stampit(Parser, {
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const OpenApiYaml3_1Parser: stampit.Stamp<IParser> = stampit(Parser, {
   props: {
-    name: 'yaml-1-2-swagger-client',
+    name: 'openapi-yaml-3-1-swagger-client',
     fileExtensions: ['.yaml', '.yml'],
     mediaTypes,
   },
@@ -24,8 +26,9 @@ const YamlParser: stampit.Stamp<IParser> = stampit(Parser, {
       if (hasSupportedMediaType) return true;
       if (!hasSupportedMediaType) {
         try {
-          YAML.load(file.toString());
-          return true;
+          const source = file.toString();
+          YAML.load(source);
+          return detectionRegExp.test(source);
         } catch {
           return false;
         }
@@ -36,7 +39,8 @@ const YamlParser: stampit.Stamp<IParser> = stampit(Parser, {
       const source = file.toString();
 
       try {
-        const element = from(YAML.load(source));
+        const pojo = YAML.load(source);
+        const element = OpenApi3_1Element.refract(pojo, this.refractorOpts);
         const parseResultElement = new ParseResultElement();
 
         element.classes.push('result');
@@ -49,4 +53,4 @@ const YamlParser: stampit.Stamp<IParser> = stampit(Parser, {
   },
 });
 
-export default YamlParser;
+export default OpenApiYaml3_1Parser;


### PR DESCRIPTION
This plugin mimics the YAML parsing mechanism from swagger-client.

Refs #2324