### PR TITLE
build: use .mjs extension for EcmaScript modules

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -67,7 +67,7 @@ module.exports = {
             version: '^7.22.15',
           },
         ],
-        [path.join(__dirname, './scripts/babel-plugin-add-import-extension.cjs'), { extension: 'js' }],
+        [path.join(__dirname, './scripts/babel-plugin-add-import-extension.cjs'), { extension: 'mjs' }],
       ],
     },
     browser: {

--- a/packages/apidom-ast/package.json
+++ b/packages/apidom-ast/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-core/package.json
+++ b/packages/apidom-core/package.json
@@ -8,20 +8,20 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/refractor/registration.js",
+    "./es/refractor/registration.mjs",
     "./cjs/refractor/registration.cjs"
   ],
   "unpkg": "./dist/apidom-core.browser.min.js",
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-error/package.json
+++ b/packages/apidom-error/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-json-path/package.json
+++ b/packages/apidom-json-path/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-json-pointer-relative/package.json
+++ b/packages/apidom-json-pointer-relative/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-json-pointer/package.json
+++ b/packages/apidom-json-pointer/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-ls/package.json
+++ b/packages/apidom-ls/package.json
@@ -22,56 +22,56 @@
   "exports": {
     ".": {
       "types": "./types/dist.d.ts",
-      "import": "./es/index.js",
+      "import": "./es/index.mjs",
       "require": "./cjs/index.cjs"
     },
     "./services/validation/providers/json-schema": {
-      "import": "./es/services/validation/providers/json-schema-validation-provider.js",
+      "import": "./es/services/validation/providers/json-schema-validation-provider.mjs",
       "require": "./cjs/services/validation/providers/json-schema-validation-provider.cjs",
       "types": "./types/services/validation/providers/json-schema-validation-provider.d.ts"
     },
     "./services/validation/providers/asyncapi-20-json-schema": {
-      "import": "./es/services/validation/providers/asyncapi-20-json-schema-validation-provider.js",
+      "import": "./es/services/validation/providers/asyncapi-20-json-schema-validation-provider.mjs",
       "require": "./cjs/services/validation/providers/asyncapi-20-json-schema-validation-provider.cjs",
       "types": "./types/services/validation/providers/asyncapi-20-json-schema-validation-provider.d.ts"
     },
     "./services/validation/providers/asyncapi-21-json-schema": {
-      "import": "./es/services/validation/providers/asyncapi-21-json-schema-validation-provider.js",
+      "import": "./es/services/validation/providers/asyncapi-21-json-schema-validation-provider.mjs",
       "require": "./cjs/services/validation/providers/asyncapi-21-json-schema-validation-provider.cjs",
       "types": "./types/services/validation/providers/asyncapi-22-json-schema-validation-provider.d.ts"
     },
     "./services/validation/providers/asyncapi-22-json-schema": {
-      "import": "./es/services/validation/providers/asyncapi-22-json-schema-validation-provider.js",
+      "import": "./es/services/validation/providers/asyncapi-22-json-schema-validation-provider.mjs",
       "require": "./cjs/services/validation/providers/asyncapi-22-json-schema-validation-provider.cjs",
       "types": "./types/services/validation/providers/asyncapi-22-json-schema-validation-provider.d.ts"
     },
     "./services/validation/providers/asyncapi-23-json-schema": {
-      "import": "./es/services/validation/providers/asyncapi-23-json-schema-validation-provider.js",
+      "import": "./es/services/validation/providers/asyncapi-23-json-schema-validation-provider.mjs",
       "require": "./cjs/services/validation/providers/asyncapi-23-json-schema-validation-provider.cjs",
       "types": "./types/services/validation/providers/asyncapi-23-json-schema-validation-provider.d.ts"
     },
     "./services/validation/providers/asyncapi-24-json-schema": {
-      "import": "./es/services/validation/providers/asyncapi-24-json-schema-validation-provider.js",
+      "import": "./es/services/validation/providers/asyncapi-24-json-schema-validation-provider.mjs",
       "require": "./cjs/services/validation/providers/asyncapi-24-json-schema-validation-provider.cjs",
       "types": "./types/services/validation/providers/asyncapi-24-json-schema-validation-provider.d.ts"
     },
     "./services/validation/providers/asyncapi-25-json-schema": {
-      "import": "./es/services/validation/providers/asyncapi-25-json-schema-validation-provider.js",
+      "import": "./es/services/validation/providers/asyncapi-25-json-schema-validation-provider.mjs",
       "require": "./cjs/services/validation/providers/asyncapi-25-json-schema-validation-provider.cjs",
       "types": "./types/services/validation/providers/asyncapi-25-json-schema-validation-provider.d.ts"
     },
     "./services/validation/providers/asyncapi-26-json-schema": {
-      "import": "./es/services/validation/providers/asyncapi-26-json-schema-validation-provider.js",
+      "import": "./es/services/validation/providers/asyncapi-26-json-schema-validation-provider.mjs",
       "require": "./cjs/services/validation/providers/asyncapi-26-json-schema-validation-provider.cjs",
       "types": "./types/services/validation/providers/asyncapi-26-json-schema-validation-provider.d.ts"
     },
     "./services/validation/providers/openapi-31-json-schema": {
-      "import": "./es/services/validation/providers/openapi-31-json-schema-validation-provider.js",
+      "import": "./es/services/validation/providers/openapi-31-json-schema-validation-provider.mjs",
       "require": "./cjs/services/validation/providers/openapi-31-json-schema-validation-provider.cjs",
       "types": "./types/services/validation/providers/openapi-31-json-schema-validation-provider.d.ts"
     },
     "./services/validation/providers/ads": {
-      "import": "./es/services/validation/providers/ads-validation-provider.js",
+      "import": "./es/services/validation/providers/ads-validation-provider.mjs",
       "require": "./cjs/services/validation/providers/ads-validation-provider.cjs",
       "types": "./types/services/validation/providers/ads-validation-provider.d.ts"
     }
@@ -79,7 +79,7 @@
   "types": "./types/",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward' && copyfiles -u 1 ./src/**/*.json es",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward' && copyfiles -u 1 ./src/**/*.json es",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward' && copyfiles -u 1 ./src/**/*.json cjs",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js",
     "lint": "eslint ./",

--- a/packages/apidom-ns-api-design-systems/package.json
+++ b/packages/apidom-ns-api-design-systems/package.json
@@ -8,20 +8,20 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/refractor/registration.js",
+    "./es/refractor/registration.mjs",
     "./cjs/refractor/registration.cjs"
   ],
   "unpkg": "./dist/apidom-ns-api-design-systems.browser.min.js",
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-ns-asyncapi-2/package.json
+++ b/packages/apidom-ns-asyncapi-2/package.json
@@ -8,20 +8,20 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/refractor/registration.js",
+    "./es/refractor/registration.mjs",
     "./cjs/refractor/registration.cjs"
   ],
   "unpkg": "./dist/apidom-ns-asyncapi-2.browser.min.js",
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-ns-json-schema-draft-4/package.json
+++ b/packages/apidom-ns-json-schema-draft-4/package.json
@@ -8,20 +8,20 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/refractor/registration.js",
+    "./es/refractor/registration.mjs",
     "./cjs/refractor/registration.cjs"
   ],
   "unpkg": "./dist/apidom-ns-json-schema-draft-4.browser.min.js",
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-ns-json-schema-draft-6/package.json
+++ b/packages/apidom-ns-json-schema-draft-6/package.json
@@ -8,20 +8,20 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/refractor/registration.js",
+    "./es/refractor/registration.mjs",
     "./cjs/refractor/registration.cjs"
   ],
   "unpkg": "./dist/apidom-ns-json-schema-draft-6.browser.min.js",
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-ns-json-schema-draft-7/package.json
+++ b/packages/apidom-ns-json-schema-draft-7/package.json
@@ -8,20 +8,20 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/refractor/registration.js",
+    "./es/refractor/registration.mjs",
     "./cjs/refractor/registration.cjs"
   ],
   "unpkg": "./dist/apidom-ns-json-schema-draft-7.browser.min.js",
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-ns-openapi-3-0/package.json
+++ b/packages/apidom-ns-openapi-3-0/package.json
@@ -8,20 +8,20 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/refractor/registration.js",
+    "./es/refractor/registration.mjs",
     "./cjs/refractor/registration.cjs"
   ],
   "unpkg": "./dist/apidom-ns-openapi-3-0.browser.min.js",
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-ns-openapi-3-1/package.json
+++ b/packages/apidom-ns-openapi-3-1/package.json
@@ -8,20 +8,20 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/refractor/registration.js",
+    "./es/refractor/registration.mjs",
     "./cjs/refractor/registration.cjs"
   ],
   "unpkg": "./dist/apidom-ns-openapi-3-1.browser.min.js",
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-ns-workflows-1/package.json
+++ b/packages/apidom-ns-workflows-1/package.json
@@ -9,20 +9,20 @@
   "private": true,
   "type": "module",
   "sideEffects": [
-    "./es/refractor/registration.js",
+    "./es/refractor/registration.mjs",
     "./cjs/refractor/registration.cjs"
   ],
   "unpkg": "./dist/apidom-ns-workflows-1.browser.min.js",
   "main": "./cjs/index.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/index.js",
+    "import": "./es/index.mjs",
     "require": "./cjs/index.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-parser-adapter-api-design-systems-json/package.json
+++ b/packages/apidom-parser-adapter-api-design-systems-json/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/adapter.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/adapter.js",
+    "import": "./es/adapter.mjs",
     "require": "./cjs/adapter.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-parser-adapter-api-design-systems-yaml/package.json
+++ b/packages/apidom-parser-adapter-api-design-systems-yaml/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/adapter.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/adapter.js",
+    "import": "./es/adapter.mjs",
     "require": "./cjs/adapter.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-parser-adapter-asyncapi-json-2/package.json
+++ b/packages/apidom-parser-adapter-asyncapi-json-2/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/adapter.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/adapter.js",
+    "import": "./es/adapter.mjs",
     "require": "./cjs/adapter.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-parser-adapter-asyncapi-yaml-2/package.json
+++ b/packages/apidom-parser-adapter-asyncapi-yaml-2/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/adapter.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/adapter.js",
+    "import": "./es/adapter.mjs",
     "require": "./cjs/adapter.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-parser-adapter-json/package.json
+++ b/packages/apidom-parser-adapter-json/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/lexical-analysis/browser-patch.js",
+    "./es/lexical-analysis/browser-patch.mjs",
     "./cjs/lexical-analysis/browser-patch.cjs"
   ],
   "unpkg": "./dist/apidom-parser-apdater-json.browser.min.js",
@@ -16,18 +16,18 @@
   "exports": {
     "types": "./types/dist.d.ts",
     "node": {
-      "import": "./es/adapter-node.js",
+      "import": "./es/adapter-node.mjs",
       "require": "./cjs/adapter-node.cjs"
     },
     "browser": {
-      "import": "./es/adapter-browser.js"
+      "import": "./es/adapter-browser.mjs"
     },
     "default": "./cjs/adapter-node.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "npm run build:wasm && npm run build:wasm:copy && cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "npm run build:wasm && npm run build:wasm:copy && cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "npm run build:wasm && npm run build:wasm:copy && BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "npm run build:wasm && npm run build:wasm:copy && cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "build:wasm": "node ../../scripts/file-exists.js ../../node_modules/tree-sitter-json/tree-sitter-json.wasm && exit 0 || cd ../../node_modules/tree-sitter-json && tree-sitter generate --abi=13 ./grammar.js && tree-sitter build-wasm && node-gyp rebuild",

--- a/packages/apidom-parser-adapter-openapi-json-3-0/package.json
+++ b/packages/apidom-parser-adapter-openapi-json-3-0/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/adapter.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/adapter.js",
+    "import": "./es/adapter.mjs",
     "require": "./cjs/adapter.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-parser-adapter-openapi-json-3-1/package.json
+++ b/packages/apidom-parser-adapter-openapi-json-3-1/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/adapter.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/adapter.js",
+    "import": "./es/adapter.mjs",
     "require": "./cjs/adapter.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/package.json
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/adapter.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/adapter.js",
+    "import": "./es/adapter.mjs",
     "require": "./cjs/adapter.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-parser-adapter-openapi-yaml-3-1/package.json
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-1/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/adapter.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/adapter.js",
+    "import": "./es/adapter.mjs",
     "require": "./cjs/adapter.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-parser-adapter-yaml-1-2/package.json
+++ b/packages/apidom-parser-adapter-yaml-1-2/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/lexical-analysis/browser-patch.js",
+    "./es/lexical-analysis/browser-patch.mjs",
     "./cjs/lexical-analysis/browser-patch.cjs"
   ],
   "unpkg": "./dist/apidom-parser-apdater-yaml-1-2.browser.min.js",
@@ -16,18 +16,18 @@
   "exports": {
     "types": "./types/dist.d.ts",
     "node": {
-      "import": "./es/adapter-node.js",
+      "import": "./es/adapter-node.mjs",
       "require": "./cjs/adapter-node.cjs"
     },
     "browser": {
-      "import": "./es/adapter-browser.js"
+      "import": "./es/adapter-browser.mjs"
     },
     "default": "./cjs/adapter-node.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "npm run build:wasm && npm run build:wasm:copy && cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "npm run build:wasm && npm run build:wasm:copy && cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "npm run build:wasm && npm run build:wasm:copy && BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "npm run build:wasm && npm run build:wasm:copy && cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "build:wasm": "node ../../scripts/file-exists.js ../../node_modules/tree-sitter-yaml/tree-sitter-yaml.wasm && exit 0 || cd ../../node_modules/tree-sitter-yaml && cross-env BABEL_ENV=cjs NODE_OPTIONS='-r core-js/stable @babel/register' tree-sitter generate --abi=13 ./grammar.js && tree-sitter build-wasm && node-gyp rebuild",

--- a/packages/apidom-parser/package.json
+++ b/packages/apidom-parser/package.json
@@ -12,13 +12,13 @@
   "main": "./cjs/parser.cjs",
   "exports": {
     "types": "./types/dist.d.ts",
-    "import": "./es/parser.js",
+    "import": "./es/parser.mjs",
     "require": "./cjs/parser.cjs"
   },
   "types": "./types/dist.d.ts",
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",

--- a/packages/apidom-reference/package.json
+++ b/packages/apidom-reference/package.json
@@ -8,150 +8,150 @@
   },
   "type": "module",
   "sideEffects": [
-    "./es/configuration/saturated.js",
+    "./es/configuration/saturated.mjs",
     "./cjs/configuration/saturated.cjs"
   ],
   "unpkg": "./dist/apidom-reference.browser.min.js",
   "browser": {
     "./cjs/parse/parsers/binary/index-node.cjs": "./cjs/parse/parsers/binary/index-browser.cjs",
     "./cjs/resolve/resolvers/file/index-node.cjs": "./cjs/resolve/resolvers/file/index-browser.cjs",
-    "./es/parse/parsers/binary/index-node.js": "./es/parse/parsers/binary/index-browser.js",
-    "./es/resolve/resolvers/file/index-node.js": "./es/resolve/resolvers/file/index-browser.js"
+    "./es/parse/parsers/binary/index-node.mjs": "./es/parse/parsers/binary/index-browser.mjs",
+    "./es/resolve/resolvers/file/index-node.mjs": "./es/resolve/resolvers/file/index-browser.mjs"
   },
   "main": "./cjs/configuration/saturated.cjs",
   "types": "./types/dist.d.ts",
   "exports": {
     ".": {
-      "import": "./es/configuration/saturated.js",
+      "import": "./es/configuration/saturated.mjs",
       "require": "./cjs/configuration/saturated.cjs",
       "types": "./types/dist.d.ts"
     },
     "./configuration/saturated": {
-      "import": "./es/configuration/saturated.js",
+      "import": "./es/configuration/saturated.mjs",
       "require": "./cjs/configuration/saturated.cjs",
       "types": "./types/dist.d.ts"
     },
     "./configuration/empty": {
-      "import": "./es/configuration/empty.js",
+      "import": "./es/configuration/empty.mjs",
       "require": "./cjs/configuration/empty.cjs",
       "types": "./types/dist.d.ts"
     },
     "./resolve/resolvers/file": {
       "browser": {
-        "import": "./es/resolve/resolvers/file/index-browser.js",
+        "import": "./es/resolve/resolvers/file/index-browser.mjs",
         "require": "./cjs/resolve/resolvers/file/index-browser.cjs",
         "types": "./types/resolve/resolvers/file/index-browser.d.ts"
       },
       "default": {
-        "import": "./es/resolve/resolvers/file/index-node.js",
+        "import": "./es/resolve/resolvers/file/index-node.mjs",
         "require": "./cjs/resolve/resolvers/file/index-node.cjs",
         "types": "./types/resolve/resolvers/file/index-node.d.ts"
       }
     },
     "./resolve/resolvers/http-axios": {
-      "import": "./es/resolve/resolvers/http-axios/index.js",
+      "import": "./es/resolve/resolvers/http-axios/index.mjs",
       "require": "./cjs/resolve/resolvers/http-axios/index.cjs",
       "types": "./types/resolve/resolvers/http-axios/index.d.ts"
     },
     "./resolve/strategies/asyncapi-2": {
-      "import": "./es/resolve/strategies/asyncapi-2/index.js",
+      "import": "./es/resolve/strategies/asyncapi-2/index.mjs",
       "require": "./cjs/resolve/strategies/asyncapi-2/index.cjs",
       "types": "./types/resolve/strategies/asyncapi-2/index.d.ts"
     },
     "./resolve/strategies/openapi-3-0": {
-      "import": "./es/resolve/strategies/openapi-3-0/index.js",
+      "import": "./es/resolve/strategies/openapi-3-0/index.mjs",
       "require": "./cjs/resolve/strategies/openapi-3-0/index.cjs",
       "types": "./types/resolve/strategies/openapi-3-0/index.d.ts"
     },
     "./resolve/strategies/openapi-3-1": {
-      "import": "./es/resolve/strategies/openapi-3-1/index.js",
+      "import": "./es/resolve/strategies/openapi-3-1/index.mjs",
       "require": "./cjs/resolve/strategies/openapi-3-1/index.cjs",
       "types": "./types/resolve/strategies/openapi-3-1/index.d.ts"
     },
     "./parse/parsers/api-design-systems-json": {
-      "import": "./es/parse/parsers/api-design-systems-json/index.js",
+      "import": "./es/parse/parsers/api-design-systems-json/index.mjs",
       "require": "./cjs/parse/parsers/api-design-systems-json/index.cjs",
       "types": "./types/parse/parsers/api-design-systems-json/index.d.ts"
     },
     "./parse/parsers/api-design-systems-yaml": {
-      "import": "./es/parse/parsers/api-design-systems-yaml/index.js",
+      "import": "./es/parse/parsers/api-design-systems-yaml/index.mjs",
       "require": "./cjs/parse/parsers/api-design-systems-yaml/index.cjs",
       "types": "./types/parse/parsers/api-design-systems-yaml/index.d.ts"
     },
     "./parse/parsers/asyncapi-json-2": {
-      "import": "./es/parse/parsers/asyncapi-json-2/index.js",
+      "import": "./es/parse/parsers/asyncapi-json-2/index.mjs",
       "require": "./cjs/parse/parsers/asyncapi-json-2/index.cjs",
       "types": "./types/parse/parsers/asyncapi-json-2/index.d.ts"
     },
     "./parse/parsers/asyncapi-yaml-2": {
-      "import": "./es/parse/parsers/asyncapi-yaml-2/index.js",
+      "import": "./es/parse/parsers/asyncapi-yaml-2/index.mjs",
       "require": "./cjs/parse/parsers/asyncapi-yaml-2/index.cjs",
       "types": "./types/parse/parsers/asyncapi-yaml-2/index.d.ts"
     },
     "./parse/parsers/binary": {
       "browser": {
-        "import": "./es/parse/parsers/binary/index-browser.js",
+        "import": "./es/parse/parsers/binary/index-browser.mjs",
         "require": "./cjs/parse/parsers/binary/index-browser.cjs",
         "types": "./types/parse/parsers/binary/index-browser.d.ts"
       },
       "default": {
-        "import": "./es/parse/parsers/binary/index-node.js",
+        "import": "./es/parse/parsers/binary/index-node.mjs",
         "require": "./cjs/parse/parsers/binary/index-node.cjs",
         "types": "./types/parse/parsers/binary/index-node.d.ts"
       }
     },
     "./parse/parsers/json": {
-      "import": "./es/parse/parsers/json/index.js",
+      "import": "./es/parse/parsers/json/index.mjs",
       "require": "./cjs/parse/parsers/json/index.cjs",
       "types": "./types/parse/parsers/json/index.d.ts"
     },
     "./parse/parsers/openapi-json-3-0": {
-      "import": "./es/parse/parsers/openapi-json-3-0/index.js",
+      "import": "./es/parse/parsers/openapi-json-3-0/index.mjs",
       "require": "./cjs/parse/parsers/openapi-json-3-0/index.cjs",
       "types": "./types/parse/parsers/openapi-json-3-0/index.d.ts"
     },
     "./parse/parsers/openapi-json-3-1": {
-      "import": "./es/parse/parsers/openapi-json-3-1/index.js",
+      "import": "./es/parse/parsers/openapi-json-3-1/index.mjs",
       "require": "./cjs/parse/parsers/openapi-json-3-1/index.cjs",
       "types": "./types/parse/parsers/openapi-json-3-1/index.d.ts"
     },
     "./parse/parsers/openapi-yaml-3-0": {
-      "import": "./es/parse/parsers/openapi-yaml-3-0/index.js",
+      "import": "./es/parse/parsers/openapi-yaml-3-0/index.mjs",
       "require": "./cjs/parse/parsers/openapi-yaml-3-0/index.cjs",
       "types": "./types/parse/parsers/openapi-yaml-3-0/index.d.ts"
     },
     "./parse/parsers/openapi-yaml-3-1": {
-      "import": "./es/parse/parsers/openapi-yaml-3-1/index.js",
+      "import": "./es/parse/parsers/openapi-yaml-3-1/index.mjs",
       "require": "./cjs/parse/parsers/openapi-yaml-3-1/index.cjs",
       "types": "./types/parse/parsers/openapi-yaml-3-1/index.d.ts"
     },
     "./parse/parsers/yaml-1-2": {
-      "import": "./es/parse/parsers/yaml-1-2/index.js",
+      "import": "./es/parse/parsers/yaml-1-2/index.mjs",
       "require": "./cjs/parse/parsers/yaml-1-2/index.cjs",
       "types": "./types/parse/parsers/yaml-1-2/index.d.ts"
     },
     "./dereference/strategies/asyncapi-2": {
-      "import": "./es/dereference/strategies/asyncapi-2/index.js",
+      "import": "./es/dereference/strategies/asyncapi-2/index.mjs",
       "require": "./cjs/dereference/strategies/asyncapi-2/index.cjs",
       "types": "./types/dereference/strategies/asyncapi-2/index.d.ts"
     },
     "./dereference/strategies/openapi-3-0": {
-      "import": "./es/dereference/strategies/openapi-3-0/index.js",
+      "import": "./es/dereference/strategies/openapi-3-0/index.mjs",
       "require": "./cjs/dereference/strategies/openapi-3-0/index.cjs",
       "types": "./types/dereference/strategies/openapi-3-0/index.d.ts"
     },
     "./dereference/strategies/openapi-3-1": {
-      "import": "./es/dereference/strategies/openapi-3-1/index.js",
+      "import": "./es/dereference/strategies/openapi-3-1/index.mjs",
       "require": "./cjs/dereference/strategies/openapi-3-1/index.cjs",
       "types": "./types/dereference/strategies/openapi-3-1/index.d.ts"
     },
     "./dereference/strategies/openapi-3-1/selectors/$anchor": {
-      "import": "./es/dereference/strategies/openapi-3-1/selectors/$anchor/index.js",
+      "import": "./es/dereference/strategies/openapi-3-1/selectors/$anchor/index.mjs",
       "require": "./cjs/dereference/strategies/openapi-3-1/selectors/$anchor/index.cjs",
       "types": "./types/dereference/strategies/openapi-3-1/selectors/$anchor/index.d.ts"
     },
     "./dereference/strategies/openapi-3-1/selectors/uri": {
-      "import": "./es/dereference/strategies/openapi-3-1/selectors/uri/index.js",
+      "import": "./es/dereference/strategies/openapi-3-1/selectors/uri/index.mjs",
       "require": "./cjs/dereference/strategies/openapi-3-1/selectors/uri/index.cjs",
       "types": "./types/dereference/strategies/openapi-3-1/selectors/uri/index.d.ts"
     }
@@ -159,21 +159,21 @@
   "imports": {
     "#buffer": {
       "node": {
-        "import": "./es/util/polyfills/buffer/protocol-import.js",
+        "import": "./es/util/polyfills/buffer/protocol-import.mjs",
         "require": "./cjs/util/polyfills/buffer/standard-import.cjs"
       },
       "default": "./cjs/util/polyfills/buffer/standard-import.cjs"
     },
     "#fs": {
       "node": {
-        "import": "./es/util/polyfills/fs/protocol-import.js",
+        "import": "./es/util/polyfills/fs/protocol-import.mjs",
         "require": "./cjs/util/polyfills/fs/standard-import.cjs"
       },
       "default": "./cjs/util/polyfills/fs/standard-import.cjs"
     },
     "#util": {
       "node": {
-        "import": "./es/util/polyfills/util/protocol-import.js",
+        "import": "./es/util/polyfills/util/protocol-import.mjs",
         "require": "./cjs/util/polyfills/util/standard-import.cjs"
       },
       "default": "./cjs/util/polyfills/util/standard-import.cjs"
@@ -181,7 +181,7 @@
   },
   "scripts": {
     "build": "npm run clean && run-p --max-parallel ${CPU_CORES:-2} typescript:declaration build:es build:cjs build:umd:browser",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --root-mode 'upward'",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward'",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir cjs --extensions '.ts' --out-file-extension '.cjs' --root-mode 'upward'",
     "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.js --progress",
     "lint": "eslint ./",


### PR DESCRIPTION
The .mjs extension is reserved for ECMAScript Modules which cannot be loaded via require().
