### PR TITLE
refactor(reference): base SwaggerClient staregy on default one

### DIFF
--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1-swagger-client/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1-swagger-client/visitor.ts
@@ -1,6 +1,6 @@
 import stampit from 'stampit';
-import { hasIn, pathSatisfies, propEq, none } from 'ramda';
-import { isUndefined, isNotUndefined } from 'ramda-adjunct';
+import { hasIn, pathSatisfies, none } from 'ramda';
+import { isNotUndefined } from 'ramda-adjunct';
 import {
   isObjectElement,
   ObjectElement,
@@ -8,7 +8,6 @@ import {
   isStringElement,
   visit,
   Element,
-  find,
 } from '@swagger-api/apidom-core';
 import { evaluate as jsonPointerEvaluate, uriToPointer } from '@swagger-api/apidom-json-pointer';
 import {
@@ -17,14 +16,9 @@ import {
   keyMap,
   ReferenceElement,
   PathItemElement,
-  LinkElement,
-  OperationElement,
-  ExampleElement,
   SchemaElement,
   isReferenceElementExternal,
   isPathItemElementExternal,
-  isLinkElementExternal,
-  isOperationElement,
   isBooleanJsonSchemaElement,
 } from '@swagger-api/apidom-ns-openapi-3-1';
 
@@ -35,89 +29,39 @@ import {
 } from '../openapi-3-1/selectors/$anchor';
 import { evaluate as uriEvaluate } from '../openapi-3-1/selectors/uri';
 import { Reference as IReference, Resolver as IResolver } from '../../../types';
-import { MaximumDereferenceDepthError, MaximumResolverDepthError } from '../../../util/errors';
+import { MaximumDereferenceDepthError } from '../../../util/errors';
 import * as url from '../../../util/url';
-import parse from '../../../parse';
-import Reference from '../../../Reference';
 import File from '../../../util/File';
 import {
   maybeRefractToSchemaElement,
   resolveSchema$refField,
 } from '../../../resolve/strategies/openapi-3-1/util';
 import EvaluationJsonSchemaUriError from '../openapi-3-1/selectors/uri/errors/EvaluationJsonSchemaUriError';
+import OpenApi3_1DereferenceVisitor from '../openapi-3-1/visitor';
 
 // @ts-ignore
 const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const OpenApi3_1SwaggerClientDereferenceVisitor = stampit({
+const OpenApi3_1SwaggerClientDereferenceVisitor = stampit(OpenApi3_1DereferenceVisitor, {
   props: {
-    indirections: null,
-    visited: null,
-    namespace: null,
-    reference: null,
-    options: null,
     useCircularStructures: true,
+    allowMetaPatches: false,
   },
   init({
-    indirections = [],
     visited = {
       SchemaElement: new WeakSet(),
       SchemaElementReference: new WeakSet(),
       SchemaElementNoReference: new WeakSet(),
     },
-    reference,
-    namespace,
-    options,
     useCircularStructures,
     allowMetaPatches,
   }) {
-    this.indirections = indirections;
     this.visited = visited;
-    this.namespace = namespace;
-    this.reference = reference;
-    this.options = options;
     this.useCircularStructures = useCircularStructures;
     this.allowMetaPatches = allowMetaPatches;
   },
   methods: {
-    toBaseURI(uri: string): string {
-      return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
-    },
-
-    async toReference(uri: string): Promise<IReference> {
-      // detect maximum depth of resolution
-      if (this.reference.depth >= this.options.resolve.maxDepth) {
-        throw new MaximumResolverDepthError(
-          `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
-        );
-      }
-
-      const baseURI = this.toBaseURI(uri);
-      const { refSet } = this.reference;
-
-      // we've already processed this Reference in past
-      if (refSet.has(baseURI)) {
-        return refSet.find(propEq('uri', baseURI));
-      }
-
-      const parseResult = await parse(url.unsanitize(baseURI), {
-        ...this.options,
-        parse: { ...this.options.parse, mediaType: 'text/plain' },
-      });
-
-      // register new Reference with ReferenceSet
-      const reference = Reference({
-        uri: baseURI,
-        value: parseResult,
-        depth: this.reference.depth + 1,
-      });
-
-      refSet.add(reference);
-
-      return reference;
-    },
-
     async ReferenceElement(referenceElement: ReferenceElement) {
       // ignore resolving external Reference Objects
       if (!this.options.resolve.external && isReferenceElementExternal(referenceElement)) {
@@ -303,93 +247,6 @@ const OpenApi3_1SwaggerClientDereferenceVisitor = stampit({
 
       // transclude referencing element with merged referenced element
       return mergedResult;
-    },
-
-    async LinkElement(linkElement: LinkElement) {
-      // ignore LinkElement without operationRef or operationId field
-      if (!isStringElement(linkElement.operationRef) && !isStringElement(linkElement.operationId)) {
-        return undefined;
-      }
-
-      // ignore resolving external Path Item Elements
-      if (!this.options.resolve.external && isLinkElementExternal(linkElement)) {
-        return undefined;
-      }
-
-      // operationRef and operationId fields are mutually exclusive
-      if (isStringElement(linkElement.operationRef) && isStringElement(linkElement.operationId)) {
-        throw new Error('LinkElement operationRef and operationId fields are mutually exclusive.');
-      }
-
-      // @ts-ignore
-      let operationElement;
-
-      if (isStringElement(linkElement.operationRef)) {
-        // possibly non-semantic referenced element
-        const jsonPointer = uriToPointer(linkElement.operationRef?.toValue());
-        const reference = await this.toReference(linkElement.operationRef?.toValue());
-        operationElement = jsonPointerEvaluate(jsonPointer, reference.value.result);
-        // applying semantics to a referenced element
-        if (isPrimitiveElement(operationElement)) {
-          operationElement = OperationElement.refract(operationElement);
-        }
-        // create shallow clone to be able to annotate with metadata
-        operationElement = new OperationElement(
-          // @ts-ignore
-          [...operationElement.content],
-          operationElement.meta.clone(),
-          operationElement.attributes.clone(),
-        );
-        // annotate operation element with info about origin
-        operationElement.setMetaProperty('ref-origin', reference.uri);
-        linkElement.operationRef?.meta.set('operation', operationElement);
-      } else if (isStringElement(linkElement.operationId)) {
-        const operationId = linkElement.operationId?.toValue();
-        operationElement = find(
-          (e) => isOperationElement(e) && e.operationId.equals(operationId),
-          this.reference.value.result,
-        );
-        // OperationElement not found by its operationId
-        if (isUndefined(operationElement)) {
-          throw new Error(`OperationElement(operationId=${operationId}) not found.`);
-        }
-        linkElement.operationId?.meta.set('operation', operationElement);
-      }
-
-      return undefined;
-    },
-
-    async ExampleElement(exampleElement: ExampleElement) {
-      // ignore ExampleElement without externalValue field
-      if (!isStringElement(exampleElement.externalValue)) {
-        return undefined;
-      }
-
-      // ignore resolving ExampleElement externalValue
-      if (!this.options.resolve.external && isStringElement(exampleElement.externalValue)) {
-        return undefined;
-      }
-
-      // value and externalValue fields are mutually exclusive
-      if (exampleElement.hasKey('value') && isStringElement(exampleElement.externalValue)) {
-        throw new Error('ExampleElement value and externalValue fields are mutually exclusive.');
-      }
-
-      const reference = await this.toReference(exampleElement.externalValue?.toValue());
-
-      // shallow clone of the referenced element
-      const valueElement = new reference.value.result.constructor(
-        reference.value.result.content,
-        reference.value.result.meta.clone(),
-        reference.value.result.attributes.clone(),
-      );
-      // annotate operation element with info about origin
-      valueElement.setMetaProperty('ref-origin', reference.uri);
-
-      // eslint-disable-next-line no-param-reassign
-      exampleElement.value = valueElement;
-
-      return undefined;
     },
 
     async SchemaElement(referencingElement: SchemaElement) {


### PR DESCRIPTION
This change is related to OpenAPI 3.1 SwaggerClient strategy and default OpenAPI 3.1 one.