### PR TITLE
bug(apidom-parser-adapter-yaml-1-2): Change message returned for syntax errors

### DIFF
--- a/packages/apidom-parser-adapter-yaml-1-2/src/syntactic-analysis/visitors/CstVisitor.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/src/syntactic-analysis/visitors/CstVisitor.ts
@@ -618,7 +618,7 @@ const CstVisitor = stampit({
         position,
         isUnexpected: !node.hasError(),
         isMissing: node.isMissing(),
-        value: node.text,
+        value: 'YAML Syntax error',
       });
 
       if (path.length === 0) {

--- a/packages/apidom-parser-adapter-yaml-1-2/src/syntactic-analysis/visitors/YamlAstVisitor.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/src/syntactic-analysis/visitors/YamlAstVisitor.ts
@@ -203,7 +203,12 @@ const YamlAstVisitor = stampit({
     };
 
     this.error = function error(node: Error, key: any, parent: any, path: string[]) {
-      const message = node.isUnexpected ? `(Unexpected ${node.value})` : `(Error ${node.value})`;
+      const message =
+        node?.value === 'YAML Syntax error'
+          ? node.value
+          : node.isUnexpected
+          ? `(Unexpected ${node.value})`
+          : `(Error ${node.value})`;
       const element = new AnnotationElement(message);
 
       element.classes.push('error');

--- a/packages/apidom-parser-adapter-yaml-1-2/test/adapter-browser.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/test/adapter-browser.ts
@@ -96,4 +96,34 @@ describe('adapter-browser', function () {
       assert.isTrue(parseResult.isEmpty);
     });
   });
+
+  context('given YAML 1.2 containing a syntax error(1)', function () {
+    specify('return YAML Syntax error as an annotation in parsing result', async function () {
+      const syntaxErrorSpec = `
+        asyncapi: 2.4.0
+        info:
+          version: '1.0.0'
+           title: Something # Badly indented
+      `;
+
+      const parseResult = await adapter.parse(syntaxErrorSpec, { sourceMap: true });
+
+      assert.isTrue(parseResult.errors.toValue()[0] === 'YAML Syntax error');
+    });
+  });
+
+  context('given YAML 1.2 containing a syntax error(2)', function () {
+    specify('return YAML Syntax error as an annotation in parsing result', async function () {
+      const syntaxErrorSpec = `
+        asyncapi: 2.4.0
+        info:
+          version: '1.0.0'
+          title Something # Missing mapping
+      `;
+
+      const parseResult = await adapter.parse(syntaxErrorSpec, { sourceMap: true });
+
+      assert.isTrue(parseResult.errors.toValue()[0] === 'YAML Syntax error');
+    });
+  });
 });

--- a/packages/apidom-parser-adapter-yaml-1-2/test/adapter-node/index.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/test/adapter-node/index.ts
@@ -80,4 +80,34 @@ describe('adapter-node', function () {
       assert.isTrue(parseResult.isEmpty);
     });
   });
+
+  context('given YAML 1.2 containing a syntax error(1)', function () {
+    specify('return YAML Syntax error as an annotation in parsing result', async function () {
+      const syntaxErrorSpec = `
+        asyncapi: 2.4.0
+        info:
+          version: '1.0.0'
+           title: Something # Badly indented
+      `;
+
+      const parseResult = await adapter.parse(syntaxErrorSpec, { sourceMap: true });
+
+      assert.isTrue(parseResult.errors.toValue()[0] === 'YAML Syntax error');
+    });
+  });
+
+  context('given YAML 1.2 containing a syntax error(2)', function () {
+    specify('return YAML Syntax error as an annotation in parsing result', async function () {
+      const syntaxErrorSpec = `
+        asyncapi: 2.4.0
+        info:
+          version: '1.0.0'
+          title Something # Missing mapping
+      `;
+
+      const parseResult = await adapter.parse(syntaxErrorSpec, { sourceMap: true });
+
+      assert.isTrue(parseResult.errors.toValue()[0] === 'YAML Syntax error');
+    });
+  });
 });


### PR DESCRIPTION
This PR changes the error message returned by `apidom-parser-adapter-yaml-1-2` when it encounters a Syntax error.

### Description
This PR does the following:
- Changes error message returned by CstVisitor
- Adds a condition to add the correct error message in ParseResult when it's YAML Syntax error
- Adds unit tests for adapter-browser and adapter-node

### Motivation and Context
closes #2889 
Currently if `apidom-parser-adapter-yaml-1-2` encounters Syntax errors in YAML definition it returns the ERROR node as an error message which is not useful information from user perspective, that's why it would be better to return the message "YAML Syntax error"
The initial idea to solve this issue was to check if the error message value is an ERROR node containing part of YAML definition and then replace the message with "YAML Syntax error" when processing an error found during parsing.
When investigating this issue and discussing it with Vladimir we decided that in terms of syntax errors, we do not need to check this in code because every error found on this level is a syntax error so we can just return a static error message there.
To make sure that there wasn't any useful information returned from the parser we are using I tested different structures used in YAML 1.2.2 (using `swagger-editor` 5.0.0-alpha.67) to check what error messages I get when introducing a syntax error.
Tested examples (found in https://yaml.org/spec/1.2.2):
- Sequences
	- Sequence of Scalars
	- Mapping Scalars to Scalars
	- Mapping Scalars to Sequences
	- Sequence of Mappings
	- Sequence of Sequences
	- Mapping of Mappings
- Structures
	- Two Documents in a Stream (in this case api-dom returns an error that only first document will be used)
	- Single Document with Two Comments
	- Node appears twice in this document
	- Mapping between Sequences
	- Compact Nested Mapping
- Scalars
	- Literal style
	- Folded style
	- Quoted Scalars
	- Multi-line Flow Scalars
- Tags
	- Integers
	- Floating Point
	- Miscellaneous
	- Timestamps
	- Various Explicit Tags
	- Global Tags
	- Unordered Sets
	- Ordered Mappings

In every scenario, I tried to cause a syntax error by removing indentation or part of correct YAML syntax (e.g. dash and space for block sequences or colon and space for mappings) which caused an ERROR node to be returned with part of YAML definition (elements with same scope/indentation above the part that causes the error or in some cases the same line e.g. when removing square brackets from flow sequence, curly braces from flow mapping or quote marks from quoted scalars).


### How Has This Been Tested?
It has been tested by adding new unit tests in the package folder.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains...
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
