### PR TITLE
ci(build): fix branch in lint commit messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Lint commit message
         if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
         run: |
-          npx commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD --verbose
+          npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,32 @@ env:
   CPU_CORES: 2
 
 jobs:
-  lint:
+  lint-commit-messages:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # necessary for linting commit messages
+          ref: ${{ github.event.pull_request.head.sha }} # necessary to check out pull request HEAD commit instead of merge commit
+      - name: Use Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint commit message
+        if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
+        run: |
+          npx commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD --verbose
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
       - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
@@ -30,9 +49,6 @@ jobs:
         run: npm ci
       - name: Lint code
         run: npm run lint
-      - name: Lint commit message
-        if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
-        run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD
 
   check-typescript-types:
     runs-on: ubuntu-latest


### PR DESCRIPTION
@char0n 

lint commit messages job seems to target the wrong commits, including commits not belonging to the branch, see e.g. [this run](https://github.com/swagger-api/apidom/actions/runs/5565788003/jobs/10166426126?pr=2954)

This seems to be related to the check out (by default) of the merge branch instead of the head one, which does mess up somehow commit history, so that  `HEAD~${{ github.event.pull_request.commits }}` for some reason points to a previous non-branch commit. Still kind of mysterious as adding a `git log` to the `HEAD~${{ github.event.pull_request.commits }}`  does point to yet another commit in history..

There might be a better solution, however this PR addresses it by having a separate job `lint-commit-message` do the work, checking out head branch



