### PR TITLE
fix: return support for Node.js >=12.20.0

### DIFF
--- a/packages/apidom-ast/src/traversal/visitor.ts
+++ b/packages/apidom-ast/src/traversal/visitor.ts
@@ -343,7 +343,7 @@ export const visit = (
   } while (stack !== undefined);
 
   if (edits.length !== 0) {
-    return edits.at(-1)[1];
+    return edits[edits.length - 1][1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
   }
 
   return root;
@@ -501,7 +501,7 @@ visit[Symbol.for('nodejs.util.promisify.custom')] = async (
   } while (stack !== undefined);
 
   if (edits.length !== 0) {
-    return edits.at(-1)[1];
+    return edits[edits.length - 1][1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
   }
 
   return root;

--- a/packages/apidom-ns-asyncapi-2/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-asyncapi-2/src/refractor/plugins/replace-empty-element.ts
@@ -1044,7 +1044,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element.value)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
         const elementFactory = findElementFactory(ancestor, toValue(element.key));
 
         // no element factory found
@@ -1069,7 +1069,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
 
         // we're only interested in empty elements in ArrayElements
         if (!isArrayElement(ancestor)) return undefined;

--- a/packages/apidom-ns-json-schema-draft-4/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-json-schema-draft-4/src/refractor/plugins/replace-empty-element.ts
@@ -192,7 +192,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element.value)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
         const elementFactory = findElementFactory(ancestor, toValue(element.key));
 
         // no element factory found
@@ -217,7 +217,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
 
         // we're only interested in empty elements in ArrayElements
         if (!isArrayElement(ancestor)) return undefined;

--- a/packages/apidom-ns-json-schema-draft-6/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-json-schema-draft-6/src/refractor/plugins/replace-empty-element.ts
@@ -206,7 +206,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element.value)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
         const elementFactory = findElementFactory(ancestor, toValue(element.key));
 
         // no element factory found
@@ -231,7 +231,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1];
 
         // we're only interested in empty elements in ArrayElements
         if (!isArrayElement(ancestor)) return undefined;

--- a/packages/apidom-ns-json-schema-draft-7/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/refractor/plugins/replace-empty-element.ts
@@ -220,7 +220,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element.value)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
         const elementFactory = findElementFactory(ancestor, toValue(element.key));
 
         // no element factory found
@@ -245,7 +245,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
 
         // we're only interested in empty elements in ArrayElements
         if (!isArrayElement(ancestor)) return undefined;

--- a/packages/apidom-ns-openapi-2/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/plugins/replace-empty-element.ts
@@ -349,7 +349,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element.value)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
         const elementFactory = findElementFactory(ancestor, toValue(element.key));
 
         // no element factory found
@@ -374,7 +374,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
 
         // we're only interested in empty elements in ArrayElements
         if (!isArrayElement(ancestor)) return undefined;

--- a/packages/apidom-ns-openapi-3-0/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-openapi-3-0/src/refractor/plugins/replace-empty-element.ts
@@ -618,7 +618,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element.value)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
         const elementFactory = findElementFactory(ancestor, toValue(element.key));
 
         // no element factory found
@@ -643,7 +643,7 @@ const plugin = () => () => {
         if (!isEmptyElement(element)) return undefined;
 
         const [, , , ancestors] = rest;
-        const ancestor = ancestors.at(-1);
+        const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
 
         // we're only interested in empty elements in ArrayElements
         if (!isArrayElement(ancestor)) return undefined;

--- a/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-servers.ts
+++ b/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-servers.ts
@@ -84,7 +84,8 @@ const plugin =
           if (ancestors.some(predicates.isComponentsElement)) return;
           if (!ancestors.some(predicates.isOpenApi3_1Element)) return;
 
-          const parentPathItemElement = ancestors.findLast(predicates.isPathItemElement);
+          // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.findLast in future
+          const parentPathItemElement = [...ancestors].reverse().find(predicates.isPathItemElement);
           const isServersUndefined = typeof operationElement.servers === 'undefined';
           const isServersArrayElement = predicates.isArrayElement(operationElement.servers);
           const isServersEmpty = isServersArrayElement && operationElement.servers!.length === 0;

--- a/packages/apidom-ns-openapi-3-1/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-openapi-3-1/src/refractor/plugins/replace-empty-element.ts
@@ -687,7 +687,7 @@ const plugin =
           if (!isEmptyElement(element.value)) return undefined;
 
           const [, , , ancestors] = rest;
-          const ancestor = ancestors.at(-1);
+          const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
           const elementFactory = findElementFactory(ancestor, toValue(element.key));
 
           // no element factory found
@@ -712,7 +712,7 @@ const plugin =
           if (!isEmptyElement(element)) return undefined;
 
           const [, , , ancestors] = rest;
-          const ancestor = ancestors.at(-1);
+          const ancestor = ancestors[ancestors.length - 1]; // @TODO(vladimir.gorej@gmail.com): can be replaced by Array.prototype.at in future
 
           // we're only interested in empty elements in ArrayElements
           if (!predicates.isArrayElement(ancestor)) return undefined;

--- a/packages/apidom-parser-adapter-json/src/syntactic-analysis/direct/index.ts
+++ b/packages/apidom-parser-adapter-json/src/syntactic-analysis/direct/index.ts
@@ -54,7 +54,7 @@ const analyze = (cst: NodeTree | WebTree, { sourceMap = false } = {}): ParseResu
   const visitor = CstVisitor();
   const cursor = cst.walk();
   const iterator = new TreeCursorIterator(cursor);
-  const rootNode = [...iterator].at(0) as TreeCursorSyntaxNode;
+  const rootNode = [...iterator][0] as TreeCursorSyntaxNode;
 
   return visit(rootNode, visitor, {
     // @ts-ignore

--- a/packages/apidom-parser-adapter-json/src/syntactic-analysis/indirect/index.ts
+++ b/packages/apidom-parser-adapter-json/src/syntactic-analysis/indirect/index.ts
@@ -32,7 +32,7 @@ type Tree = WebTree | NodeTree;
 const analyze = (cst: Tree, { sourceMap = false } = {}): ParseResultElement => {
   const cursor = cst.walk();
   const iterator = new TreeCursorIterator(cursor);
-  const rootNode = [...iterator].at(0) as TreeCursorSyntaxNode;
+  const rootNode = [...iterator][0] as TreeCursorSyntaxNode;
   const cstVisitor = CstVisitor();
   const astVisitor = JsonAstVisitor();
 

--- a/packages/apidom-parser-adapter-yaml-1-2/src/syntactic-analysis/indirect/index.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/src/syntactic-analysis/indirect/index.ts
@@ -22,7 +22,7 @@ type Tree = WebTree | NodeTree;
 const analyze = (cst: Tree, { sourceMap = false } = {}): ParseResultElement => {
   const cursor = cst.walk();
   const iterator = new TreeCursorIterator(cursor);
-  const rootNode = [...iterator].at(0) as TreeCursorSyntaxNode;
+  const rootNode = [...iterator][0] as TreeCursorSyntaxNode;
   const cstVisitor = CstVisitor();
   const astVisitor = YamlAstVisitor();
   const schema = JsonSchema();


### PR DESCRIPTION
Array.prototype.at and Array.prototype.findLast are not available in `Node.js 12.20.0` environment and calling them throws `TypeError`. This PR addressed this issue and returns back support for `Node.js >= 12.20.0`.