### PR TITLE
fix(ls): fix Parameter Object required fields lint rule

### DIFF
--- a/packages/apidom-ls/src/config/openapi/parameter/lint/required-fields.ts
+++ b/packages/apidom-ls/src/config/openapi/parameter/lint/required-fields.ts
@@ -13,6 +13,10 @@ const requiredFieldsLint: LinterMeta = {
   marker: 'key',
   conditions: [
     {
+      function: 'missingField',
+      params: ['$ref'],
+    },
+    {
       function: 'missingFields',
       params: [['content', 'schema']],
     },


### PR DESCRIPTION
Before the fix, Reference Object referencing Parameter Objects generated 5150001 error, which was a false positive.

Refs https://github.com/swagger-api/swagger-editor/issues/3791