### PR TITLE
feat(ls): fix  completion paths, self and indirect refs

### DIFF
--- a/packages/apidom-ls/src/apidom-language-types.ts
+++ b/packages/apidom-ls/src/apidom-language-types.ts
@@ -104,6 +104,7 @@ export interface ContentLanguage {
   namespace: string;
   format?: 'JSON' | 'YAML';
   version?: string;
+  admitsRefsSiblings?: boolean;
 }
 
 export interface ValidationProviderResult {
@@ -279,6 +280,7 @@ export interface ValidationContext {
 export interface CompletionContext {
   maxNumberOfItems?: number;
   enableLSPFilter?: boolean;
+  includeIndirectRefs?: boolean;
 }
 
 export interface DerefContext {

--- a/packages/apidom-ls/src/utils/utils.ts
+++ b/packages/apidom-ls/src/utils/utils.ts
@@ -184,7 +184,8 @@ export function logJson(label: string, message: unknown): void {
 }
 
 export function buildJsonPointer(path: string[]): string {
-  return `#/${path.join('/')}`;
+  const jsonPointer = path.map((s) => s.replaceAll('/', '~1')).join('/');
+  return `#/${jsonPointer}`;
 }
 
 interface FoundNode {
@@ -818,6 +819,7 @@ export async function findNamespace(
       namespace: 'openapi',
       version: versionMatch?.groups?.version_json,
       format: 'JSON',
+      admitsRefsSiblings: true,
     };
   }
   if (await openapi3_1AdapterYaml.detect(text)) {
@@ -826,6 +828,7 @@ export async function findNamespace(
       namespace: 'openapi',
       version: versionMatch?.groups?.version_yaml || versionMatch?.groups?.version_json,
       format: 'YAML',
+      admitsRefsSiblings: true,
     };
   }
   if (await adsAdapterJson.detect(text)) {
@@ -846,6 +849,7 @@ export async function findNamespace(
           namespace: defaultContentLanguage.namespace,
           version: defaultContentLanguage.version,
           format: 'JSON',
+          admitsRefsSiblings: defaultContentLanguage.admitsRefsSiblings,
         }
       : {
           namespace: 'apidom',
@@ -858,6 +862,7 @@ export async function findNamespace(
           namespace: defaultContentLanguage.namespace,
           version: defaultContentLanguage.version,
           format: 'YAML',
+          admitsRefsSiblings: defaultContentLanguage.admitsRefsSiblings,
         }
       : {
           namespace: 'apidom',
@@ -869,6 +874,7 @@ export async function findNamespace(
         namespace: defaultContentLanguage.namespace,
         version: defaultContentLanguage.version,
         format: json ? 'JSON' : 'YAML',
+        admitsRefsSiblings: defaultContentLanguage.admitsRefsSiblings,
       }
     : {
         namespace: 'apidom',

--- a/packages/apidom-ls/test/complete.ts
+++ b/packages/apidom-ls/test/complete.ts
@@ -507,12 +507,11 @@ describe('apidom-ls-complete', function () {
           },
         },
         {
-          label: '#/components/messages/userSignUp/headers/properties/appli...',
-          insertText:
-            "'#/components/messages/userSignUp/headers/properties/applicationInstanceId$1'",
+          label: '#/channels/user~1signin/subscribe/message/payload',
+          insertText: "'#/channels/user~1signin/subscribe/message/payload$1'",
           kind: 18,
           documentation:
-            'description: Unique identifier for a given instance of the publishing\n              application\n            type: string',
+            'type: object\n          properties:\n            user:\n              $ref: "#/components/schemas/Category"',
           insertTextFormat: 2,
           sortText: 'i',
           filterText: '"#/components/schemas/Category"',
@@ -527,16 +526,16 @@ describe('apidom-ls-complete', function () {
                 character: 51,
               },
             },
-            newText:
-              "'#/components/messages/userSignUp/headers/properties/applicationInstanceId$1'",
+            newText: "'#/channels/user~1signin/subscribe/message/payload$1'",
           },
         },
         {
-          label: '#/channels/user/signin/subscribe/message/payload',
-          insertText: "'#/channels/user/signin/subscribe/message/payload$1'",
+          label: '#/components/messages/userSignUp/headers/properties/appli...',
+          insertText:
+            "'#/components/messages/userSignUp/headers/properties/applicationInstanceId$1'",
           kind: 18,
           documentation:
-            'type: object\n          properties:\n            user:\n              $ref: "#/components/schemas/Category"',
+            'description: Unique identifier for a given instance of the publishing\n              application\n            type: string',
           insertTextFormat: 2,
           sortText: 'j',
           filterText: '"#/components/schemas/Category"',
@@ -551,7 +550,8 @@ describe('apidom-ls-complete', function () {
                 character: 51,
               },
             },
-            newText: "'#/channels/user/signin/subscribe/message/payload$1'",
+            newText:
+              "'#/components/messages/userSignUp/headers/properties/applicationInstanceId$1'",
           },
         },
       ],

--- a/packages/apidom-ls/test/completion-provider.ts
+++ b/packages/apidom-ls/test/completion-provider.ts
@@ -478,12 +478,132 @@ describe('apidom-ls-completion-provider', function () {
           filterText: '',
         },
         {
-          label: '#/paths//users/get/responses/200/content/application/json...',
-          insertText: "'#/paths//users/get/responses/200/content/application/json/schema$1'",
+          label: 'http://example.com/#components/schemas/foo',
+          insertText: "'http://example.com/#components/schemas/foo$1'",
           kind: 18,
-          documentation: '"$ref":',
+          insertTextFormat: 2,
+          sortText: 'ĭ',
+          filterText: '',
+        },
+        {
+          label: 'http://example.com/#components/schemas/bar',
+          insertText: "'http://example.com/#components/schemas/bar$1'",
+          kind: 18,
+          insertTextFormat: 2,
+          sortText: 'Į',
+          filterText: '',
+        },
+      ] as CompletionItem[];
+
+      const resultAsync = await languageService.doCompletion(
+        docOpenapi,
+        { line: 13, character: 24 },
+        completionContext,
+      );
+      assert.deepEqual(resultAsync!.items, expected as CompletionItem[]);
+      languageService.terminate();
+      languageService = getLanguageService(contextRef);
+      const result = await languageService.doCompletion(
+        docOpenapi,
+        { line: 13, character: 24 },
+        completionContext,
+      );
+      assert.deepEqual(result!.items, expected as CompletionItem[]);
+    } finally {
+      languageService.terminate();
+    }
+  });
+
+  it('test completion ref provider with indirect', async function () {
+    const completionContext: CompletionContext = {
+      maxNumberOfItems: 100,
+      includeIndirectRefs: true,
+    };
+    let languageService: LanguageService = getLanguageService(contextAsyncRef);
+
+    try {
+      // valid spec
+      const docOpenapi: TextDocument = TextDocument.create(
+        'foo://bar/openapi.yaml',
+        'specOpenapi',
+        0,
+        specOpenapi,
+      );
+
+      const expected = [
+        {
+          label: '#/components/schemas/UserProfile',
+          insertText: "'#/components/schemas/UserProfile$1'",
+          kind: 18,
+          documentation:
+            'type: object\n      properties:\n        email:\n          type: string\n          x-nullable: true\n',
+          insertTextFormat: 2,
+          sortText: 'a',
+          filterText: '',
+        },
+        {
+          label: '#/components/schemas/User',
+          insertText: "'#/components/schemas/User$1'",
+          kind: 18,
+          documentation:
+            'type: object\n      properties:\n        id:\n          type: integer\n        name:\n          type: string\n        profile:\n          "$ref": "#/components/schemas/UserProfile"\n          summary: user profile reference summary\n          description: user profile reference description\n        profileExternalRef:\n          "$ref": "http://example.com/test.yaml#/components/schemas/UserProfile"',
+          insertTextFormat: 2,
+          sortText: 'b',
+          filterText: '',
+        },
+        {
+          label: '#/components/schemas/UserProfile/properties/email',
+          insertText: "'#/components/schemas/UserProfile/properties/email$1'",
+          kind: 18,
+          documentation: 'type: string\n          x-nullable: true\n',
+          insertTextFormat: 2,
+          sortText: 'c',
+          filterText: '',
+        },
+        {
+          label: '#/components/schemas/User/properties/profileExternalRef',
+          insertText: "'#/components/schemas/User/properties/profileExternalRef$1'",
+          kind: 18,
+          documentation: '"$ref": "http://example.com/test.yaml#/components/schemas/UserProfile"',
+          insertTextFormat: 2,
+          sortText: 'd',
+          filterText: '',
+        },
+        {
+          label: '#/components/schemas/User/properties/profile',
+          insertText: "'#/components/schemas/User/properties/profile$1'",
+          kind: 18,
+          documentation:
+            '"$ref": "#/components/schemas/UserProfile"\n          summary: user profile reference summary\n          description: user profile reference description',
+          insertTextFormat: 2,
+          sortText: 'e',
+          filterText: '',
+        },
+        {
+          label: '#/components/schemas/User/properties/name',
+          insertText: "'#/components/schemas/User/properties/name$1'",
+          kind: 18,
+          documentation: 'type: string',
           insertTextFormat: 2,
           sortText: 'f',
+          filterText: '',
+        },
+        {
+          label: '#/components/schemas/User/properties/id',
+          insertText: "'#/components/schemas/User/properties/id$1'",
+          kind: 18,
+          documentation: 'type: integer',
+          insertTextFormat: 2,
+          sortText: 'g',
+          filterText: '',
+        },
+        {
+          label: '#/paths/~1users/get/responses/201/content/application~1js...',
+          insertText: "'#/paths/~1users/get/responses/201/content/application~1json/schema$1'",
+          kind: 18,
+          documentation: '"$ref": "#/components/schemas/User"',
+          insertTextFormat: 2,
+          sortText: 'h',
           filterText: '',
         },
         {
@@ -509,7 +629,6 @@ describe('apidom-ls-completion-provider', function () {
         { line: 13, character: 24 },
         completionContext,
       );
-
       assert.deepEqual(resultAsync!.items, expected as CompletionItem[]);
       languageService.terminate();
       languageService = getLanguageService(contextRef);


### PR DESCRIPTION
fixes completion of references:

* doesn't include reference to self
* fixes JSON Pointer paths escaping
* doesn't include by default indirect references (target nodes being a reference themselves). 
Provides a `completionContext` option `includeIndirectRefs`: if set to `true` indirect refs are also included, but only when the document namespace (specification + version) allows for siblings of `$ref` field, as this is the only case where such a reference would make sense. Currently the only namespace supporting this is OpenAPI 3.1