### PR TITLE
feat(reference): support native fragment deref/resolve - OpenAPI 3.1 / Reference Object

### DIFF
--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
@@ -129,8 +129,9 @@ const OpenApi3_1DereferenceVisitor = stampit({
         return false;
       }
 
-      const reference = await this.toReference(referencingElement.$ref?.toValue());
-      const retrievalURI = reference.uri;
+      let reference = await this.toReference(this.reference.uri);
+      reference = await this.toReference(referencingElement.$ref?.toValue());
+      const { uri: retrievalURI } = reference;
       const $refBaseURI = url.resolve(retrievalURI, referencingElement.$ref?.toValue());
 
       this.indirections.push(referencingElement);

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/dereference-apidom.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/dereference-apidom.ts
@@ -14,145 +14,245 @@ describe('dereference', function () {
   context('strategies', function () {
     context('openapi-3-1', function () {
       context('Reference Object', function () {
-        context('given single ReferenceElement passed to dereferenceApiDOM', function () {
-          context('given dereferencing using local file system', function () {
-            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+        context(
+          'given single ReferenceElement passed to dereferenceApiDOM with internal references',
+          function () {
+            context('given dereferencing using local file system', function () {
+              const fixturePath = path.join(__dirname, 'fixtures', 'internal-only', 'root.json');
 
-            specify('should dereference', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
+              specify('should dereference', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/userId',
+                  parseResult.api as OpenApi3_1Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: {
+                    baseURI: `${fixturePath}#/components/parameters/userId`,
+                  },
+                });
+
+                assert.isTrue(isParameterElement(dereferenced));
               });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_1Element,
+
+              specify('should dereference and contain metadata about origin', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/userId',
+                  parseResult.api as OpenApi3_1Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: `${fixturePath}#/components/parameters/userId` },
+                });
+
+                assert.match(
+                  dereferenced.meta.get('ref-origin').toValue(),
+                  /internal-only\/root\.json$/,
+                );
+              });
+            });
+
+            context('given dereferencing using HTTP protocol', function () {
+              const fixturePath = path.join(__dirname, 'fixtures', 'internal-only', 'root.json');
+              const httpPort = 8123;
+              let httpServer: ServerTerminable;
+
+              beforeEach(function () {
+                const cwd = path.join(__dirname, 'fixtures', 'internal-only');
+                httpServer = createHTTPServer({ port: httpPort, cwd });
+              });
+
+              afterEach(async function () {
+                await httpServer.terminate();
+              });
+
+              specify('should dereference', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/userId',
+                  parseResult.api as OpenApi3_1Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: {
+                    baseURI: `http://localhost:${httpPort}/root.json#/components/parameters/userId`,
+                  },
+                });
+
+                assert.isTrue(isParameterElement(dereferenced));
+              });
+
+              specify('should dereference and contain metadata about origin', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/userId',
+                  parseResult.api as OpenApi3_1Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: {
+                    baseURI: `http://localhost:${httpPort}/root.json#/components/parameters/userId`,
+                  },
+                });
+
+                assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/root\.json$/);
+              });
+            });
+          },
+        );
+
+        context(
+          'given single ReferenceElement passed to dereferenceApiDOM with external references',
+          function () {
+            context('given dereferencing using local file system', function () {
+              const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+
+              specify('should dereference', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_1Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: fixturePath },
+                });
+
+                assert.isTrue(isParameterElement(dereferenced));
+              });
+
+              specify('should dereference and contain metadata about origin', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_1Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: fixturePath },
+                });
+
+                assert.match(
+                  dereferenced.meta.get('ref-origin').toValue(),
+                  /external-only\/ex\.json$/,
+                );
+              });
+            });
+
+            context('given dereferencing using HTTP protocol', function () {
+              const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+              const httpPort = 8123;
+              let httpServer: ServerTerminable;
+
+              beforeEach(function () {
+                const cwd = path.join(__dirname, 'fixtures', 'external-only');
+                httpServer = createHTTPServer({ port: httpPort, cwd });
+              });
+
+              afterEach(async function () {
+                await httpServer.terminate();
+              });
+
+              specify('should dereference', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_1Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+                });
+
+                assert.isTrue(isParameterElement(dereferenced));
+              });
+
+              specify('should dereference and contain metadata about origin', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_1Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+                });
+
+                assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
+              });
+            });
+
+            context('given dereferencing using HTTP protocol and absolute URLs', function () {
+              const fixturePath = path.join(
+                __dirname,
+                'fixtures',
+                'external-only-absolute-url',
+                'root.json',
               );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: fixturePath },
+              const httpPort = 8123;
+              let httpServer: ServerTerminable;
+
+              beforeEach(function () {
+                const cwd = path.join(__dirname, 'fixtures', 'external-only-absolute-url');
+                httpServer = createHTTPServer({ port: httpPort, cwd });
               });
 
-              assert.isTrue(isParameterElement(dereferenced));
+              afterEach(async function () {
+                await httpServer.terminate();
+              });
+
+              specify('should dereference', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_1Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+                });
+
+                assert.isTrue(isParameterElement(dereferenced));
+              });
+
+              specify('should dereference and contain metadata about origin', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_1Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+                });
+
+                assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
+              });
             });
-
-            specify('should dereference and contain metadata about origin', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_1Element,
-              );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: fixturePath },
-              });
-
-              assert.match(
-                dereferenced.meta.get('ref-origin').toValue(),
-                /external-only\/ex\.json$/,
-              );
-            });
-          });
-
-          context('given dereferencing using HTTP protocol', function () {
-            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
-            const httpPort = 8123;
-            let httpServer: ServerTerminable;
-
-            beforeEach(function () {
-              const cwd = path.join(__dirname, 'fixtures', 'external-only');
-              httpServer = createHTTPServer({ port: httpPort, cwd });
-            });
-
-            afterEach(async function () {
-              await httpServer.terminate();
-            });
-
-            specify('should dereference', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_1Element,
-              );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
-              });
-
-              assert.isTrue(isParameterElement(dereferenced));
-            });
-
-            specify('should dereference and contain metadata about origin', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_1Element,
-              );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
-              });
-
-              assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
-            });
-          });
-
-          context('given dereferencing using HTTP protocol and absolute URLs', function () {
-            const fixturePath = path.join(
-              __dirname,
-              'fixtures',
-              'external-only-absolute-url',
-              'root.json',
-            );
-            const httpPort = 8123;
-            let httpServer: ServerTerminable;
-
-            beforeEach(function () {
-              const cwd = path.join(__dirname, 'fixtures', 'external-only-absolute-url');
-              httpServer = createHTTPServer({ port: httpPort, cwd });
-            });
-
-            afterEach(async function () {
-              await httpServer.terminate();
-            });
-
-            specify('should dereference', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_1Element,
-              );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
-              });
-
-              assert.isTrue(isParameterElement(dereferenced));
-            });
-
-            specify('should dereference and contain metadata about origin', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_1Element,
-              );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
-              });
-
-              assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
-            });
-          });
-        });
+          },
+        );
       });
     });
   });

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/dereference-apidom.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/dereference-apidom.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { mediaTypes, isSchemaElement, OpenApi3_1Element } from '@swagger-api/apidom-ns-openapi-3-1';
 import { evaluate } from '@swagger-api/apidom-json-pointer';
 
-import { parse, dereferenceApiDOM, Reference, ReferenceSet } from '../../../../../src';
+import { parse, dereferenceApiDOM } from '../../../../../src';
 
 describe('dereference', function () {
   context('strategies', function () {
@@ -22,11 +22,6 @@ describe('dereference', function () {
                 '/components/schemas/User/properties/profile',
                 parseResult.api as OpenApi3_1Element,
               );
-              const reference = Reference({ uri: fixturePath, parseResult });
-              const refSet = ReferenceSet({ refs: [reference] });
-              // @ts-ignore
-              refSet.rootRef = null;
-
               const dereferenced = await dereferenceApiDOM(schemaElement, {
                 parse: { mediaType: mediaTypes.latest('json') },
                 resolve: { baseURI: `${fixturePath}#/components/schemas/User/properties/profile` },
@@ -43,11 +38,6 @@ describe('dereference', function () {
                 '/components/schemas/User/properties/profile',
                 parseResult.api as OpenApi3_1Element,
               );
-              const reference = Reference({ uri: fixturePath, parseResult });
-              const refSet = ReferenceSet({ refs: [reference] });
-              // @ts-ignore
-              refSet.rootRef = null;
-
               const dereferenced = await dereferenceApiDOM(schemaElement, {
                 parse: { mediaType: mediaTypes.latest('json') },
                 resolve: { baseURI: `${fixturePath}#/components/schemas/User/properties/profile` },


### PR DESCRIPTION
This native support includes resolving external and internal
Reference Object references within the fragment.

Refs #2934

