### PR TITLE
feat(reference): separate abstractions from configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30776,7 +30776,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.20.7",
-        "@swagger-api/apidom-ast": "^0.58.0",
         "@swagger-api/apidom-core": "^0.58.0",
         "@swagger-api/apidom-json-pointer": "^0.58.0",
         "@swagger-api/apidom-ns-asyncapi-2": "^0.58.0",
@@ -36429,7 +36428,6 @@
       "version": "file:packages/apidom-reference",
       "requires": {
         "@babel/runtime-corejs3": "=7.20.7",
-        "@swagger-api/apidom-ast": "^0.58.0",
         "@swagger-api/apidom-core": "^0.58.0",
         "@swagger-api/apidom-json-pointer": "^0.58.0",
         "@swagger-api/apidom-ns-asyncapi-2": "^0.58.0",

--- a/packages/apidom-reference/package.json
+++ b/packages/apidom-reference/package.json
@@ -6,18 +6,130 @@
     "registry": "https://npm.pkg.github.com"
   },
   "type": "module",
+  "sideEffects": [
+    "./es/configuration/complete.js",
+    "./cjs/configuration/complete.cjs"
+  ],
   "unpkg": "./dist/apidom-reference.browser.min.js",
   "browser": {
-    "./es/parse/parsers/binary/index-node.js": "./es/parse/parsers/binary/index-browser.js",
     "./cjs/parse/parsers/binary/index-node.cjs": "./cjs/parse/parsers/binary/index-browser.cjs",
     "./cjs/resolve/resolvers/file/index-node.cjs": "./cjs/resolve/resolvers/file/index-browser.cjs",
+    "./es/parse/parsers/binary/index-node.js": "./es/parse/parsers/binary/index-browser.js",
     "./es/resolve/resolvers/file/index-node.js": "./es/resolve/resolvers/file/index-browser.js"
   },
   "main": "./cjs/index.cjs",
   "exports": {
-    "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
-    "require": "./cjs/index.cjs"
+    ".": {
+      "types": "./types/dist.d.ts",
+      "import": "./es/configuration/saturated.js",
+      "require": "./cjs/configuration/saturated.cjs"
+    },
+    "./configuration/saturated": {
+      "types": "./types/dist.d.ts",
+      "import": "./es/configuration/saturated.js",
+      "require": "./cjs/configuration/saturated.cjs"
+    },
+    "./configuration/empty": {
+      "types": "./types/dist.d.ts",
+      "import": "./es/configuration/empty.js",
+      "require": "./cjs/configuration/empty.cjs"
+    },
+    "./resolve/resolvers/file": {
+      "browser": {
+        "import": "./es/resolve/resolvers/file/index-browser.js",
+        "require": "./cjs/resolve/resolvers/file/index-browser.cjs"
+      },
+      "default": {
+        "import": "./es/resolve/resolvers/file/index-node.js",
+        "require": "./cjs/resolve/resolvers/file/index-node.cjs"
+      }
+    },
+    "./resolve/resolvers/http-axios": {
+      "import": "./es/resolve/resolvers/http-axios/index.js",
+      "require": "./cjs/resolve/resolvers/http-axios/index.cjs"
+    },
+    "./resolve/resolvers/http-swagger-client": {
+      "import": "./es/resolve/resolvers/http-swagger-client/index.js",
+      "require": "./cjs/resolve/resolvers/http-swagger-client/index.cjs"
+    },
+    "./resolve/strategies/asyncapi-2": {
+      "import": "./es/resolve/strategies/asyncapi-2/index.js",
+      "require": "./cjs/resolve/strategies/asyncapi-2/index.cjs"
+    },
+    "./resolve/strategies/openapi-3-0": {
+      "import": "./es/resolve/strategies/openapi-3-0/index.js",
+      "require": "./cjs/resolve/strategies/openapi-3-0/index.cjs"
+    },
+    "./resolve/strategies/openapi-3-1": {
+      "import": "./es/resolve/strategies/openapi-3-1/index.js",
+      "require": "./cjs/resolve/strategies/openapi-3-1/index.cjs"
+    },
+    "./parse/parsers/api-design-systems-json": {
+      "import": "./es/parse/parsers/api-design-systems-json/index.js",
+      "require": "./cjs/parse/parsers/api-design-systems-json/index.cjs"
+    },
+    "./parse/parsers/api-design-systems-yaml": {
+      "import": "./es/parse/parsers/api-design-systems-yaml/index.js",
+      "require": "./cjs/parse/parsers/api-design-systems-yaml/index.cjs"
+    },
+    "./parse/parsers/asyncapi-json-2": {
+      "import": "./es/parse/parsers/asyncapi-json-2/index.js",
+      "require": "./cjs/parse/parsers/asyncapi-json-2/index.cjs"
+    },
+    "./parse/parsers/asyncapi-yaml-2": {
+      "import": "./es/parse/parsers/asyncapi-yaml-2/index.js",
+      "require": "./cjs/parse/parsers/asyncapi-yaml-2/index.cjs"
+    },
+    "./parse/parsers/binary": {
+      "browser": {
+        "import": "./es/parse/parsers/binary/index-browser.js",
+        "require": "./cjs/parse/parsers/binary/index-browser.cjs"
+      },
+      "default": {
+        "import": "./es/parse/parsers/binary/index-node.js",
+        "require": "./cjs/parse/parsers/binary/index-node.cjs"
+      }
+    },
+    "./parse/parsers/json": {
+      "import": "./es/parse/parsers/json/index.js",
+      "require": "./cjs/parse/parsers/json/index.cjs"
+    },
+    "./parse/parsers/openapi-json-3-0": {
+      "import": "./es/parse/parsers/openapi-json-3-0/index.js",
+      "require": "./cjs/parse/parsers/openapi-json-3-0/index.cjs"
+    },
+    "./parse/parsers/openapi-json-3-1": {
+      "import": "./es/parse/parsers/openapi-json-3-1/index.js",
+      "require": "./cjs/parse/parsers/openapi-json-3-1/index.cjs"
+    },
+    "./parse/parsers/openapi-yaml-3-0": {
+      "import": "./es/parse/parsers/openapi-yaml-3-0/index.js",
+      "require": "./cjs/parse/parsers/openapi-yaml-3-0/index.cjs"
+    },
+    "./parse/parsers/openapi-yaml-3-1": {
+      "import": "./es/parse/parsers/openapi-yaml-3-1/index.js",
+      "require": "./cjs/parse/parsers/openapi-yaml-3-1/index.cjs"
+    },
+    "./parse/parsers/yaml-1-2": {
+      "import": "./es/parse/parsers/yaml-1-2/index.js",
+      "require": "./cjs/parse/parsers/yaml-1-2/index.cjs"
+    },
+    "./dereference/strategies/asyncapi-2": {
+      "import": "./es/dereference/strategies/asyncapi-2/index.js",
+      "require": "./cjs/dereference/strategies/asyncapi-2/index.cjs"
+    },
+    "./dereference/strategies/openapi-3-0": {
+      "import": "./es/dereference/strategies/openapi-3-0/index.js",
+      "require": "./cjs/dereference/strategies/openapi-3-0/index.cjs"
+    },
+    "./dereference/strategies/openapi-3-1": {
+      "import": "./es/dereference/strategies/openapi-3-1/index.js",
+      "require": "./cjs/dereference/strategies/openapi-3-1/index.cjs"
+    },
+    "./dereference/strategies/openapi-3-1-swagger-client": {
+      "import": "./es/dereference/strategies/openapi-3-1-swagger-client/index.js",
+      "require": "./cjs/dereference/strategies/openapi-3-1-swagger-client/index.cjs"
+    }
   },
   "types": "./types/dist.d.ts",
   "scripts": {
@@ -42,7 +154,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime-corejs3": "=7.20.7",
-    "@swagger-api/apidom-ast": "^0.58.0",
     "@swagger-api/apidom-core": "^0.58.0",
     "@swagger-api/apidom-json-pointer": "^0.58.0",
     "@swagger-api/apidom-ns-asyncapi-2": "^0.58.0",

--- a/packages/apidom-reference/src/configuration/empty.ts
+++ b/packages/apidom-reference/src/configuration/empty.ts
@@ -1,0 +1,1 @@
+export * from '../index';

--- a/packages/apidom-reference/src/configuration/saturated.ts
+++ b/packages/apidom-reference/src/configuration/saturated.ts
@@ -1,0 +1,53 @@
+import FileResolver from '../resolve/resolvers/file/index-node';
+import HttpResolverAxios from '../resolve/resolvers/http-axios';
+import OpenApi3_0ResolveStrategy from '../resolve/strategies/openapi-3-0';
+import OpenApi3_1ResolveStrategy from '../resolve/strategies/openapi-3-1';
+import AsyncApi2ResolveStrategy from '../resolve/strategies/asyncapi-2';
+import ApiDesignSystemsJsonParser from '../parse/parsers/api-design-systems-json';
+import ApiDesignSystemsYamlParser from '../parse/parsers/api-design-systems-yaml';
+import OpenApiJson3_0Parser from '../parse/parsers/openapi-json-3-0';
+import OpenApiYaml3_0Parser from '../parse/parsers/openapi-yaml-3-0';
+import OpenApiJson3_1Parser from '../parse/parsers/openapi-json-3-1';
+import OpenApiYaml3_1Parser from '../parse/parsers/openapi-yaml-3-1';
+import AsyncApiJson2Parser from '../parse/parsers/asyncapi-json-2';
+import AsyncApiYaml2Parser from '../parse/parsers/asyncapi-yaml-2';
+import JsonParser from '../parse/parsers/json';
+import YamlParser from '../parse/parsers/yaml-1-2';
+import BinaryParser from '../parse/parsers/binary/index-node';
+import OpenApi3_0DereferenceStrategy from '../dereference/strategies/openapi-3-0';
+import OpenApi3_1DereferenceStrategy from '../dereference/strategies/openapi-3-1';
+import AsyncApi2DereferenceStrategy from '../dereference/strategies/asyncapi-2';
+import { options } from '../index';
+
+options.parse.parsers = [
+  OpenApiJson3_0Parser({ allowEmpty: true, sourceMap: false }),
+  OpenApiYaml3_0Parser({ allowEmpty: true, sourceMap: false }),
+  OpenApiJson3_1Parser({ allowEmpty: true, sourceMap: false }),
+  OpenApiYaml3_1Parser({ allowEmpty: true, sourceMap: false }),
+  AsyncApiJson2Parser({ allowEmpty: true, sourceMap: false }),
+  AsyncApiYaml2Parser({ allowEmpty: true, sourceMap: false }),
+  ApiDesignSystemsJsonParser({ allowEmpty: true, sourceMap: false }),
+  ApiDesignSystemsYamlParser({ allowEmpty: true, sourceMap: false }),
+  JsonParser({ allowEmpty: true, sourceMap: false }),
+  YamlParser({ allowEmpty: true, sourceMap: false }),
+  BinaryParser({ allowEmpty: true }),
+];
+
+options.resolve.resolvers = [
+  FileResolver(),
+  HttpResolverAxios({ timeout: 5000, redirects: 5, withCredentials: false }),
+];
+
+options.resolve.strategies = [
+  OpenApi3_0ResolveStrategy(),
+  OpenApi3_1ResolveStrategy(),
+  AsyncApi2ResolveStrategy(),
+];
+
+options.dereference.strategies = [
+  OpenApi3_0DereferenceStrategy(),
+  OpenApi3_1DereferenceStrategy(),
+  AsyncApi2DereferenceStrategy(),
+];
+
+export * from '../index';

--- a/packages/apidom-reference/src/index.ts
+++ b/packages/apidom-reference/src/index.ts
@@ -10,38 +10,33 @@ import resolveFn, { resolveApiDOM as resolveApiDOMFn } from './resolve';
 import { readFile as readFileFn } from './resolve/util';
 import dereferenceFn, { dereferenceApiDOM as dereferenceApiDOMFn } from './dereference';
 
+export { url };
+
 export { default as Parser } from './parse/parsers/Parser';
-export { default as ApiDesignSystemsJsonParser } from './parse/parsers/api-design-systems-json';
-export { default as ApiDesignSystemsYamlParser } from './parse/parsers/api-design-systems-yaml';
-export { default as OpenApiJson3_0Parser } from './parse/parsers/openapi-json-3-0';
-export { default as OpenApiYaml3_0Parser } from './parse/parsers/openapi-yaml-3-0';
-export { default as OpenApiJson3_1Parser } from './parse/parsers/openapi-json-3-1';
-export { default as OpenApiYaml3_1Parser } from './parse/parsers/openapi-yaml-3-1';
-export { default as AsyncApiJson2Parser } from './parse/parsers/asyncapi-json-2';
-export { default as AsyncApiYaml2Parser } from './parse/parsers/asyncapi-yaml-2';
-export { default as JsonParser } from './parse/parsers/json';
-export { default as YamlParser } from './parse/parsers/yaml-1-2';
-export { default as BinaryParser } from './parse/parsers/binary/index-node';
 
-export { default as FileResolver } from './resolve/resolvers/file/index-node';
-export { default as HttpResolverAxios } from './resolve/resolvers/http-axios';
-export { default as HttpResolverSwaggerClient } from './resolve/resolvers/http-swagger-client';
-export { default as HttpResolver } from './resolve/resolvers/HttpResolver';
 export { default as Resolver } from './resolve/resolvers/Resolver';
-export { default as ResolveStrategy } from './resolve/strategies/ResolveStrategy';
-export { default as AsyncApi2ResolveStrategy } from './resolve/strategies/asyncapi-2';
-export { default as OpenApi3_0ResolveStrategy } from './resolve/strategies/openapi-3-0';
-export { default as OpenApi3_1ResolveStrategy } from './resolve/strategies/openapi-3-1';
 
-export { default as AsyncApi2DereferenceStrategy } from './dereference/strategies/asyncapi-2';
-export { default as OpenApi3_0DereferenceStrategy } from './dereference/strategies/openapi-3-0';
-export { default as OpenApi3_1DereferenceStrategy } from './dereference/strategies/openapi-3-1';
+export { default as ResolveStrategy } from './resolve/strategies/ResolveStrategy';
 
 export { default as options } from './options';
 export { merge as mergeOptions } from './options/util';
 
 export { default as Reference } from './Reference';
 export { default as ReferenceSet } from './ReferenceSet';
+
+export {
+  DereferenceError,
+  InvalidSelectorError,
+  MaximumDereferenceDepthError,
+  MaximumResolverDepthError,
+  NotImplementedError,
+  ParserError,
+  PluginError,
+  ResolverError,
+  UnmatchedDereferenceStrategyError,
+  UnmatchedResolveStrategyError,
+  UnmatchedResolverError,
+} from './util/errors';
 
 export const readFile = async (uri: string, options = {}): Promise<Buffer> => {
   const mergedOptions = mergeOptions(defaultOptions, options);
@@ -80,17 +75,3 @@ export const dereferenceApiDOM = async <T extends Element>(
   const mergedOptions = mergeOptions(defaultOptions, options);
   return dereferenceApiDOMFn(element, mergedOptions);
 };
-
-export {
-  DereferenceError,
-  InvalidSelectorError,
-  MaximumDereferenceDepthError,
-  MaximumResolverDepthError,
-  NotImplementedError,
-  ParserError,
-  PluginError,
-  ResolverError,
-  UnmatchedDereferenceStrategyError,
-  UnmatchedResolveStrategyError,
-  UnmatchedResolverError,
-} from './util/errors';

--- a/packages/apidom-reference/src/options/index.ts
+++ b/packages/apidom-reference/src/options/index.ts
@@ -1,22 +1,3 @@
-import FileResolver from '../resolve/resolvers/file/index-node';
-import HttpResolverAxios from '../resolve/resolvers/http-axios';
-import OpenApi3_0ResolveStrategy from '../resolve/strategies/openapi-3-0';
-import OpenApi3_1ResolveStrategy from '../resolve/strategies/openapi-3-1';
-import AsyncApi2ResolveStrategy from '../resolve/strategies/asyncapi-2';
-import ApiDesignSystemsJsonParser from '../parse/parsers/api-design-systems-json';
-import ApiDesignSystemsYamlParser from '../parse/parsers/api-design-systems-yaml';
-import OpenApiJson3_0Parser from '../parse/parsers/openapi-json-3-0';
-import OpenApiYaml3_0Parser from '../parse/parsers/openapi-yaml-3-0';
-import OpenApiJson3_1Parser from '../parse/parsers/openapi-json-3-1';
-import OpenApiYaml3_1Parser from '../parse/parsers/openapi-yaml-3-1';
-import AsyncApiJson2Parser from '../parse/parsers/asyncapi-json-2';
-import AsyncApiYaml2Parser from '../parse/parsers/asyncapi-yaml-2';
-import JsonParser from '../parse/parsers/json';
-import YamlParser from '../parse/parsers/yaml-1-2';
-import BinaryParser from '../parse/parsers/binary/index-node';
-import OpenApi3_0DereferenceStrategy from '../dereference/strategies/openapi-3-0';
-import OpenApi3_1DereferenceStrategy from '../dereference/strategies/openapi-3-1';
-import AsyncApi2DereferenceStrategy from '../dereference/strategies/asyncapi-2';
 import { ReferenceOptions as IReferenceOptions } from '../types';
 
 const defaultOptions: IReferenceOptions = {
@@ -33,19 +14,7 @@ const defaultOptions: IReferenceOptions = {
      * your own implementation, or remove any resolver by removing it from the list.
      * It's recommended to keep the order of parser from most specific ones to most generic ones.
      */
-    parsers: [
-      OpenApiJson3_0Parser({ allowEmpty: true, sourceMap: false }),
-      OpenApiYaml3_0Parser({ allowEmpty: true, sourceMap: false }),
-      OpenApiJson3_1Parser({ allowEmpty: true, sourceMap: false }),
-      OpenApiYaml3_1Parser({ allowEmpty: true, sourceMap: false }),
-      AsyncApiJson2Parser({ allowEmpty: true, sourceMap: false }),
-      AsyncApiYaml2Parser({ allowEmpty: true, sourceMap: false }),
-      ApiDesignSystemsJsonParser({ allowEmpty: true, sourceMap: false }),
-      ApiDesignSystemsYamlParser({ allowEmpty: true, sourceMap: false }),
-      JsonParser({ allowEmpty: true, sourceMap: false }),
-      YamlParser({ allowEmpty: true, sourceMap: false }),
-      BinaryParser({ allowEmpty: true }),
-    ],
+    parsers: [],
 
     /**
      * These options are merged with parser plugin instance before the plugin is run.
@@ -63,10 +32,7 @@ const defaultOptions: IReferenceOptions = {
      * You can add additional resolvers of your own, replace an existing one with
      * your own implementation, or remove any resolver by removing it from the list.
      */
-    resolvers: [
-      FileResolver(),
-      HttpResolverAxios({ timeout: 5000, redirects: 5, withCredentials: false }),
-    ],
+    resolvers: [],
     /**
      * These options are merged with resolver plugin instance before the plugin is run.
      */
@@ -78,11 +44,7 @@ const defaultOptions: IReferenceOptions = {
      * You can add additional resolver strategies of your own, replace an existing one with
      * your own implementation, or remove any resolve strategy by removing it from the list.
      */
-    strategies: [
-      OpenApi3_0ResolveStrategy(),
-      OpenApi3_1ResolveStrategy(),
-      AsyncApi2ResolveStrategy(),
-    ],
+    strategies: [],
     /**
      * Determines whether external references will be resolved.
      * If this option is disabled, then none of above resolvers will be called.
@@ -110,11 +72,7 @@ const defaultOptions: IReferenceOptions = {
      * You can add additional dereference strategies of your own, replace an existing one with
      * your own implementation, or remove any dereference strategy by removing it from the list.
      */
-    strategies: [
-      OpenApi3_0DereferenceStrategy(),
-      OpenApi3_1DereferenceStrategy(),
-      AsyncApi2DereferenceStrategy(),
-    ],
+    strategies: [],
     /**
      * This option accepts an instance of pre-computed ReferenceSet.
      * If provided it will speed up the dereferencing significantly as the external

--- a/packages/apidom-reference/test/mocha-bootstrap.cjs
+++ b/packages/apidom-reference/test/mocha-bootstrap.cjs
@@ -5,7 +5,7 @@ const { jestSnapshotPlugin, addSerializer } = require('mocha-chai-jest-snapshot'
 
 const jestApiDOMSerializer = require('../../../scripts/jest-serializer-apidom.cjs');
 const jestStringSerializer = require('../../../scripts/jest-serializer-string.cjs');
-const { options } = require('../src/configuration/complete');
+const { options } = require('../src/configuration/saturated');
 
 // setup snapshot testing
 chai.use(jestSnapshotPlugin());

--- a/packages/apidom-reference/test/mocha-bootstrap.cjs
+++ b/packages/apidom-reference/test/mocha-bootstrap.cjs
@@ -5,7 +5,7 @@ const { jestSnapshotPlugin, addSerializer } = require('mocha-chai-jest-snapshot'
 
 const jestApiDOMSerializer = require('../../../scripts/jest-serializer-apidom.cjs');
 const jestStringSerializer = require('../../../scripts/jest-serializer-string.cjs');
-const { options } = require('../src');
+const { options } = require('../src/configuration/complete');
 
 // setup snapshot testing
 chai.use(jestSnapshotPlugin());

--- a/packages/apidom-reference/test/resolve/index.ts
+++ b/packages/apidom-reference/test/resolve/index.ts
@@ -2,7 +2,8 @@ import path from 'node:path';
 import { assert } from 'chai';
 import { mediaTypes } from '@swagger-api/apidom-ns-openapi-3-1';
 
-import { resolve, resolveApiDOM, parse, FileResolver } from '../../src';
+import { resolve, resolveApiDOM, parse } from '../../src';
+import FileResolver from '../../src/resolve/resolvers/file/index-node';
 import { UnmatchedResolveStrategyError, ResolverError, ParserError } from '../../src/util/errors';
 import OpenApiJson3_1Parser from '../../src/parse/parsers/openapi-json-3-1';
 


### PR DESCRIPTION
Configuration of options has been extracted into
configuration/ module. This allowed to separate
all abstractions from the configuration.

apidom-reference package now exports two types
of configuration - saturated and empty.

Saturated configuration setups all the package components and wire them into options.

Empty configuration setups empty options.

sideEffects package.json field has been turned on for the satured configuration.

Subpath exports has been utilized to allow importing individual components without importing everything.

Refs #2718

