### PR TITLE
feat(json-path): use error hierarchy and metadata when throwing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34635,6 +34635,7 @@
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
         "@swagger-api/apidom-core": "^0.75.0",
+        "@swagger-api/apidom-error": "^0.75.0",
         "@swagger-api/apidom-json-pointer": "^0.75.0",
         "jsonpath-plus": "^7.2.0"
       }

--- a/packages/apidom-json-path/package.json
+++ b/packages/apidom-json-path/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "^7.20.7",
     "@swagger-api/apidom-core": "^0.75.0",
+    "@swagger-api/apidom-error": "^0.75.0",
     "@swagger-api/apidom-json-pointer": "^0.75.0",
     "jsonpath-plus": "^7.2.0"
   },

--- a/packages/apidom-json-path/src/errors/EvaluationJsonPathError.ts
+++ b/packages/apidom-json-path/src/errors/EvaluationJsonPathError.ts
@@ -1,0 +1,31 @@
+import { Element, hasElementSourceMap, toValue } from '@swagger-api/apidom-core';
+import { ApiDOMErrorOptions } from '@swagger-api/apidom-error';
+
+import JsonPathError from './JsonPathError';
+
+export interface EvaluationJsonPathErrorOptions<T extends Element> extends ApiDOMErrorOptions {
+  path: string | string[];
+  element: T;
+}
+
+class EvaluationJsonPathError<T extends Element> extends JsonPathError {
+  public readonly path!: string | string[];
+
+  public readonly element!: string;
+
+  public readonly elementSourceMap?: [[number, number, number], [number, number, number]];
+
+  constructor(message?: string, structuredOptions?: EvaluationJsonPathErrorOptions<T>) {
+    super(message, structuredOptions);
+
+    if (typeof structuredOptions !== 'undefined') {
+      this.path = structuredOptions.path;
+      this.element = structuredOptions.element.element;
+      if (hasElementSourceMap(structuredOptions.element)) {
+        this.elementSourceMap = toValue(structuredOptions.element.getMetaProperty('sourceMap'));
+      }
+    }
+  }
+}
+
+export default EvaluationJsonPathError;

--- a/packages/apidom-json-path/src/errors/JsonPathError.ts
+++ b/packages/apidom-json-path/src/errors/JsonPathError.ts
@@ -1,0 +1,5 @@
+import { ApiDOMStructuredError } from '@swagger-api/apidom-error';
+
+class JsonPathError extends ApiDOMStructuredError {}
+
+export default JsonPathError;

--- a/packages/apidom-json-path/src/errors/MultiEvaluationJsonPathError.ts
+++ b/packages/apidom-json-path/src/errors/MultiEvaluationJsonPathError.ts
@@ -1,0 +1,31 @@
+import { Element, hasElementSourceMap, toValue } from '@swagger-api/apidom-core';
+import { ApiDOMErrorOptions } from '@swagger-api/apidom-error';
+
+import JsonPathError from './JsonPathError';
+
+export interface MultiEvaluationJsonPathErrorOptions<T extends Element> extends ApiDOMErrorOptions {
+  paths: string[] | string[][];
+  element: T;
+}
+
+class MultiEvaluationJsonPathError<T extends Element> extends JsonPathError {
+  public readonly paths!: string[] | string[][];
+
+  public readonly element!: string;
+
+  public readonly elementSourceMap?: [[number, number, number], [number, number, number]];
+
+  constructor(message?: string, structuredOptions?: MultiEvaluationJsonPathErrorOptions<T>) {
+    super(message, structuredOptions);
+
+    if (typeof structuredOptions !== 'undefined') {
+      this.paths = structuredOptions.paths;
+      this.element = structuredOptions.element.element;
+      if (hasElementSourceMap(structuredOptions.element)) {
+        this.elementSourceMap = toValue(structuredOptions.element.getMetaProperty('sourceMap'));
+      }
+    }
+  }
+}
+
+export default MultiEvaluationJsonPathError;

--- a/packages/apidom-json-path/src/index.ts
+++ b/packages/apidom-json-path/src/index.ts
@@ -1,2 +1,6 @@
+export { default as EvaluationJsonPathError } from './errors/EvaluationJsonPathError';
+export type { EvaluationJsonPathErrorOptions } from './errors/EvaluationJsonPathError';
+export { default as MultiEvaluationJsonPathError } from './errors/MultiEvaluationJsonPathError';
+export type { MultiEvaluationJsonPathErrorOptions } from './errors/MultiEvaluationJsonPathError';
 export { default as evaluate } from './evaluate';
 export { default as evaluateMulti } from './evaluate-multi';

--- a/packages/apidom-json-pointer/src/compile.ts
+++ b/packages/apidom-json-pointer/src/compile.ts
@@ -14,6 +14,7 @@ const compile = (tokens: string[]): string => {
       'JSON Pointer compilation of tokens encountered an error.',
       {
         tokens,
+        cause: error,
       },
     );
   }

--- a/packages/apidom-json-pointer/src/evaluate.ts
+++ b/packages/apidom-json-pointer/src/evaluate.ts
@@ -16,6 +16,7 @@ const evaluate = <T extends Element>(pointer: string, element: T): Element => {
       {
         pointer,
         element,
+        cause: error,
       },
     );
   }

--- a/packages/apidom-json-pointer/src/parse.ts
+++ b/packages/apidom-json-pointer/src/parse.ts
@@ -27,6 +27,7 @@ const parse = (pointer: string): string[] => {
       `JSON Pointer parsing of "${pointer}" encountered an error.`,
       {
         pointer,
+        cause: error,
       },
     );
   }


### PR DESCRIPTION
Refs #3039