### PR TITLE
test(ns-openapi-3-0): add additional test for Schema.items

### DIFF
--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Schema/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Schema/__snapshots__/index.ts.snap
@@ -20,6 +20,13 @@ exports[`refractor elements SchemaElement given embedded SchemaElements should r
           (SchemaElement))))))
 `;
 
+exports[`refractor elements SchemaElement given items keyword in form of object should refract to semantic ApiDOM tree 1`] = `
+(SchemaElement
+  (MemberElement
+    (StringElement)
+    (SchemaElement)))
+`;
+
 exports[`refractor elements SchemaElement should refract to semantic ApiDOM tree 1`] = `
 (SchemaElement
   (MemberElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Schema/index.ts
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Schema/index.ts
@@ -59,6 +59,16 @@ describe('refractor', function () {
         expect(sexprs(schemaElement)).toMatchSnapshot();
       });
 
+      context('given items keyword in form of object', function () {
+        specify('should refract to semantic ApiDOM tree', function () {
+          const schemaElement = SchemaElement.refract({
+            items: {},
+          });
+
+          expect(sexprs(schemaElement)).toMatchSnapshot();
+        });
+      });
+
       context('given embedded SchemaElements', function () {
         specify('should refract to semantic ApiDOM tree', function () {
           const schemaElement = SchemaElement.refract({


### PR DESCRIPTION
This test guarantees that when Schema.items
is on object, it refracts to Schema. When
Schema.items is array, this array is refracted
into generic array and not array of Schemas.

Refs #2470
