### PR TITLE
fix(ls): serialize dereferenced ApiDOM to proper format

### DIFF
--- a/packages/apidom-core/src/index.ts
+++ b/packages/apidom-core/src/index.ts
@@ -108,7 +108,7 @@ export const toYAML = serializeYAML;
 export const dehydrate = (
   element: Element,
   namespace: INamespace = defaultNamespaceInstance,
-): Record<string, any> => {
+): any => {
   return namespace.toRefract(element);
 };
 

--- a/packages/apidom-core/src/serializers/json.ts
+++ b/packages/apidom-core/src/serializers/json.ts
@@ -2,6 +2,10 @@ import { Element } from 'minim';
 
 import serializeValue from './value';
 
-const serializer = (element: Element): string => JSON.stringify(serializeValue(element));
+const serializer = (
+  element: Element,
+  replacer?: (this: any, key: string, value: any) => any,
+  space?: string | number,
+): string => JSON.stringify(serializeValue(element), replacer, space);
 
 export default serializer;

--- a/packages/apidom-core/src/serializers/yaml-1-2.ts
+++ b/packages/apidom-core/src/serializers/yaml-1-2.ts
@@ -83,7 +83,7 @@ const YamlVisitor = stampit({
   },
 });
 
-const serializer = (element: Element): any => {
+const serializer = (element: Element): string => {
   const signature = '%YAML 1.2\n---\n';
   const visitor = YamlVisitor({ signature });
 

--- a/packages/apidom-core/test/serializers/yaml1-2.ts
+++ b/packages/apidom-core/test/serializers/yaml1-2.ts
@@ -46,6 +46,16 @@ describe('serializers', function () {
 
         assert.strictEqual(serialized, expected);
       });
+
+      context('and is multiline', function () {
+        specify('should serialize to YAML 1.2', function () {
+          const apidom = from('test\n\ntest\n');
+          const serialized = serialize(apidom);
+          const expected = `%YAML 1.2\n---\n${String.raw`"test\n\ntest\n"`}`;
+
+          assert.strictEqual(serialized, expected);
+        });
+      });
     });
 
     context('given NullElement', function () {

--- a/packages/apidom-ls/src/services/deref/deref-service.ts
+++ b/packages/apidom-ls/src/services/deref/deref-service.ts
@@ -1,7 +1,15 @@
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { dereferenceApiDOM } from '@swagger-api/apidom-reference';
 import { isString } from 'ramda-adjunct';
-import { ArraySlice, Element, filter, ObjectElement, toValue } from '@swagger-api/apidom-core';
+import {
+  ArraySlice,
+  Element,
+  filter,
+  ObjectElement,
+  toJSON,
+  toYAML,
+  toString,
+} from '@swagger-api/apidom-core';
 
 import { DerefContext, Format, LanguageSettings } from '../../apidom-language-types';
 import { parse } from '../../parser-factory';
@@ -78,12 +86,11 @@ export class DefaultDerefService implements DerefService {
         },
       },
     });
-    const dereferencedValue = toValue(dereferenced);
 
-    // TODO (francesco.tumanischvili@smartbear.com): transform/serialize to YAML if format `YAML` is passed
-    // @ts-ignore
-    return format === Format.YAML
-      ? JSON.stringify(dereferencedValue, null, 2) // serialize to YAML
-      : JSON.stringify(dereferencedValue, null, 2); // default to JSON
+    return format === Format.JSON
+      ? toJSON(dereferenced, undefined, 2)
+      : format === Format.YAML
+      ? toYAML(dereferenced)
+      : toString(dereferenced);
   }
 }


### PR DESCRIPTION
Before this fix, doDeref always returned
JSON string.

Refs #2662