### PR TITLE
feat (apidom-ls): Change error message for type linting rules

### DIFF
--- a/packages/apidom-ls/src/config/asyncapi/security-scheme/lint/type--equals-2-0.ts
+++ b/packages/apidom-ls/src/config/asyncapi/security-scheme/lint/type--equals-2-0.ts
@@ -7,7 +7,8 @@ import { LinterMeta } from '../../../../apidom-language-types';
 const typeEqualsLint2_0: LinterMeta = {
   code: ApilintCodes.ASYNCAPI2_SECURITY_SCHEME_FIELD_TYPE_EQUALS_2_2,
   source: 'apilint',
-  message: 'type must be one of allowed values',
+  message:
+    'type must be one of allowed values: userPassword, apiKey, X509, symmetricEncryption, asymmetricEncryption, httpApiKey, http, oauth2, openIdConnect',
   severity: DiagnosticSeverity.Error,
   targetSpecs: [{ namespace: 'asyncapi', version: '2.0.0' }],
   linterFunction: 'apilintValueOrArray',

--- a/packages/apidom-ls/src/config/asyncapi/security-scheme/lint/type--equals-2-1--2-6.ts
+++ b/packages/apidom-ls/src/config/asyncapi/security-scheme/lint/type--equals-2-1--2-6.ts
@@ -7,7 +7,8 @@ import { LinterMeta } from '../../../../apidom-language-types';
 const typeEqualsLint2_1__2_6Lint: LinterMeta = {
   code: ApilintCodes.ASYNCAPI2_SECURITY_SCHEME_FIELD_TYPE_EQUALS_2_2__2_6,
   source: 'apilint',
-  message: 'type must be one of allowed values',
+  message:
+    'type must be one of allowed values: userPassword, apiKey, X509, symmetricEncryption, asymmetricEncryption, httpApiKey, http, oauth2, openIdConnect, plain, scramSha256, scramSha512, gssapi',
   severity: DiagnosticSeverity.Error,
   linterFunction: 'apilintValueOrArray',
   linterParams: [

--- a/packages/apidom-ls/src/config/openapi/security-scheme/lint/type--equals-3-0.ts
+++ b/packages/apidom-ls/src/config/openapi/security-scheme/lint/type--equals-3-0.ts
@@ -7,7 +7,7 @@ import { LinterMeta } from '../../../../apidom-language-types';
 const typeEquals3_0Lint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_SECURITY_SCHEME_FIELD_TYPE_EQUALS,
   source: 'apilint',
-  message: 'type must be one of allowed values',
+  message: 'type must be one of allowed values: apiKey, http, oauth2, openIdConnect',
   severity: DiagnosticSeverity.Error,
   linterFunction: 'apilintValueOrArray',
   linterParams: [['apiKey', 'http', 'oauth2', 'openIdConnect']],

--- a/packages/apidom-ls/src/config/openapi/security-scheme/lint/type--equals-3-1.ts
+++ b/packages/apidom-ls/src/config/openapi/security-scheme/lint/type--equals-3-1.ts
@@ -7,7 +7,7 @@ import { LinterMeta } from '../../../../apidom-language-types';
 const typeEquals3_1Lint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_1_SECURITY_SCHEME_FIELD_TYPE_EQUALS,
   source: 'apilint',
-  message: 'type must be one of allowed values',
+  message: 'type must be one of allowed values: apiKey, http, mutualTLS, oauth2, openIdConnect',
   severity: DiagnosticSeverity.Error,
   linterFunction: 'apilintValueOrArray',
   linterParams: [['apiKey', 'http', 'mutualTLS', 'oauth2', 'openIdConnect']],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR changes the error messages for type linting rules for OpenAPI 3.0.x, OpenAPI 3.1, AsyncAPI 2.0, and AsyncAPI 2.1-2.6 to include the information about allowed values for the type field.

### Description
<!--- Describe your changes in detail -->
This PR does the following:
- Changes error messages for  OpenAPI 3.0.x, OpenAPI 3.1, AsyncAPI 2.0, and AsyncAPI 2.1-2.6


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Closes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
This change is required to solve this ticket https://smartbear.atlassian.net/browse/SWG-8486 found during OpenAPI 3.1 bug bash. It has been decided that  it would be better to include information about what are the allowed values for type field.



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR only changes error message text so there are no changes in the package behavior.



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains...
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
