### PR TITLE
refactor(error): use native JavaScript features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32755,10 +32755,7 @@
       "version": "0.82.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7",
-        "@types/ramda": "~0.29.6",
-        "ramda": "~0.29.0",
-        "ramda-adjunct": "^4.0.0"
+        "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "packages/apidom-json-path": {

--- a/packages/apidom-error/package.json
+++ b/packages/apidom-error/package.json
@@ -37,10 +37,7 @@
   "author": "Vladimír Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.20.7",
-    "@types/ramda": "~0.29.6",
-    "ramda": "~0.29.0",
-    "ramda-adjunct": "^4.0.0"
+    "@babel/runtime-corejs3": "^7.20.7"
   },
   "files": [
     "cjs/",

--- a/packages/apidom-error/src/ApiDOMAggregateError.ts
+++ b/packages/apidom-error/src/ApiDOMAggregateError.ts
@@ -1,7 +1,4 @@
-import { isPlainObject } from 'ramda-adjunct';
-import { hasIn } from 'ramda';
-
-import ApiDOMErrorOptions from './ApiDOMErrorOptions';
+import type ApiDOMErrorOptions from './ApiDOMErrorOptions';
 
 class ApiDOMAggregateError extends AggregateError {
   constructor(errors: Iterable<unknown>, message?: string, options?: ApiDOMErrorOptions) {
@@ -19,13 +16,18 @@ class ApiDOMAggregateError extends AggregateError {
 
     /**
      * This needs to stay here until our minimum supported version of Node.js is >= 16.9.0.
-     * Node.js is >= 16.9.0 supports error causes natively.
+     * Node.js >= 16.9.0 supports error causes natively.
      */
-    if (isPlainObject(options) && hasIn('cause', options) && !hasIn('cause', this)) {
+    if (
+      options != null &&
+      typeof options === 'object' &&
+      Object.hasOwn(options, 'cause') &&
+      !('cause' in this)
+    ) {
       const { cause } = options;
       this.cause = cause;
-      if (cause instanceof Error && hasIn('stack', cause)) {
-        this.stack = `${this.stack}\nCAUSE: ${cause?.stack}`;
+      if (cause instanceof Error && 'stack' in cause) {
+        this.stack = `${this.stack}\nCAUSE: ${cause.stack}`;
       }
     }
   }

--- a/packages/apidom-error/src/ApiDOMError.ts
+++ b/packages/apidom-error/src/ApiDOMError.ts
@@ -1,8 +1,5 @@
-import { hasIn } from 'ramda';
-import { isPlainObject } from 'ramda-adjunct';
-
 import ApiDOMAggregateError from './ApiDOMAggregateError';
-import ApiDOMErrorOptions from './ApiDOMErrorOptions';
+import type ApiDOMErrorOptions from './ApiDOMErrorOptions';
 
 class ApiDOMError extends Error {
   public static [Symbol.hasInstance](instance: unknown) {
@@ -30,11 +27,16 @@ class ApiDOMError extends Error {
      * This needs to stay here until our minimum supported version of Node.js is >= 16.9.0.
      * Node.js is >= 16.9.0 supports error causes natively.
      */
-    if (isPlainObject(options) && hasIn('cause', options) && !hasIn('cause', this)) {
+    if (
+      options != null &&
+      typeof options === 'object' &&
+      Object.hasOwn(options, 'cause') &&
+      !('cause' in this)
+    ) {
       const { cause } = options;
       this.cause = cause;
-      if (cause instanceof Error && hasIn('stack', cause)) {
-        this.stack = `${this.stack}\nCAUSE: ${cause?.stack}`;
+      if (cause instanceof Error && 'stack' in cause) {
+        this.stack = `${this.stack}\nCAUSE: ${cause.stack}`;
       }
     }
   }

--- a/packages/apidom-error/src/ApiDOMStructuredError.ts
+++ b/packages/apidom-error/src/ApiDOMStructuredError.ts
@@ -1,5 +1,3 @@
-import { omit } from 'ramda';
-
 import ApiDOMError from './ApiDOMError';
 import ApiDOMErrorOptions from './ApiDOMErrorOptions';
 
@@ -7,8 +5,9 @@ class ApiDOMStructuredError extends ApiDOMError {
   constructor(message?: string, structuredOptions?: ApiDOMErrorOptions) {
     super(message, structuredOptions);
 
-    if (typeof structuredOptions !== 'undefined') {
-      Object.assign(this, omit(['cause'], structuredOptions));
+    if (structuredOptions != null && typeof structuredOptions === 'object') {
+      const { cause, ...causelessOptions } = structuredOptions;
+      Object.assign(this, causelessOptions);
     }
   }
 }


### PR DESCRIPTION
This commit remove dependance of ramda and
ramda-adjunct libraries.

It replaces ramda* functions with native
JavaScript features.

