### PR TITLE
docs(ns-openapi-3-1): provide docs for refractor plugins

### DIFF
--- a/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-operation-ids.ts
+++ b/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-operation-ids.ts
@@ -38,7 +38,7 @@ const normalizeOperationId = (operationId: string, path: string, method: string)
  *
  * Existing Operation.operationId fields are normalized into snake case form.
  *
- * For Operation Objects, that do not define operationId field, are left untouched.
+ * Operation Objects, that do not define operationId field, are left untouched.
  *
  * Original operationId is stored in meta and as new `__originalOperationId` field.
  *


### PR DESCRIPTION
Docs has been provided for following plugins:

- refractorPluginNormalizeParameters
- refractorPluginNormalizeSecurityRequirements
- refractorPluginNormalizeServers
- refractorPluginNormalizeOperationIds

Refs #2362