### PR TITLE
fix(core): fix isArrayElement predicate polymorhic characteristics

### DIFF
--- a/packages/apidom-core/src/predicates/index.ts
+++ b/packages/apidom-core/src/predicates/index.ts
@@ -49,19 +49,6 @@ export const isBooleanElement = createPredicate(({ hasBasicElementProps, primiti
     (hasBasicElementProps(element) && primitiveEq('boolean', element));
 });
 
-export const isArrayElement = createPredicate(
-  ({ hasBasicElementProps, primitiveEq, hasMethod }) => {
-    return (element: any) =>
-      element instanceof ArrayElement ||
-      (hasBasicElementProps(element) &&
-        primitiveEq('array', element) &&
-        hasMethod('push', element) &&
-        hasMethod('unshift', element) &&
-        hasMethod('map', element) &&
-        hasMethod('reduce', element));
-  },
-);
-
 export const isObjectElement = createPredicate(
   ({ hasBasicElementProps, primitiveEq, hasMethod }) => {
     return (element: any) =>
@@ -71,6 +58,19 @@ export const isObjectElement = createPredicate(
         hasMethod('keys', element) &&
         hasMethod('values', element) &&
         hasMethod('items', element));
+  },
+);
+
+export const isArrayElement = createPredicate(
+  ({ hasBasicElementProps, primitiveEq, hasMethod }) => {
+    return (element: any) =>
+      (element instanceof ArrayElement && !(element instanceof ObjectElement)) ||
+      (hasBasicElementProps(element) &&
+        primitiveEq('array', element) &&
+        hasMethod('push', element) &&
+        hasMethod('unshift', element) &&
+        hasMethod('map', element) &&
+        hasMethod('reduce', element));
   },
 );
 

--- a/packages/apidom-core/test/predicates/index.ts
+++ b/packages/apidom-core/test/predicates/index.ts
@@ -359,7 +359,9 @@ describe('predicates', function () {
 
     context('given subtype instance value', function () {
       specify('should return true', function () {
-        assert.isTrue(isArrayElement(new ObjectElement()));
+        class ArraySubElement extends ArrayElement {}
+
+        assert.isTrue(isArrayElement(new ArraySubElement()));
       });
     });
 
@@ -371,6 +373,7 @@ describe('predicates', function () {
         assert.isFalse(isArrayElement({}));
         assert.isFalse(isArrayElement([]));
         assert.isFalse(isArrayElement('string'));
+        assert.isFalse(isArrayElement(new ObjectElement()));
 
         assert.isFalse(isArrayElement(new StringElement()));
         assert.isFalse(isArrayElement(new BooleanElement()));


### PR DESCRIPTION
As ObjectElement is extension of ArrayElement,
isArrayElement returned true for every ObjectElement instance. Although that was technically correct, it was casing nasty bugs when using isArrayElement.

This commit make the fact that the ObjectElement is extension of ArrayElement an implementation detail, and from now on isArrayElement returns false when asserting on ObjectElement.

