### PR TITLE
feat(reference): support native fragment deref/resolve - OpenAPI 3.0.x

### DIFF
--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
@@ -119,7 +119,7 @@ const OpenApi3_0DereferenceVisitor = stampit({
       }
 
       const reference = await this.toReference(referencingElement.$ref?.toValue());
-      const retrievalURI = reference.uri;
+      const { uri: retrievalURI } = reference;
       const $refBaseURI = url.resolve(retrievalURI, referencingElement.$ref?.toValue());
 
       this.indirections.push(referencingElement);
@@ -335,9 +335,10 @@ const OpenApi3_0DereferenceVisitor = stampit({
         linkElement.operationRef?.meta.set('operation', operationElement);
       } else if (isStringElement(linkElement.operationId)) {
         const operationId = linkElement.operationId?.toValue();
+        const reference = await this.toReference(url.unsanitize(this.reference.uri));
         operationElement = find(
           (e) => isOperationElement(e) && e.operationId.equals(operationId),
-          this.reference.value.result,
+          reference.value.result,
         );
         // OperationElement not found by its operationId
         if (isUndefined(operationElement)) {

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
@@ -357,9 +357,10 @@ const OpenApi3_1DereferenceVisitor = stampit({
         linkElement.operationRef?.meta.set('operation', operationElement);
       } else if (isStringElement(linkElement.operationId)) {
         const operationId = linkElement.operationId?.toValue();
+        const reference = await this.toReference(url.unsanitize(this.reference.uri));
         operationElement = find(
           (e) => isOperationElement(e) && e.operationId.equals(operationId),
-          this.reference.value.result,
+          reference.value.result,
         );
         // OperationElement not found by its operationId
         if (isUndefined(operationElement)) {

--- a/packages/apidom-reference/src/resolve/strategies/openapi-3-1/visitor.ts
+++ b/packages/apidom-reference/src/resolve/strategies/openapi-3-1/visitor.ts
@@ -206,7 +206,7 @@ const OpenApi3_1ResolveVisitor = stampit({
       }
 
       // compute baseURI using rules around $id and $ref keywords
-      const reference = await this.toReference(this.reference.uri);
+      const reference = await this.toReference(url.unsanitize(this.reference.uri));
       const { uri: retrievalURI } = reference;
       const $refBaseURI = resolveSchema$refField(retrievalURI, schemaElement) as string;
       const $refBaseURIStrippedHash = url.stripHash($refBaseURI);

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/path-item-object/dereference-apidom.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/path-item-object/dereference-apidom.ts
@@ -13,41 +13,85 @@ describe('dereference', function () {
   context('strategies', function () {
     context('openapi-3-0', function () {
       context('Path Item Object', function () {
-        context('given single PathItemElement passed to dereferenceApiDOM', function () {
-          const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+        context(
+          'given single PathItemElement passed to dereferenceApiDOM with internal references',
+          function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'internal-only', 'root.json');
 
-          specify('should dereference', async function () {
-            const parseResult = await parse(fixturePath, {
-              parse: { mediaType: mediaTypes.latest('json') },
-            });
-            const pathItemElement = evaluate(
-              compile(['paths', '/path1']),
-              parseResult.api as OpenApi3_0Element,
-            );
-            const dereferenced = await dereferenceApiDOM(pathItemElement, {
-              parse: { mediaType: mediaTypes.latest('json') },
-              resolve: { baseURI: fixturePath },
-            });
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const jsonPointer = compile(['paths', '/path1']);
+              const pathItemElement = evaluate(jsonPointer, parseResult.api as OpenApi3_0Element);
+              const dereferenced = await dereferenceApiDOM(pathItemElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `${fixturePath}#${jsonPointer}` },
+              });
 
-            assert.isTrue(isPathItemElement(dereferenced));
-          });
-
-          specify('should dereference and contain metadata about origin', async function () {
-            const parseResult = await parse(fixturePath, {
-              parse: { mediaType: mediaTypes.latest('json') },
-            });
-            const pathItemElement = evaluate(
-              compile(['paths', '/path1']),
-              parseResult.api as OpenApi3_0Element,
-            );
-            const dereferenced = await dereferenceApiDOM(pathItemElement, {
-              parse: { mediaType: mediaTypes.latest('json') },
-              resolve: { baseURI: fixturePath },
+              assert.isTrue(isPathItemElement(dereferenced));
             });
 
-            assert.match(dereferenced.meta.get('ref-origin').toValue(), /external-only\/ex\.json$/);
-          });
-        });
+            specify('should dereference and contain metadata about origin', async function () {
+              const jsonPointer = compile(['paths', '/path1']);
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const pathItemElement = evaluate(jsonPointer, parseResult.api as OpenApi3_0Element);
+              const dereferenced = await dereferenceApiDOM(pathItemElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: `${fixturePath}#${jsonPointer}` },
+              });
+
+              assert.match(
+                dereferenced.meta.get('ref-origin').toValue(),
+                /internal-only\/root\.json$/,
+              );
+            });
+          },
+        );
+
+        context(
+          'given single PathItemElement passed to dereferenceApiDOM with external references',
+          function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+
+            specify('should dereference', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const pathItemElement = evaluate(
+                compile(['paths', '/path1']),
+                parseResult.api as OpenApi3_0Element,
+              );
+              const dereferenced = await dereferenceApiDOM(pathItemElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: fixturePath },
+              });
+
+              assert.isTrue(isPathItemElement(dereferenced));
+            });
+
+            specify('should dereference and contain metadata about origin', async function () {
+              const parseResult = await parse(fixturePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const pathItemElement = evaluate(
+                compile(['paths', '/path1']),
+                parseResult.api as OpenApi3_0Element,
+              );
+              const dereferenced = await dereferenceApiDOM(pathItemElement, {
+                parse: { mediaType: mediaTypes.latest('json') },
+                resolve: { baseURI: fixturePath },
+              });
+
+              assert.match(
+                dereferenced.meta.get('ref-origin').toValue(),
+                /external-only\/ex\.json$/,
+              );
+            });
+          },
+        );
       });
     });
   });

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/reference-object/dereference-apidom.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/reference-object/dereference-apidom.ts
@@ -14,145 +14,245 @@ describe('dereference', function () {
   context('strategies', function () {
     context('openapi-3-o', function () {
       context('Reference Object', function () {
-        context('given single ReferenceElement passed to dereferenceApiDOM', function () {
-          context('given dereferencing using local file system', function () {
-            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+        context(
+          'given single ReferenceElement passed to dereferenceApiDOM with internal references',
+          function () {
+            context('given dereferencing using local file system', function () {
+              const fixturePath = path.join(__dirname, 'fixtures', 'internal-only', 'root.json');
 
-            specify('should dereference', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
+              specify('should dereference', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/userId',
+                  parseResult.api as OpenApi3_0Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: {
+                    baseURI: `${fixturePath}#/components/parameters/userId`,
+                  },
+                });
+
+                assert.isTrue(isParameterElement(dereferenced));
               });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_0Element,
+
+              specify('should dereference and contain metadata about origin', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/userId',
+                  parseResult.api as OpenApi3_0Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: `${fixturePath}#/components/parameters/userId` },
+                });
+
+                assert.match(
+                  dereferenced.meta.get('ref-origin').toValue(),
+                  /internal-only\/root\.json$/,
+                );
+              });
+            });
+
+            context('given dereferencing using HTTP protocol', function () {
+              const fixturePath = path.join(__dirname, 'fixtures', 'internal-only', 'root.json');
+              const httpPort = 8123;
+              let httpServer: ServerTerminable;
+
+              beforeEach(function () {
+                const cwd = path.join(__dirname, 'fixtures', 'internal-only');
+                httpServer = createHTTPServer({ port: httpPort, cwd });
+              });
+
+              afterEach(async function () {
+                await httpServer.terminate();
+              });
+
+              specify('should dereference', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/userId',
+                  parseResult.api as OpenApi3_0Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: {
+                    baseURI: `http://localhost:${httpPort}/root.json#/components/parameters/userId`,
+                  },
+                });
+
+                assert.isTrue(isParameterElement(dereferenced));
+              });
+
+              specify('should dereference and contain metadata about origin', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/userId',
+                  parseResult.api as OpenApi3_0Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: {
+                    baseURI: `http://localhost:${httpPort}/root.json#/components/parameters/userId`,
+                  },
+                });
+
+                assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/root\.json$/);
+              });
+            });
+          },
+        );
+
+        context(
+          'given single ReferenceElement passed to dereferenceApiDOM with external references',
+          function () {
+            context('given dereferencing using local file system', function () {
+              const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+
+              specify('should dereference', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_0Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: fixturePath },
+                });
+
+                assert.isTrue(isParameterElement(dereferenced));
+              });
+
+              specify('should dereference and contain metadata about origin', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_0Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: fixturePath },
+                });
+
+                assert.match(
+                  dereferenced.meta.get('ref-origin').toValue(),
+                  /external-only\/ex\.json$/,
+                );
+              });
+            });
+
+            context('given dereferencing using HTTP protocol', function () {
+              const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
+              const httpPort = 8123;
+              let httpServer: ServerTerminable;
+
+              beforeEach(function () {
+                const cwd = path.join(__dirname, 'fixtures', 'external-only');
+                httpServer = createHTTPServer({ port: httpPort, cwd });
+              });
+
+              afterEach(async function () {
+                await httpServer.terminate();
+              });
+
+              specify('should dereference', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_0Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+                });
+
+                assert.isTrue(isParameterElement(dereferenced));
+              });
+
+              specify('should dereference and contain metadata about origin', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_0Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+                });
+
+                assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
+              });
+            });
+
+            context('given dereferencing using HTTP protocol and absolute URLs', function () {
+              const fixturePath = path.join(
+                __dirname,
+                'fixtures',
+                'external-only-absolute-url',
+                'root.json',
               );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: fixturePath },
+              const httpPort = 8123;
+              let httpServer: ServerTerminable;
+
+              beforeEach(function () {
+                const cwd = path.join(__dirname, 'fixtures', 'external-only-absolute-url');
+                httpServer = createHTTPServer({ port: httpPort, cwd });
               });
 
-              assert.isTrue(isParameterElement(dereferenced));
+              afterEach(async function () {
+                await httpServer.terminate();
+              });
+
+              specify('should dereference', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_0Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+                });
+
+                assert.isTrue(isParameterElement(dereferenced));
+              });
+
+              specify('should dereference and contain metadata about origin', async function () {
+                const parseResult = await parse(fixturePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const referenceElement = evaluate(
+                  '/components/parameters/externalRef',
+                  parseResult.api as OpenApi3_0Element,
+                );
+                const dereferenced = await dereferenceApiDOM(referenceElement, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
+                });
+
+                assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
+              });
             });
-
-            specify('should dereference and contain metadata about origin', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_0Element,
-              );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: fixturePath },
-              });
-
-              assert.match(
-                dereferenced.meta.get('ref-origin').toValue(),
-                /external-only\/ex\.json$/,
-              );
-            });
-          });
-
-          context('given dereferencing using HTTP protocol', function () {
-            const fixturePath = path.join(__dirname, 'fixtures', 'external-only', 'root.json');
-            const httpPort = 8123;
-            let httpServer: ServerTerminable;
-
-            beforeEach(function () {
-              const cwd = path.join(__dirname, 'fixtures', 'external-only');
-              httpServer = createHTTPServer({ port: httpPort, cwd });
-            });
-
-            afterEach(async function () {
-              await httpServer.terminate();
-            });
-
-            specify('should dereference', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_0Element,
-              );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
-              });
-
-              assert.isTrue(isParameterElement(dereferenced));
-            });
-
-            specify('should dereference and contain metadata about origin', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_0Element,
-              );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
-              });
-
-              assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
-            });
-          });
-
-          context('given dereferencing using HTTP protocol and absolute URLs', function () {
-            const fixturePath = path.join(
-              __dirname,
-              'fixtures',
-              'external-only-absolute-url',
-              'root.json',
-            );
-            const httpPort = 8123;
-            let httpServer: ServerTerminable;
-
-            beforeEach(function () {
-              const cwd = path.join(__dirname, 'fixtures', 'external-only-absolute-url');
-              httpServer = createHTTPServer({ port: httpPort, cwd });
-            });
-
-            afterEach(async function () {
-              await httpServer.terminate();
-            });
-
-            specify('should dereference', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_0Element,
-              );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
-              });
-
-              assert.isTrue(isParameterElement(dereferenced));
-            });
-
-            specify('should dereference and contain metadata about origin', async function () {
-              const parseResult = await parse(fixturePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
-              const referenceElement = evaluate(
-                '/components/parameters/externalRef',
-                parseResult.api as OpenApi3_0Element,
-              );
-              const dereferenced = await dereferenceApiDOM(referenceElement, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { baseURI: `http://localhost:${httpPort}/root.json` },
-              });
-
-              assert.match(dereferenced.meta.get('ref-origin').toValue(), /\/ex\.json$/);
-            });
-          });
-        });
+          },
+        );
       });
     });
   });


### PR DESCRIPTION
This native support includes resolving external and internal
references within the OpenAPI 3.0.x fragment.
    
Refs #2934
