### PR TITLE
feat(reference): add support for useCircularStructures option

### DIFF
--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/bootstrap.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/bootstrap.ts
@@ -7,9 +7,11 @@ import YamlParser from './helpers/parsers/yaml1-2';
 import OpenApiJson3_1Parser from './helpers/parsers/openapi-json-3-1';
 import OpenApiYaml3_1Parser from './helpers/parsers/openapi-yaml-3-1';
 import HttpResolverSwaggerClient from '../../../../src/resolve/resolvers/HttpResolverSwaggerClient';
+import OpenApi3_1SwaggerClientDereferenceStrategy from '../../../../src/dereference/strategies/openapi-3-1-swagger-client';
 
 const originalParsers = [...options.parse.parsers];
 const originalResolvers = [...options.resolve.resolvers];
+const originalDereferenceStrategies = [...options.dereference.strategies];
 
 export const before = () => {
   // configure custom parser plugins globally
@@ -43,9 +45,20 @@ export const before = () => {
 
     return resolver;
   });
+
+  // configure custom dereference strategy globally
+  options.dereference.strategies = options.dereference.strategies.map((strategy) => {
+    // @ts-ignore
+    if (strategy.name === 'openapi-3-1') {
+      return OpenApi3_1SwaggerClientDereferenceStrategy();
+    }
+
+    return strategy;
+  });
 };
 
 export const after = () => {
   options.parse.parsers = originalParsers;
   options.resolve.resolvers = originalResolvers;
+  options.dereference.strategies = originalDereferenceStrategies;
 };

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled-http/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled-http/dereferenced.json
@@ -1,0 +1,21 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "profile": {
+              "properties": {
+                "parent": {
+                  "$ref": "http://localhost:8123/ex.json#/$defs/UserProfile"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled-http/ex.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled-http/ex.json
@@ -1,0 +1,11 @@
+{
+  "$defs": {
+    "UserProfile": {
+      "properties": {
+        "parent": {
+          "$ref": "#/$defs/UserProfile"
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled-http/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled-http/root.json
@@ -1,0 +1,15 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "profile": {
+            "$ref": "./ex.json#/$defs/UserProfile"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled/dereferenced.json
@@ -1,0 +1,21 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "profile": {
+              "properties": {
+                "parent": {
+                  "$ref": "#/$defs/UserProfile"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled/ex.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled/ex.json
@@ -1,0 +1,11 @@
+{
+  "$defs": {
+    "UserProfile": {
+      "properties": {
+        "parent": {
+          "$ref": "#/$defs/UserProfile"
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-external-disabled/root.json
@@ -1,0 +1,15 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "profile": {
+            "$ref": "./ex.json#/$defs/UserProfile"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-internal-disabled-http/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-internal-disabled-http/dereferenced.json
@@ -1,0 +1,17 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "parent": {
+              "$ref": "http://localhost:8123/root.json#/components/schemas/User"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-internal-disabled-http/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-internal-disabled-http/root.json
@@ -1,0 +1,15 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "parent": {
+            "$ref": "#/components/schemas/User"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-internal-disabled/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-internal-disabled/dereferenced.json
@@ -1,0 +1,17 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "parent": {
+              "$ref": "#/components/schemas/User"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-internal-disabled/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/cycle-internal-disabled/root.json
@@ -1,0 +1,15 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "parent": {
+            "$ref": "#/components/schemas/User"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This affects OpenAPI 3.1 swagger-client dereference strategy.

Refs #2328
