### PR TITLE
feat(reference): add fallbacks for Node.js protocol imports

### DIFF
--- a/packages/apidom-reference/package.json
+++ b/packages/apidom-reference/package.json
@@ -165,6 +165,29 @@
       "types": "./types/dereference/strategies/openapi-3-1-swagger-client/index.d.ts"
     }
   },
+  "imports": {
+    "#buffer": {
+      "node": {
+        "import": "./es/util/polyfills/buffer/protocol-import.js",
+        "require": "./cjs/util/polyfills/buffer/standard-import.cjs"
+      },
+      "default": "./cjs/util/polyfills/buffer/standard-import.cjs"
+    },
+    "#fs": {
+      "node": {
+        "import": "./es/util/polyfills/fs/protocol-import.js",
+        "require": "./cjs/util/polyfills/fs/standard-import.cjs"
+      },
+      "default": "./cjs/util/polyfills/fs/standard-import.cjs"
+    },
+    "#util": {
+      "node": {
+        "import": "./es/util/polyfills/util/protocol-import.js",
+        "require": "./cjs/util/polyfills/util/standard-import.cjs"
+      },
+      "default": "./cjs/util/polyfills/util/standard-import.cjs"
+    }
+  },
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",

--- a/packages/apidom-reference/src/parse/parsers/binary/index-node.ts
+++ b/packages/apidom-reference/src/parse/parsers/binary/index-node.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'node:buffer';
+import { Buffer } from '#buffer'; // eslint-disable-line import/order
 import stampit from 'stampit';
 import { ParseResultElement, StringElement } from '@swagger-api/apidom-core';
 

--- a/packages/apidom-reference/src/resolve/resolvers/file/index-node.ts
+++ b/packages/apidom-reference/src/resolve/resolvers/file/index-node.ts
@@ -1,5 +1,5 @@
-import { readFile } from 'node:fs';
-import { promisify } from 'node:util';
+import { readFile } from '#fs'; // eslint-disable-line import/order
+import { promisify } from '#util'; // eslint-disable-line import/order
 import stampit from 'stampit';
 import minimatch from 'minimatch';
 

--- a/packages/apidom-reference/src/util/polyfills/buffer/protocol-import.ts
+++ b/packages/apidom-reference/src/util/polyfills/buffer/protocol-import.ts
@@ -1,0 +1,5 @@
+/**
+ * This is polyfill for Node.js >=16.0.0 && >=v14.18.0
+ * which support node protocol imports.
+ */
+export * from 'node:buffer';

--- a/packages/apidom-reference/src/util/polyfills/buffer/standard-import.ts
+++ b/packages/apidom-reference/src/util/polyfills/buffer/standard-import.ts
@@ -1,0 +1,5 @@
+/**
+ * This is polyfill for Node.js >=v12.20.0
+ * which doesn't support node protocol imports.
+ */
+export * from 'buffer';

--- a/packages/apidom-reference/src/util/polyfills/fs/protocol-import.ts
+++ b/packages/apidom-reference/src/util/polyfills/fs/protocol-import.ts
@@ -1,0 +1,5 @@
+/**
+ * This is polyfill for Node.js >=16.0.0 && >=v14.18.0
+ * which support node protocol imports.
+ */
+export * from 'node:fs';

--- a/packages/apidom-reference/src/util/polyfills/fs/standard-import.ts
+++ b/packages/apidom-reference/src/util/polyfills/fs/standard-import.ts
@@ -1,0 +1,5 @@
+/**
+ * This is polyfill for Node.js >=v12.20.0
+ * which doesn't support node protocol imports.
+ */
+export * from 'fs';

--- a/packages/apidom-reference/src/util/polyfills/util/protocol-import.ts
+++ b/packages/apidom-reference/src/util/polyfills/util/protocol-import.ts
@@ -1,0 +1,5 @@
+/**
+ * This is polyfill for Node.js >=16.0.0 && >=v14.18.0
+ * which support node protocol imports.
+ */
+export * from 'node:util';

--- a/packages/apidom-reference/src/util/polyfills/util/standard-import.ts
+++ b/packages/apidom-reference/src/util/polyfills/util/standard-import.ts
@@ -1,0 +1,5 @@
+/**
+ * This is polyfill for Node.js >=v12.20.0
+ * which doesn't support node protocol imports.
+ */
+export * from 'util';

--- a/packages/apidom-reference/tsconfig.json
+++ b/packages/apidom-reference/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "#buffer": ["./src/util/polyfills/buffer/protocol-import"],
+      "#fs": ["./src/util/polyfills/fs/protocol-import"],
+      "#util": ["./src/util/polyfills/util/protocol-import"]
+    }
+  },
   "include": [
     "src/**/*",
     "test/**/*"


### PR DESCRIPTION
This will allow to use ApiDOM with Node.js >= 12.20.0. As exports field condition doesn't allow to specify Node.js versions, when code is requested using require(), non-protocol import fallback will be always used.

Protocol import support is as follows:
- v16.0.0, v14.18.0 (ESM import and CommonJS require())
- v14.13.1, v12.20.0 (only ESM import)