### PR TITLE
fix(reference): fix OpenAPI 3.1 Schema Object resolution

### DIFF
--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
@@ -35,7 +35,7 @@ import parse from '../../../parse';
 import Reference from '../../../Reference';
 import File from '../../../util/File';
 import {
-  resolveInherited$id,
+  resolveSchema$refField,
   maybeRefractToSchemaElement,
 } from '../../../resolve/strategies/openapi-3-1/util';
 import EvaluationJsonSchemaUriError from './selectors/uri/errors/EvaluationJsonSchemaUriError';
@@ -370,11 +370,13 @@ const OpenApi3_1DereferenceVisitor = stampit({
       }
 
       // compute baseURI using rules around $id and $ref keywords
-      const baseURI = resolveInherited$id(this.reference.uri, referencingElement);
-      const file = File({ uri: baseURI });
+      const retrieveURI = this.reference.uri;
+      const $refBaseURI = resolveSchema$refField(retrieveURI, referencingElement) as string;
+      const $refBaseURIStrippedHash = url.stripHash($refBaseURI);
+      const file = File({ uri: $refBaseURIStrippedHash });
       const isUnknownURI = none((r: IResolver) => r.canRead(file), this.options.resolve.resolvers);
       const isURL = !isUnknownURI;
-      const isExternal = this.reference.uri !== baseURI && isURL;
+      const isExternal = isURL && this.reference.uri !== $refBaseURIStrippedHash;
 
       // ignore resolving external Schema Objects
       if (!this.options.resolve.external && isExternal) {
@@ -387,7 +389,6 @@ const OpenApi3_1DereferenceVisitor = stampit({
       this.indirections.push(referencingElement);
 
       // determining reference, proper evaluation and selection mechanism
-      const $refValue = referencingElement.$ref?.toValue();
       let reference: IReference;
       let referencedElement;
 
@@ -395,25 +396,16 @@ const OpenApi3_1DereferenceVisitor = stampit({
         if (isUnknownURI || isURL) {
           // we're dealing with canonical URI or URL with possible fragment
           reference = this.reference;
-          const selector = url.resolve(reference.uri, $refValue);
+          const selector = $refBaseURI;
           referencedElement = uriEvaluate(
-            selector,
-            // @ts-ignore
-            maybeRefractToSchemaElement(reference.value.result),
-          );
-        } else if (isAnchor(uriToAnchor($refValue))) {
-          // we're dealing with JSON Schema $anchor here
-          reference = await this.toReference(url.unsanitize(baseURI));
-          const selector = uriToAnchor($refValue);
-          referencedElement = $anchorEvaluate(
             selector,
             // @ts-ignore
             maybeRefractToSchemaElement(reference.value.result),
           );
         } else {
           // we're assuming here that we're dealing with JSON Pointer here
-          reference = await this.toReference(url.unsanitize(baseURI));
-          const selector = uriToPointer($refValue);
+          reference = await this.toReference(url.unsanitize($refBaseURI));
+          const selector = uriToPointer($refBaseURI);
           referencedElement = maybeRefractToSchemaElement(
             // @ts-ignore
             jsonPointerEvaluate(selector, reference.value.result),
@@ -425,10 +417,10 @@ const OpenApi3_1DereferenceVisitor = stampit({
          * the URL and assume the returned response is a JSON Schema.
          */
         if (isURL && error instanceof EvaluationJsonSchemaUriError) {
-          if (isAnchor(uriToAnchor($refValue))) {
+          if (isAnchor(uriToAnchor($refBaseURI))) {
             // we're dealing with JSON Schema $anchor here
-            reference = await this.toReference(url.unsanitize(baseURI));
-            const selector = uriToAnchor($refValue);
+            reference = await this.toReference(url.unsanitize($refBaseURI));
+            const selector = uriToAnchor($refBaseURI);
             referencedElement = $anchorEvaluate(
               selector,
               // @ts-ignore
@@ -436,8 +428,8 @@ const OpenApi3_1DereferenceVisitor = stampit({
             );
           } else {
             // we're assuming here that we're dealing with JSON Pointer here
-            reference = await this.toReference(url.unsanitize(baseURI));
-            const selector = uriToPointer($refValue);
+            reference = await this.toReference(url.unsanitize($refBaseURI));
+            const selector = uriToPointer($refBaseURI);
             referencedElement = maybeRefractToSchemaElement(
               // @ts-ignore
               jsonPointerEvaluate(selector, reference.value.result),
@@ -507,7 +499,6 @@ const OpenApi3_1DereferenceVisitor = stampit({
         mergedResult.content.push(item);
       });
       mergedResult.remove('$ref');
-
       // annotate referenced element with info about original referencing element
       mergedResult.setMetaProperty('ref-fields', {
         $ref: referencingElement.$ref?.toValue(),

--- a/packages/apidom-reference/src/resolve/strategies/openapi-3-1/util.ts
+++ b/packages/apidom-reference/src/resolve/strategies/openapi-3-1/util.ts
@@ -4,19 +4,37 @@ import { SchemaElement } from '@swagger-api/apidom-ns-openapi-3-1';
 
 import * as url from '../../../util/url';
 
-/**
- * Folding of inherited$id list from left to right using
- * URL resolving mechanism.
- */
-export const resolveInherited$id = (baseURI: string, schemaElement: SchemaElement) => {
+export const resolveSchema$refField = (retrieveURI: string, schemaElement: SchemaElement) => {
+  if (typeof schemaElement.$ref === 'undefined') {
+    return undefined;
+  }
+
+  const hash = url.getHash(schemaElement.$ref.toValue());
+  const inherited$id = schemaElement.meta.get('inherited$id').toValue();
+  const $refBaseURI = reduce(
+    (acc: string, uri: string): string => {
+      return url.resolve(acc, url.sanitize(url.stripHash(uri)));
+    },
+    retrieveURI,
+    [...inherited$id, schemaElement.$ref.toValue()],
+  );
+
+  return `${$refBaseURI}${hash === '#' ? '' : hash}`;
+};
+
+export const resolveSchema$idField = (retrieveURI: string, schemaElement: SchemaElement) => {
+  if (typeof schemaElement.$id === 'undefined') {
+    return undefined;
+  }
+
   const inherited$id = schemaElement.meta.get('inherited$id').toValue();
 
   return reduce(
     (acc: string, $id: string): string => {
       return url.resolve(acc, url.sanitize(url.stripHash($id)));
     },
-    baseURI,
-    [...inherited$id, schemaElement.$ref?.toValue()],
+    retrieveURI,
+    [...inherited$id, schemaElement.$id.toValue()],
   );
 };
 

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/$ref-url-relative-reference/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/$ref-url-relative-reference/dereferenced.json
@@ -1,0 +1,35 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "$id": "https://swagger.io/schemas/user",
+          "properties": {
+            "login": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "profileAvatar": {
+              "$id": "/schemas/user-profile/avatar",
+              "type": "string"
+            }
+          }
+        },
+        "UserProfile": {
+          "$id": "https://swagger.io/schemas/user-profile",
+          "type": "object",
+          "properties": {
+            "avatar": {
+              "$id": "/schemas/user-profile/avatar",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/$ref-url-relative-reference/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/fixtures/$ref-url-relative-reference/root.json
@@ -1,0 +1,32 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "$id": "https://swagger.io/schemas/user",
+        "properties": {
+          "login": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "profileAvatar": {
+            "$ref": "/schemas/user-profile/avatar"
+          }
+        }
+      },
+      "UserProfile": {
+        "$id": "https://swagger.io/schemas/user-profile",
+        "type": "object",
+        "properties": {
+          "avatar": {
+            "$id": "/schemas/user-profile/avatar",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1-swagger-client/schema-object/index.ts
@@ -579,6 +579,23 @@ describe('dereference', function () {
         });
 
         context(
+          'given Schema Objects with $ref keyword containing relative references',
+          function () {
+            const fixturePath = path.join(rootFixturePath, '$ref-url-relative-reference');
+
+            specify('should dereference', async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const actual = await dereference(rootFilePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const expected = loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+              assert.deepEqual(toValue(actual), expected);
+            });
+          },
+        );
+
+        context(
           'given Schema Objects with $ref keyword containing URL and JSON Pointer fragment',
           function () {
             const fixturePath = path.join(rootFixturePath, '$ref-url-pointer');

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-url-relative-reference/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-url-relative-reference/dereferenced.json
@@ -1,0 +1,35 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "$id": "https://swagger.io/schemas/user",
+          "properties": {
+            "login": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "profileAvatar": {
+              "$id": "/schemas/user-profile/avatar",
+              "type": "string"
+            }
+          }
+        },
+        "UserProfile": {
+          "$id": "https://swagger.io/schemas/user-profile",
+          "type": "object",
+          "properties": {
+            "avatar": {
+              "$id": "/schemas/user-profile/avatar",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-url-relative-reference/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/fixtures/$ref-url-relative-reference/root.json
@@ -1,0 +1,32 @@
+{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "$id": "https://swagger.io/schemas/user",
+        "properties": {
+          "login": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "profileAvatar": {
+            "$ref": "/schemas/user-profile/avatar"
+          }
+        }
+      },
+      "UserProfile": {
+        "$id": "https://swagger.io/schemas/user-profile",
+        "type": "object",
+        "properties": {
+          "avatar": {
+            "$id": "/schemas/user-profile/avatar",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/index.ts
@@ -446,6 +446,23 @@ describe('dereference', function () {
         });
 
         context(
+          'given Schema Objects with $ref keyword containing relative references',
+          function () {
+            const fixturePath = path.join(rootFixturePath, '$ref-url-relative-reference');
+
+            specify('should dereference', async function () {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const actual = await dereference(rootFilePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const expected = loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+              assert.deepEqual(toValue(actual), expected);
+            });
+          },
+        );
+
+        context(
           'given Schema Objects with $ref keyword containing URL and JSON Pointer fragment',
           function () {
             const fixturePath = path.join(rootFixturePath, '$ref-url-pointer');


### PR DESCRIPTION
Affected by this commit are OpenAPI 3.1 related dereference and resolution strategies. BaseURI is now properly resolved from  and  keywords.
