### PR TITLE
fix(deps): relax @babel/runtime-corejs3 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29278,7 +29278,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -29291,7 +29291,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-ast": "^0.67.0",
         "@types/ramda": "=0.28.23",
         "minim": "=0.23.8",
@@ -29306,7 +29306,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-json-pointer": "^0.67.0",
         "jsonpath-plus": "=7.2.0"
@@ -29317,7 +29317,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
@@ -29328,7 +29328,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-json-pointer": "^0.67.0",
         "@swagger-api/apidom-ns-api-design-systems": "^0.67.0",
@@ -29373,7 +29373,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-1": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -29387,7 +29387,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-json-schema-draft-7": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -29401,7 +29401,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
@@ -29414,7 +29414,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-json-schema-draft-4": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -29428,7 +29428,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-json-schema-draft-6": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -29442,7 +29442,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-json-schema-draft-4": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -29456,7 +29456,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-0": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -29470,7 +29470,7 @@
       "version": "0.66.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.66.0",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
@@ -29529,7 +29529,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
@@ -29542,7 +29542,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-api-design-systems": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-json": "^0.67.0",
@@ -29556,7 +29556,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-api-design-systems": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",
@@ -29570,7 +29570,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-asyncapi-2": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-json": "^0.67.0",
@@ -29584,7 +29584,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-asyncapi-2": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",
@@ -29598,7 +29598,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-ast": "^0.67.0",
         "@swagger-api/apidom-core": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -29618,7 +29618,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-0": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-json": "^0.67.0",
@@ -29632,7 +29632,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-1": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-json": "^0.67.0",
@@ -29646,7 +29646,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-0": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",
@@ -29660,7 +29660,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-1": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",
@@ -29674,7 +29674,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-ast": "^0.67.0",
         "@swagger-api/apidom-core": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -29739,7 +29739,7 @@
       "version": "0.67.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-json-pointer": "^0.67.0",
         "@swagger-api/apidom-ns-asyncapi-2": "^0.67.0",
@@ -33808,7 +33808,7 @@
     "@swagger-api/apidom-ast": {
       "version": "file:packages/apidom-ast",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -33819,7 +33819,7 @@
     "@swagger-api/apidom-core": {
       "version": "file:packages/apidom-core",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-ast": "^0.67.0",
         "@types/ramda": "=0.28.23",
         "minim": "=0.23.8",
@@ -33832,7 +33832,7 @@
     "@swagger-api/apidom-json-path": {
       "version": "file:packages/apidom-json-path",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-json-pointer": "^0.67.0",
         "jsonpath-plus": "=7.2.0"
@@ -33841,7 +33841,7 @@
     "@swagger-api/apidom-json-pointer": {
       "version": "file:packages/apidom-json-pointer",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0"
@@ -33850,7 +33850,7 @@
     "@swagger-api/apidom-ls": {
       "version": "file:packages/apidom-ls",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-json-pointer": "^0.67.0",
         "@swagger-api/apidom-ns-api-design-systems": "^0.67.0",
@@ -33892,7 +33892,7 @@
     "@swagger-api/apidom-ns-api-design-systems": {
       "version": "file:packages/apidom-ns-api-design-systems",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-1": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -33904,7 +33904,7 @@
     "@swagger-api/apidom-ns-asyncapi-2": {
       "version": "file:packages/apidom-ns-asyncapi-2",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-json-schema-draft-7": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -33916,7 +33916,7 @@
     "@swagger-api/apidom-ns-json-schema-draft-4": {
       "version": "file:packages/apidom-ns-json-schema-draft-4",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
@@ -33927,7 +33927,7 @@
     "@swagger-api/apidom-ns-json-schema-draft-6": {
       "version": "file:packages/apidom-ns-json-schema-draft-6",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-json-schema-draft-4": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -33939,7 +33939,7 @@
     "@swagger-api/apidom-ns-json-schema-draft-7": {
       "version": "file:packages/apidom-ns-json-schema-draft-7",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-json-schema-draft-6": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -33951,7 +33951,7 @@
     "@swagger-api/apidom-ns-openapi-3-0": {
       "version": "file:packages/apidom-ns-openapi-3-0",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-json-schema-draft-4": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -33963,7 +33963,7 @@
     "@swagger-api/apidom-ns-openapi-3-1": {
       "version": "file:packages/apidom-ns-openapi-3-1",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-0": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -33975,7 +33975,7 @@
     "@swagger-api/apidom-ns-workflows-1": {
       "version": "file:packages/apidom-ns-workflows-1",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.66.0",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
@@ -34036,7 +34036,7 @@
     "@swagger-api/apidom-parser": {
       "version": "file:packages/apidom-parser",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@types/ramda": "=0.28.23",
         "ramda": "=0.28.0",
@@ -34047,7 +34047,7 @@
     "@swagger-api/apidom-parser-adapter-api-design-systems-json": {
       "version": "file:packages/apidom-parser-adapter-api-design-systems-json",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-api-design-systems": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-json": "^0.67.0",
@@ -34059,7 +34059,7 @@
     "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
       "version": "file:packages/apidom-parser-adapter-api-design-systems-yaml",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-api-design-systems": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",
@@ -34071,7 +34071,7 @@
     "@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
       "version": "file:packages/apidom-parser-adapter-asyncapi-json-2",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-asyncapi-2": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-json": "^0.67.0",
@@ -34083,7 +34083,7 @@
     "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
       "version": "file:packages/apidom-parser-adapter-asyncapi-yaml-2",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-asyncapi-2": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",
@@ -34095,7 +34095,7 @@
     "@swagger-api/apidom-parser-adapter-json": {
       "version": "file:packages/apidom-parser-adapter-json",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-ast": "^0.67.0",
         "@swagger-api/apidom-core": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -34111,7 +34111,7 @@
     "@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
       "version": "file:packages/apidom-parser-adapter-openapi-json-3-0",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-0": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-json": "^0.67.0",
@@ -34123,7 +34123,7 @@
     "@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
       "version": "file:packages/apidom-parser-adapter-openapi-json-3-1",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-1": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-json": "^0.67.0",
@@ -34135,7 +34135,7 @@
     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
       "version": "file:packages/apidom-parser-adapter-openapi-yaml-3-0",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-0": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",
@@ -34147,7 +34147,7 @@
     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
       "version": "file:packages/apidom-parser-adapter-openapi-yaml-3-1",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-ns-openapi-3-1": "^0.67.0",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",
@@ -34159,7 +34159,7 @@
     "@swagger-api/apidom-parser-adapter-yaml-1-2": {
       "version": "file:packages/apidom-parser-adapter-yaml-1-2",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-ast": "^0.67.0",
         "@swagger-api/apidom-core": "^0.67.0",
         "@types/ramda": "=0.28.23",
@@ -34216,7 +34216,7 @@
     "@swagger-api/apidom-reference": {
       "version": "file:packages/apidom-reference",
       "requires": {
-        "@babel/runtime-corejs3": "=7.20.7",
+        "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.67.0",
         "@swagger-api/apidom-json-pointer": "^0.67.0",
         "@swagger-api/apidom-ns-asyncapi-2": "^0.67.0",

--- a/packages/apidom-ast/package.json
+++ b/packages/apidom-ast/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/swagger-api/apidom#readme",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@types/ramda": "=0.28.23",
     "ramda": "=0.28.0",
     "ramda-adjunct": "=3.4.0",

--- a/packages/apidom-core/package.json
+++ b/packages/apidom-core/package.json
@@ -36,7 +36,7 @@
   "author": "Vladimír Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-ast": "^0.67.0",
     "@types/ramda": "=0.28.23",
     "minim": "=0.23.8",

--- a/packages/apidom-json-path/package.json
+++ b/packages/apidom-json-path/package.json
@@ -35,7 +35,7 @@
   "author": "Vladimír Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-json-pointer": "^0.67.0",
     "jsonpath-plus": "=7.2.0"

--- a/packages/apidom-json-pointer/package.json
+++ b/packages/apidom-json-pointer/package.json
@@ -35,7 +35,7 @@
   "author": "Vladimír Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "ramda": "=0.28.0",
     "ramda-adjunct": "=3.4.0"

--- a/packages/apidom-ls/package.json
+++ b/packages/apidom-ls/package.json
@@ -39,7 +39,7 @@
     "postpack": "rimraf NOTICE LICENSES"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-json-pointer": "^0.67.0",
     "@swagger-api/apidom-ns-api-design-systems": "^0.67.0",

--- a/packages/apidom-ns-api-design-systems/package.json
+++ b/packages/apidom-ns-api-design-systems/package.json
@@ -36,7 +36,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-openapi-3-1": "^0.67.0",
     "@types/ramda": "=0.28.23",

--- a/packages/apidom-ns-asyncapi-2/package.json
+++ b/packages/apidom-ns-asyncapi-2/package.json
@@ -38,7 +38,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-json-schema-draft-7": "^0.67.0",
     "@types/ramda": "=0.28.23",

--- a/packages/apidom-ns-json-schema-draft-4/package.json
+++ b/packages/apidom-ns-json-schema-draft-4/package.json
@@ -36,7 +36,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@types/ramda": "=0.28.23",
     "ramda": "=0.28.0",

--- a/packages/apidom-ns-json-schema-draft-6/package.json
+++ b/packages/apidom-ns-json-schema-draft-6/package.json
@@ -36,7 +36,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-json-schema-draft-4": "^0.67.0",
     "@types/ramda": "=0.28.23",

--- a/packages/apidom-ns-json-schema-draft-7/package.json
+++ b/packages/apidom-ns-json-schema-draft-7/package.json
@@ -36,7 +36,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-json-schema-draft-6": "^0.67.0",
     "@types/ramda": "=0.28.23",

--- a/packages/apidom-ns-openapi-3-0/package.json
+++ b/packages/apidom-ns-openapi-3-0/package.json
@@ -36,7 +36,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-json-schema-draft-4": "^0.67.0",
     "@types/ramda": "=0.28.23",

--- a/packages/apidom-ns-openapi-3-1/package.json
+++ b/packages/apidom-ns-openapi-3-1/package.json
@@ -39,7 +39,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-openapi-3-0": "^0.67.0",
     "@types/ramda": "=0.28.23",

--- a/packages/apidom-ns-workflows-1/package.json
+++ b/packages/apidom-ns-workflows-1/package.json
@@ -37,7 +37,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.66.0",
     "@types/ramda": "=0.28.23",
     "ramda": "=0.28.0",

--- a/packages/apidom-parser-adapter-api-design-systems-json/package.json
+++ b/packages/apidom-parser-adapter-api-design-systems-json/package.json
@@ -35,7 +35,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-api-design-systems": "^0.67.0",
     "@swagger-api/apidom-parser-adapter-json": "^0.67.0",

--- a/packages/apidom-parser-adapter-api-design-systems-yaml/package.json
+++ b/packages/apidom-parser-adapter-api-design-systems-yaml/package.json
@@ -35,7 +35,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-api-design-systems": "^0.67.0",
     "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",

--- a/packages/apidom-parser-adapter-asyncapi-json-2/package.json
+++ b/packages/apidom-parser-adapter-asyncapi-json-2/package.json
@@ -40,7 +40,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-asyncapi-2": "^0.67.0",
     "@swagger-api/apidom-parser-adapter-json": "^0.67.0",

--- a/packages/apidom-parser-adapter-asyncapi-yaml-2/package.json
+++ b/packages/apidom-parser-adapter-asyncapi-yaml-2/package.json
@@ -40,7 +40,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-asyncapi-2": "^0.67.0",
     "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",

--- a/packages/apidom-parser-adapter-json/package.json
+++ b/packages/apidom-parser-adapter-json/package.json
@@ -47,7 +47,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-ast": "^0.67.0",
     "@swagger-api/apidom-core": "^0.67.0",
     "@types/ramda": "=0.28.23",

--- a/packages/apidom-parser-adapter-openapi-json-3-0/package.json
+++ b/packages/apidom-parser-adapter-openapi-json-3-0/package.json
@@ -35,7 +35,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-openapi-3-0": "^0.67.0",
     "@swagger-api/apidom-parser-adapter-json": "^0.67.0",

--- a/packages/apidom-parser-adapter-openapi-json-3-1/package.json
+++ b/packages/apidom-parser-adapter-openapi-json-3-1/package.json
@@ -40,7 +40,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-openapi-3-1": "^0.67.0",
     "@swagger-api/apidom-parser-adapter-json": "^0.67.0",

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/package.json
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/package.json
@@ -35,7 +35,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-openapi-3-0": "^0.67.0",
     "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",

--- a/packages/apidom-parser-adapter-openapi-yaml-3-1/package.json
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-1/package.json
@@ -40,7 +40,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-ns-openapi-3-1": "^0.67.0",
     "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.67.0",

--- a/packages/apidom-parser-adapter-yaml-1-2/package.json
+++ b/packages/apidom-parser-adapter-yaml-1-2/package.json
@@ -46,7 +46,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-ast": "^0.67.0",
     "@swagger-api/apidom-core": "^0.67.0",
     "@types/ramda": "=0.28.23",

--- a/packages/apidom-parser/package.json
+++ b/packages/apidom-parser/package.json
@@ -35,7 +35,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@types/ramda": "=0.28.23",
     "ramda": "=0.28.0",

--- a/packages/apidom-reference/package.json
+++ b/packages/apidom-reference/package.json
@@ -199,7 +199,7 @@
   "author": "Vladimir Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "=7.20.7",
+    "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.67.0",
     "@swagger-api/apidom-json-pointer": "^0.67.0",
     "@swagger-api/apidom-ns-asyncapi-2": "^0.67.0",


### PR DESCRIPTION
With this change we will avoid webpack aliases.

Refs #2562