### PR TITLE
fix(ls): provide completion items with proper filtering

### DIFF
--- a/packages/apidom-ls/src/services/completion/completion-service.ts
+++ b/packages/apidom-ls/src/services/completion/completion-service.ts
@@ -781,7 +781,7 @@ export class DefaultCompletionService implements CompletionService {
             */
             item.filterText = text.substring(nodeSourceMap.offset, nodeSourceMap.endOffset!);
 
-            if (word && word.length > 0 && unquotedOriginalInsertText?.startsWith(word)) {
+            if (word && word.length > 0 && unquotedOriginalInsertText?.includes(word)) {
               collector.add(item);
             } else if (!word) {
               collector.add(item);


### PR DESCRIPTION
Before this change, completion items were only
provided if they started by the filtered text.

With this change, completion items are provided
if they include filtered text.

Refs https://github.com/swagger-api/swagger-editor/issues/3216