### PR TITLE
fix(ns-openapi-3-1): avoid returning false in ractor plugins

### DIFF
--- a/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-parameters.ts
+++ b/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-parameters.ts
@@ -53,7 +53,7 @@ const plugin =
           ) {
             // skip visiting this Path Item
             if (ancestors.some(predicates.isComponentsElement)) {
-              return false;
+              return;
             }
 
             const { parameters } = pathItemElement;
@@ -63,8 +63,6 @@ const plugin =
             } else {
               pathItemParameters.push([]);
             }
-
-            return undefined;
           },
           leave() {
             pathItemParameters.pop();

--- a/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-security-requirements.ts
+++ b/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-security-requirements.ts
@@ -27,9 +27,7 @@ const plugin =
           enter(openapiElement: OpenApi3_1Element) {
             if (predicates.isArrayElement(openapiElement.security)) {
               topLevelSecurity = openapiElement.security;
-              return undefined;
             }
-            return false;
           },
           leave() {
             topLevelSecurity = undefined;
@@ -45,7 +43,7 @@ const plugin =
           ) {
             // skip visiting this Operation
             if (ancestors.some(predicates.isComponentsElement)) {
-              return false;
+              return;
             }
 
             const missingOperationLevelSecurity = typeof operationElement.security === 'undefined';
@@ -54,8 +52,6 @@ const plugin =
             if (missingOperationLevelSecurity && hasTopLevelSecurity) {
               operationElement.security = new OperationSecurityElement(topLevelSecurity?.content);
             }
-
-            return undefined;
           },
         },
       },

--- a/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-servers.ts
+++ b/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-servers.ts
@@ -52,7 +52,7 @@ const plugin =
           ) {
             // skip visiting this Path Item
             if (ancestors.some(predicates.isComponentsElement)) {
-              return false;
+              return;
             }
 
             // duplicate OpenAPI.servers into this Path Item object
@@ -70,8 +70,6 @@ const plugin =
             } else {
               pathItemServers.push(undefined);
             }
-
-            return undefined;
           },
           leave() {
             pathItemServers.pop();


### PR DESCRIPTION
This will allow refractor plugin composition.
When returning false, other plugins will not be
able to intercept the skipped nodes.