### PR TITLE
fix(docker): make all tests pass in docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,12 @@ SHELL ["/bin/bash", "-c"]
 
 # install emscripten
 WORKDIR /tmp
-RUN git clone https://github.com/emscripten-core/emsdk.git
+RUN git clone --depth 1 --branch 2.0.24 https://github.com/emscripten-core/emsdk.git
 WORKDIR emsdk
-RUN ./emsdk install latest
-RUN ./emsdk activate latest
+RUN ./emsdk install 2.0.24
+RUN ./emsdk activate 2.0.24
 ENV PATH="/tmp/emsdk:/tmp/emsdk/upstream/emscripten:${PATH}"
 ENV EMSDK = /tmp/emsdk
 
 # setting CWD
 WORKDIR /apidom
-


### PR DESCRIPTION
Some tests were not passing in local docker setup. We needed to pin the emcsriptem to certain version.

