### PR TITLE
fix(ls): fix OpenAPI 3.x.y Server.url field linting

### DIFF
--- a/packages/apidom-ls/src/config/openapi/server/lint/url--format-uri.ts
+++ b/packages/apidom-ls/src/config/openapi/server/lint/url--format-uri.ts
@@ -12,6 +12,12 @@ const urlFormatURILint: LinterMeta = {
   marker: 'value',
   target: 'url',
   data: {},
+  conditions: [
+    {
+      function: 'apilintValueRegex',
+      params: ['^(?!.*\\{\\S+?\\}).*$'], // validate as URI only if variables in brackets not present
+    },
+  ],
 };
 
 export default urlFormatURILint;


### PR DESCRIPTION
Server.url field in not validated as URL if it
contains {variables} inside it.

Refs #2858
