### PR TITLE
feat(reference): add support for allowMetaPatches option

### DIFF
--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1-swagger-client/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1-swagger-client/index.ts
@@ -24,6 +24,7 @@ const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
 // eslint-disable-next-line @typescript-eslint/naming-convention
 interface IOpenApi3_1SwaggerClientDereferenceStrategy extends IDereferenceStrategy {
   useCircularStructures: boolean;
+  allowMetaPatches: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -31,14 +32,19 @@ const OpenApi3_1SwaggerClientDereferenceStrategy: stampit.Stamp<IOpenApi3_1Swagg
   stampit(DereferenceStrategy, {
     props: {
       useCircularStructures: true,
+      allowMetaPatches: false,
     },
     init(
       this: IOpenApi3_1SwaggerClientDereferenceStrategy,
-      { useCircularStructures = this.useCircularStructures } = {},
+      {
+        useCircularStructures = this.useCircularStructures,
+        allowMetaPatches = this.allowMetaPatches,
+      } = {},
     ) {
       // @ts-ignore
       this.name = 'openapi-3-1-swagger-client';
       this.useCircularStructures = useCircularStructures;
+      this.allowMetaPatches = allowMetaPatches;
     },
     methods: {
       canDereference(file: IFile): boolean {
@@ -69,6 +75,7 @@ const OpenApi3_1SwaggerClientDereferenceStrategy: stampit.Stamp<IOpenApi3_1Swagg
           namespace,
           options,
           useCircularStructures: this.useCircularStructures,
+          allowMetaPatches: this.allowMetaPatches,
         });
         const dereferencedElement = await visitAsync(refSet.rootRef.value, visitor, {
           keyMap,

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-external/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-external/dereferenced.json
@@ -1,0 +1,14 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "pathItems": {
+        "externalRef": {
+          "description": "external ref",
+          "get": {},
+          "$$ref": "http://localhost:8123/ex3.json#/externalPathItem"
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-external/ex1.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-external/ex1.json
@@ -1,0 +1,5 @@
+{
+  "indirection": {
+    "$ref": "./ex2.json#/indirection"
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-external/ex2.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-external/ex2.json
@@ -1,0 +1,5 @@
+{
+  "indirection": {
+    "$ref": "./ex3.json#/externalPathItem"
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-external/ex3.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-external/ex3.json
@@ -1,0 +1,6 @@
+{
+  "externalPathItem": {
+    "description": "this is path item stored in external file",
+    "get": {}
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-external/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-external/root.json
@@ -1,0 +1,11 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "pathItems": {
+       "externalRef": {
+        "$ref": "./ex1.json#/indirection",
+        "description": "external ref"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-internal/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-internal/dereferenced.json
@@ -1,0 +1,23 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "pathItems": {
+        "pathItem1": {
+          "summary": "path item summary",
+          "description": "path item description",
+          "$$ref": "http://localhost:8123/root.json#/components/pathItems/pathItem3"
+        },
+        "pathItem2": {
+          "summary": "path item summary",
+          "description": "path item description",
+          "$$ref": "http://localhost:8123/root.json#/components/pathItems/pathItem3"
+        },
+        "pathItem3": {
+          "summary": "path item summary",
+          "description": "path item description"
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-internal/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/path-item-object/fixtures/meta-patches-internal/root.json
@@ -1,0 +1,17 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "pathItems": {
+      "pathItem1": {
+        "$ref": "#/components/pathItems/pathItem2"
+      },
+      "pathItem2": {
+        "$ref": "#/components/pathItems/pathItem3"
+      },
+      "pathItem3": {
+        "summary": "path item summary",
+        "description": "path item description"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-external/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-external/dereferenced.json
@@ -1,0 +1,16 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "parameters": {
+        "externalRef": {
+          "name": "externalParameter",
+          "in": "query",
+          "description": "external ref",
+          "required": true,
+          "$$ref": "http://localhost:8123/ex3.json#/externalParameter"
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-external/ex1.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-external/ex1.json
@@ -1,0 +1,5 @@
+{
+  "indirection": {
+    "$ref": "./ex2.json#/indirection"
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-external/ex2.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-external/ex2.json
@@ -1,0 +1,5 @@
+{
+  "indirection": {
+    "$ref": "./ex3.json#/externalParameter"
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-external/ex3.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-external/ex3.json
@@ -1,0 +1,8 @@
+{
+  "externalParameter": {
+    "name": "externalParameter",
+    "in": "query",
+    "description": "this is parameter stored in external file",
+    "required": true
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-external/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-external/root.json
@@ -1,0 +1,11 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "parameters": {
+       "externalRef": {
+        "$ref": "./ex1.json#/indirection",
+        "description": "external ref"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-internal/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-internal/dereferenced.json
@@ -1,0 +1,27 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "parameters": {
+        "param1": {
+          "name": "offset",
+          "in": "query",
+          "required": true,
+          "$$ref": "http://localhost:8123/root.json#/components/parameters/param3"
+        },
+        "param2": {
+          "name": "offset",
+          "in": "query",
+          "required": true,
+          "$$ref": "http://localhost:8123/root.json#/components/parameters/param3"
+        },
+        "param3": {
+          "name": "offset",
+          "in": "query",
+          "required": true
+        }
+      }
+    }
+  }
+
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-internal/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/reference-object/fixtures/meta-patches-internal/root.json
@@ -1,0 +1,18 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "parameters": {
+      "param1": {
+        "$ref": "#/components/parameters/param2"
+      },
+      "param2": {
+        "$ref": "#/components/parameters/param3"
+      },
+      "param3": {
+        "name": "offset",
+        "in": "query",
+        "required": true
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-external/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-external/dereferenced.json
@@ -1,0 +1,14 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "externalRef": {
+          "description": "external ref",
+          "type": "object",
+          "$$ref": "http://localhost:8123/ex3.json#/$defs/externalSchema"
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-external/ex1.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-external/ex1.json
@@ -1,0 +1,5 @@
+{
+  "indirection": {
+    "$ref": "./ex2.json#/indirection"
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-external/ex2.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-external/ex2.json
@@ -1,0 +1,5 @@
+{
+  "indirection": {
+    "$ref": "./ex3.json#/$defs/externalSchema"
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-external/ex3.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-external/ex3.json
@@ -1,0 +1,8 @@
+{
+  "$defs": {
+    "externalSchema": {
+      "description": "this is path item stored in external file",
+      "type": "object"
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-external/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-external/root.json
@@ -1,0 +1,11 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+       "externalRef": {
+        "$ref": "./ex1.json#/indirection",
+        "description": "external ref"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-internal/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-internal/dereferenced.json
@@ -1,0 +1,19 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "schema1": {
+          "type": "object",
+          "$$ref": "http://localhost:8123/root.json#/components/schemas/schema3"
+        },
+        "schema2": {
+          "$ref": "#/components/schemas/schema3"
+        },
+        "schema3": {
+          "type": "object"
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-internal/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/meta-patches-internal/root.json
@@ -1,0 +1,16 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "schema1": {
+        "$ref": "#/components/schemas/schema2"
+      },
+      "schema2": {
+        "$ref": "#/components/schemas/schema3"
+      },
+      "schema3": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/index.ts
@@ -187,6 +187,58 @@ describe('dereference', function () {
           });
         });
 
+        context('given Schema Object pointing internally', function () {
+          context('and allowMetaPatches=true', function () {
+            specify('should dereference', async function () {
+              let httpServer: any;
+
+              try {
+                const fixturePath = path.join(rootFixturePath, 'meta-patches-internal');
+                httpServer = createHTTPServer({ port: 8123, cwd: fixturePath });
+                const actual = await dereference('http://localhost:8123/root.json', {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  dereference: {
+                    strategies: [
+                      OpenApi3_1SwaggerClientDereferenceStrategy({ allowMetaPatches: true }),
+                    ],
+                  },
+                });
+                const expected = loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+                assert.deepEqual(toValue(actual), expected);
+              } finally {
+                httpServer?.terminate();
+              }
+            });
+          });
+        });
+
+        context('given Schema Object pointing externally', function () {
+          context('and allowMetaPatches=true', function () {
+            specify('should dereference', async function () {
+              let httpServer: any;
+
+              try {
+                const fixturePath = path.join(rootFixturePath, 'meta-patches-external');
+                httpServer = createHTTPServer({ port: 8123, cwd: fixturePath });
+                const actual = await dereference('http://localhost:8123/root.json', {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  dereference: {
+                    strategies: [
+                      OpenApi3_1SwaggerClientDereferenceStrategy({ allowMetaPatches: true }),
+                    ],
+                  },
+                });
+                const expected = loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+                assert.deepEqual(toValue(actual), expected);
+              } finally {
+                httpServer?.terminate();
+              }
+            });
+          });
+        });
+
         context('given Schema Objects with internal and external cycles', function () {
           const fixturePath = path.join(rootFixturePath, 'cycle-internal-external');
 


### PR DESCRIPTION
This affects OpenAPI 3.1 swagger-client dereference strategy.

Refs #2336
