### PR TITLE
ci(dependabot): ignore updating tree-sitter dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     ignore:
       - dependency-name: "web-tree-sitter"
       - dependency-name: "tree-sitter-cli"
+      - dependency-name: "tree-sitter"
 
   - package-ecosystem: "github-actions"
     target-branch: "main"


### PR DESCRIPTION
This is the latest combo of **tree-sitter** related libs that works with YALM grammar (tree-sitter-yaml).
Beyond this versions the YAML grammar still works but the error recovery is non existent anymore.

```json
    "tree-sitter": "=0.20.4",
    "tree-sitter-cli": "=0.20.4",
    "web-tree-sitter": "=0.20.3"
```

Refs #2903


