### PR TITLE
fix(core): fix serialization of BooleanElement(false) elements

### DIFF
--- a/packages/apidom-ast/src/traversal/visitor.ts
+++ b/packages/apidom-ast/src/traversal/visitor.ts
@@ -196,6 +196,7 @@ export const visit = (
     state = {},
     breakSymbol = BREAK,
     deleteNodeSymbol = null,
+    skipVisitingNodeSymbol = false,
     visitFnGetter = getVisitFn,
     nodeTypeGetter = getNodeType,
     nodePredicate = isNode,
@@ -296,7 +297,7 @@ export const visit = (
           break;
         }
 
-        if (result === false) {
+        if (result === skipVisitingNodeSymbol) {
           if (!isLeaving) {
             path.pop();
             continue;
@@ -354,6 +355,7 @@ visit[Symbol.for('nodejs.util.promisify.custom')] = async (
     state = {},
     breakSymbol = BREAK,
     deleteNodeSymbol = null,
+    skipVisitingNodeSymbol = false,
     visitFnGetter = getVisitFn,
     nodeTypeGetter = getNodeType,
     nodePredicate = isNode,
@@ -450,7 +452,7 @@ visit[Symbol.for('nodejs.util.promisify.custom')] = async (
           break;
         }
 
-        if (result === false) {
+        if (result === skipVisitingNodeSymbol) {
           if (!isLeaving) {
             path.pop();
             continue;

--- a/packages/apidom-core/src/serializers/value/visitor.ts
+++ b/packages/apidom-core/src/serializers/value/visitor.ts
@@ -35,6 +35,7 @@ export const visit = (
     nodePredicate: stubTrue,
     detectCycles: false,
     deleteNodeSymbol: Symbol.for('delete-node'),
+    skipVisitingNodeSymbol: Symbol.for('skip-visiting-node'),
     ...rest,
   });
 };
@@ -51,6 +52,7 @@ visit[Symbol.for('nodejs.util.promisify.custom')] = async (
     nodePredicate: stubTrue,
     detectCycles: false,
     deleteNodeSymbol: Symbol.for('delete-node'),
+    skipVisitingNodeSymbol: Symbol.for('skip-visiting-node'),
     ...rest,
   });
 };

--- a/packages/apidom-core/test/serializers/value.ts
+++ b/packages/apidom-core/test/serializers/value.ts
@@ -14,9 +14,11 @@ describe('serializers', function () {
   context('value', function () {
     context('given BooleanElement', function () {
       specify('should serialize to JavaScript value', function () {
-        const booleanElement = new BooleanElement(true);
+        const trueBooleanElement = new BooleanElement(true);
+        const falseBooleanElement = new BooleanElement(false);
 
-        assert.strictEqual(serializer(booleanElement), true);
+        assert.strictEqual(serializer(trueBooleanElement), true);
+        assert.strictEqual(serializer(falseBooleanElement), false);
       });
     });
 
@@ -46,9 +48,9 @@ describe('serializers', function () {
 
     context('given ObjectElement', function () {
       specify('should serialize to JavaScript value', function () {
-        const objectElement = new ObjectElement({ a: { b: { c: 'd' } } });
+        const objectElement = new ObjectElement({ a: { b: { c: 'd', e: true } } });
 
-        assert.deepEqual(serializer(objectElement), { a: { b: { c: 'd' } } });
+        assert.deepEqual(serializer(objectElement), { a: { b: { c: 'd', e: true } } });
       });
 
       context('and with cycle', function () {
@@ -120,6 +122,15 @@ describe('serializers', function () {
 
         assert.deepEqual(serialized, [{ a: 'b' }, { a: 'b' }]);
         assert.strictEqual(serialized[0], serialized[1]);
+      });
+    });
+
+    context('given ObjectElement with undefined value', function () {
+      specify('should serialize to JavaScript value', function () {
+        const object = new ObjectElement({ a: undefined });
+        const serialized = serializer(object);
+
+        assert.deepEqual(serialized, { a: undefined });
       });
     });
 


### PR DESCRIPTION
When BooleanElement(false) get's converted to primitive false value, this value was returned from visitor method. Visitor mechanism uses boolean false value returned from visitor methods as indicator that it should skip visiting the node.

Thus the value that is used as an indicator is now configurable and for the purpose of toValue serialization, different indicator is used.

Refs https://github.com/swagger-api/swagger-editor/issues/3723