### PR TITLE
chore(SCA): remove all whitesource configs

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,3 +1,0 @@
-{
-  "settingsInheritedFrom": "swagger-api/whitesource-config@main"
-}

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,1 +1,0 @@
-npm.includeDevDependencies=true


### PR DESCRIPTION
We've stopped using Whitesource as of 1st January 2023.