### PR TITLE
feat(reference): support native fragment deref/resolve - OpenAPI 3.1 / Path Item Object

### DIFF
--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
@@ -129,8 +129,7 @@ const OpenApi3_1DereferenceVisitor = stampit({
         return false;
       }
 
-      let reference = await this.toReference(this.reference.uri);
-      reference = await this.toReference(referencingElement.$ref?.toValue());
+      const reference = await this.toReference(referencingElement.$ref?.toValue());
       const { uri: retrievalURI } = reference;
       const $refBaseURI = url.resolve(retrievalURI, referencingElement.$ref?.toValue());
 
@@ -245,7 +244,7 @@ const OpenApi3_1DereferenceVisitor = stampit({
       }
 
       const reference = await this.toReference(referencingElement.$ref?.toValue());
-      const retrievalURI = reference.uri;
+      const { uri: retrievalURI } = reference;
       const $refBaseURI = url.resolve(retrievalURI, referencingElement.$ref?.toValue());
 
       this.indirections.push(referencingElement);

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/path-item-object/dereference-apidom.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/path-item-object/dereference-apidom.ts
@@ -13,41 +13,85 @@ describe('dereference', function () {
   context('strategies', function () {
     context('openapi-3-1', function () {
       context('Path Item Object', function () {
-        context('given single PathItemElement passed to dereferenceApiDOM', function () {
-          const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+        context(
+          'given single PathItemElement passed to dereferenceApiDOM with internal references',
+          function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'internal-only', 'root.json');
 
-          specify('should dereference', async function () {
-            const parseResult = await parse(fixturePath, {
-              parse: { mediaType: mediaTypes.latest('json') },
-            });
-            const pathItemElement = evaluate(
-              compile(['paths', '/path1']),
-              parseResult.api as OpenApi3_1Element,
-            );
-            const dereferenced = await dereferenceApiDOM(pathItemElement, {
-              parse: { mediaType: mediaTypes.latest('json') },
-              resolve: { baseURI: fixturePath },
-            });
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const jsonPointer = compile(['paths', '/path1']);
+              const pathItemElement = evaluate(jsonPointer, parseResult.api as OpenApi3_1Element);
+              const dereferenced = await dereferenceApiDOM(pathItemElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `${fixturePath}#${jsonPointer}` },
+              });
 
-            assert.isTrue(isPathItemElement(dereferenced));
-          });
-
-          specify('should dereference and contain metadata about origin', async function () {
-            const parseResult = await parse(fixturePath, {
-              parse: { mediaType: mediaTypes.latest('json') },
-            });
-            const pathItemElement = evaluate(
-              compile(['paths', '/path1']),
-              parseResult.api as OpenApi3_1Element,
-            );
-            const dereferenced = await dereferenceApiDOM(pathItemElement, {
-              parse: { mediaType: mediaTypes.latest('json') },
-              resolve: { baseURI: fixturePath },
+              assert.isTrue(isPathItemElement(dereferenced));
             });
 
-            assert.match(dereferenced.meta.get('ref-origin').toValue(), /external-only\/ex\.json$/);
-          });
-        });
+            specify('should dereference and contain metadata about origin', async function () {
+              const jsonPointer = compile(['paths', '/path1']);
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const pathItemElement = evaluate(jsonPointer, parseResult.api as OpenApi3_1Element);
+              const dereferenced = await dereferenceApiDOM(pathItemElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `${fixturePath}#${jsonPointer}` },
+              });
+
+              assert.match(
+                dereferenced.meta.get('ref-origin').toValue(),
+                /internal-only\/root\.json$/,
+              );
+            });
+          },
+        );
+
+        context(
+          'given single PathItemElement passed to dereferenceApiDOM with external references',
+          function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const pathItemElement = evaluate(
+                compile(['paths', '/path1']),
+                parseResult.api as OpenApi3_1Element,
+              );
+              const dereferenced = await dereferenceApiDOM(pathItemElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: fixturePath },
+              });
+
+              assert.isTrue(isPathItemElement(dereferenced));
+            });
+
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const pathItemElement = evaluate(
+                compile(['paths', '/path1']),
+                parseResult.api as OpenApi3_1Element,
+              );
+              const dereferenced = await dereferenceApiDOM(pathItemElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: fixturePath },
+              });
+
+              assert.match(
+                dereferenced.meta.get('ref-origin').toValue(),
+                /external-only\/ex\.json$/,
+              );
+            });
+          },
+        );
       });
     });
   });


### PR DESCRIPTION
This native support includes resolving external and internal
Path Item Object references within the fragment.

Refs #2934

