### PR TITLE
refactor(ls): scope OpenAPI 3.x.y rules explicitly (batch 2)

### DIFF
--- a/packages/apidom-ls/src/config/openapi/example/completion.ts
+++ b/packages/apidom-ls/src/config/openapi/example/completion.ts
@@ -3,6 +3,7 @@ import {
   CompletionFormat,
   CompletionType,
 } from '../../../apidom-language-types';
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
 
 const completion: ApidomCompletionItem[] = [
   {
@@ -16,6 +17,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: 'A reference to an Example.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'summary',
@@ -28,6 +30,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: 'Short description for the example.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'description',
@@ -41,6 +44,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'value',
@@ -54,6 +58,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'externalValue',
@@ -67,12 +72,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'externalValue',
@@ -86,7 +86,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. See the rules for resolving [Relative References](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#relativeReferencesURI).',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/example/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/example/documentation.ts
@@ -1,43 +1,38 @@
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
+
 const documentation = [
   {
     target: 'summary',
     docs: 'Short description for the example.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'description',
     docs: 'Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'value',
     docs: 'Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'externalValue',
     docs: 'A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive.',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'externalValue',
     docs: 'A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. See the rules for resolving [Relative References](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#relativeReferencesURI).',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     docs: "#### [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#exampleObject)\n\n##### Fixed Fields\nField Name | Type | Description\n---|:---:|---\nsummary | `string` | Short description for the example.\ndescription | `string` | Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.\nvalue | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.\nexternalValue | `string` | A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive.\n\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions).\n\nIn all cases, the example value is expected to be compatible with the type schema\nof its associated value.  Tooling implementations MAY choose to\nvalidate compatibility automatically, and reject the example value(s) if incompatible.\n\n##### Example Object Examples\n\nIn a request body:\n\n\n\\\nYAML\n```yaml\nrequestBody:\n  content:\n    'application/json':\n      schema:\n        $ref: '#/components/schemas/Address'\n      examples:\n        foo:\n          summary: A foo example\n          value: {\"foo\": \"bar\"}\n        bar:\n          summary: A bar example\n          value: {\"bar\": \"baz\"}\n    'application/xml':\n      examples:\n        xmlExample:\n          summary: This is an example in XML\n          externalValue: 'http://example.org/examples/address-example.xml'\n    'text/plain':\n      examples:\n        textExample:\n          summary: This is a text example\n          externalValue: 'http://foo.bar/examples/address-example.txt'\n```\n\nIn a parameter:\n\n```yaml\nparameters:\n  - name: 'zipCode'\n    in: 'query'\n    schema:\n      type: 'string'\n      format: 'zip-code'\n    examples:\n      zip-example:\n        $ref: '#/components/examples/zip-example'\n```\n\nIn a response:\n\n```yaml\nresponses:\n  '200':\n    description: your car appointment has been booked\n    content:\n      application/json:\n        schema:\n          $ref: '#/components/schemas/SuccessResponse'\n        examples:\n          confirmation-success:\n            $ref: '#/components/examples/confirmation-success'\n```",
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     docs: "#### [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#exampleObject)\n\n##### Fixed Fields\n\nField Name | Type | Description\n---|:---:|---\nsummary | `string` | Short description for the example.\ndescription | `string` | Long description for the example. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.\nvalue | Any | Embedded literal example. The `value` field and `externalValue` field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary.\nexternalValue | `string` | A URI that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.  The `value` field and `externalValue` field are mutually exclusive. See the rules for resolving [Relative References](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#relativeReferencesURI).\n\n\\\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions).\n\n\\\nIn all cases, the example value is expected to be compatible with the type schema of its associated value. Tooling implementations MAY choose to validate compatibility automatically, and reject the example value(s) if incompatible.\n##### Example Object Examples\n\nIn a request body:\n\n\\\nYAML\n```yaml\nrequestBody:\n  content:\n    'application/json':\n      schema:\n        $ref: '#/components/schemas/Address'\n      examples: \n        foo:\n          summary: A foo example\n          value: {\"foo\": \"bar\"}\n        bar:\n          summary: A bar example\n          value: {\"bar\": \"baz\"}\n    'application/xml':\n      examples: \n        xmlExample:\n          summary: This is an example in XML\n          externalValue: 'https://example.org/examples/address-example.xml'\n    'text/plain':\n      examples:\n        textExample: \n          summary: This is a text example\n          externalValue: 'https://foo.bar/examples/address-example.txt'\n```\n\n\\\nIn a parameter:\n\n\\\nYAML\n```yaml\nparameters:\n  - name: 'zipCode'\n    in: 'query'\n    schema:\n      type: 'string'\n      format: 'zip-code'\n    examples:\n      zip-example: \n        $ref: '#/components/examples/zip-example'\n```\n\n\\\nIn a response:\n\n\\\nYAML\n```yaml\nresponses:\n  '200':\n    description: your car appointment has been booked\n    content: \n      application/json:\n        schema:\n          $ref: '#/components/schemas/SuccessResponse'\n        examples:\n          confirmation-success:\n            $ref: '#/components/examples/confirmation-success'\n```\n",
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/example/lint/allowed-fields-3-0.ts
+++ b/packages/apidom-ls/src/config/openapi/example/lint/allowed-fields-3-0.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI30 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const allowedFields3_0Lint: LinterMeta = {
@@ -12,12 +13,7 @@ const allowedFields3_0Lint: LinterMeta = {
   linterFunction: 'allowedFields',
   linterParams: [['summary', 'description', 'value', 'externalValue', '$ref'], 'x-'],
   marker: 'key',
-  targetSpecs: [
-    { namespace: 'openapi', version: '3.0.0' },
-    { namespace: 'openapi', version: '3.0.1' },
-    { namespace: 'openapi', version: '3.0.2' },
-    { namespace: 'openapi', version: '3.0.3' },
-  ],
+  targetSpecs: OpenAPI30,
 };
 
 export default allowedFields3_0Lint;

--- a/packages/apidom-ls/src/config/openapi/example/lint/allowed-fields-3-1.ts
+++ b/packages/apidom-ls/src/config/openapi/example/lint/allowed-fields-3-1.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI31 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const allowedFields3_1Lint: LinterMeta = {
@@ -18,7 +19,7 @@ const allowedFields3_1Lint: LinterMeta = {
       params: ['$ref'],
     },
   ],
-  targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  targetSpecs: OpenAPI31,
 };
 
 export default allowedFields3_1Lint;

--- a/packages/apidom-ls/src/config/openapi/example/lint/description--type.ts
+++ b/packages/apidom-ls/src/config/openapi/example/lint/description--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const descriptionTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_EXAMPLE_FIELD_DESCRIPTION_TYPE,
@@ -13,6 +14,7 @@ const descriptionTypeLint: LinterMeta = {
   marker: 'value',
   target: 'description',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default descriptionTypeLint;

--- a/packages/apidom-ls/src/config/openapi/example/lint/external-value--format-uri.ts
+++ b/packages/apidom-ls/src/config/openapi/example/lint/external-value--format-uri.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const externalValueFormatURILint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_EXAMPLE_FIELD_EXTERNAL_VALUE_FORMAT_URI,
@@ -12,6 +13,7 @@ const externalValueFormatURILint: LinterMeta = {
   marker: 'value',
   target: 'externalValue',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default externalValueFormatURILint;

--- a/packages/apidom-ls/src/config/openapi/example/lint/summary--type.ts
+++ b/packages/apidom-ls/src/config/openapi/example/lint/summary--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const summaryTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_EXAMPLE_FIELD_SUMMARY_TYPE,
@@ -13,6 +14,7 @@ const summaryTypeLint: LinterMeta = {
   marker: 'value',
   target: 'summary',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default summaryTypeLint;

--- a/packages/apidom-ls/src/config/openapi/example/lint/value--mutually-exclusive.ts
+++ b/packages/apidom-ls/src/config/openapi/example/lint/value--mutually-exclusive.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const valueMutuallyExclusiveLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_EXAMPLE_FIELD_VALUE_MUTUALLY_EXCLUSIVE,
@@ -18,6 +19,7 @@ const valueMutuallyExclusiveLint: LinterMeta = {
       params: [['externalValue']],
     },
   ],
+  targetSpecs: OpenAPI3,
 };
 
 export default valueMutuallyExclusiveLint;

--- a/packages/apidom-ls/src/config/openapi/external-documentation/completion.ts
+++ b/packages/apidom-ls/src/config/openapi/external-documentation/completion.ts
@@ -3,6 +3,7 @@ import {
   CompletionFormat,
   CompletionType,
 } from '../../../apidom-language-types';
+import { OpenAPI3 } from '../target-specs';
 
 const completion: ApidomCompletionItem[] = [
   {
@@ -17,6 +18,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'A description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'url',
@@ -30,6 +32,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '**REQUIRED**. The URL for the target documentation. This MUST be in the form of a URL.',
     },
+    targetSpecs: OpenAPI3,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/external-documentation/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/external-documentation/documentation.ts
@@ -1,24 +1,23 @@
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
+
 const documentation = [
   {
     target: 'description',
     docs: 'A description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'url',
     docs: '**REQUIRED**. The URL for the target documentation. This MUST be in the form of a URL.',
+    targetSpecs: OpenAPI3,
   },
   {
     docs: '#### [External Documentation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#externalDocumentationObject)\n\nAllows referencing an external resource for extended documentation.\n\n##### Fixed Fields\n\nField Name | Type | Description\n---|:---:|---\ndescription | `string` | A short description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.\nurl | `string` | **REQUIRED**. The URL for the target documentation. Value MUST be in the format of a URL.\n\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions).\n\n##### External Documentation Object Example\n\n\n\\\nJSON\n```json\n{\n  "description": "Find more info here",\n  "url": "https://example.com"\n}\n```\n\n\n\\\nYAML\n```yaml\ndescription: Find more info here\nurl: https://example.com\n```',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     docs: '#### [External Documentation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#external-documentation-object)\n\nAllows referencing an external resource for extended documentation.\n\n##### Fixed Fields\n\nField Name | Type | Description\n---|:---:|---\ndescription | `string` | A description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.\nurl | `string` | **REQUIRED**. The URL for the target documentation. This MUST be in the form of a URL.\n\n\\\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions).\n\n##### External Documentation Object Example\n\n\n\\\nJSON\n```json\n{\n  "description": "Find more info here",\n  "url": "https://example.com"\n}\n```\n\n\n\\\nYAML\n```yaml\ndescription: Find more info here\nurl: https://example.com\n```',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/external-documentation/lint/allowed-fields.ts
+++ b/packages/apidom-ls/src/config/openapi/external-documentation/lint/allowed-fields.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const allowedFieldsLint: LinterMeta = {
   code: ApilintCodes.NOT_ALLOWED_FIELDS,
@@ -11,6 +12,7 @@ const allowedFieldsLint: LinterMeta = {
   linterFunction: 'allowedFields',
   linterParams: [['description', 'url'], 'x-'],
   marker: 'key',
+  targetSpecs: OpenAPI3,
 };
 
 export default allowedFieldsLint;

--- a/packages/apidom-ls/src/config/openapi/external-documentation/lint/description--type.ts
+++ b/packages/apidom-ls/src/config/openapi/external-documentation/lint/description--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const descriptionTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_EXTERNAL_DOCUMENTATION_FIELD_DESCRIPTION_TYPE,
@@ -13,6 +14,7 @@ const descriptionTypeLint: LinterMeta = {
   marker: 'value',
   target: 'description',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default descriptionTypeLint;

--- a/packages/apidom-ls/src/config/openapi/external-documentation/lint/url--format-uri.ts
+++ b/packages/apidom-ls/src/config/openapi/external-documentation/lint/url--format-uri.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const urlFormatURILint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_EXTERNAL_DOCUMENTATION_FIELD_URL_FORMAT_URI,
@@ -12,6 +13,7 @@ const urlFormatURILint: LinterMeta = {
   marker: 'value',
   target: 'url',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default urlFormatURILint;

--- a/packages/apidom-ls/src/config/openapi/external-documentation/lint/url--required.ts
+++ b/packages/apidom-ls/src/config/openapi/external-documentation/lint/url--required.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const urlRequiredLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_EXTERNAL_DOCUMENTATION_FIELD_URL_REQUIRED,
@@ -21,6 +22,7 @@ const urlRequiredLint: LinterMeta = {
       },
     ],
   },
+  targetSpecs: OpenAPI3,
 };
 
 export default urlRequiredLint;

--- a/packages/apidom-ls/src/config/openapi/header/completion.ts
+++ b/packages/apidom-ls/src/config/openapi/header/completion.ts
@@ -3,6 +3,7 @@ import {
   CompletionFormat,
   CompletionType,
 } from '../../../apidom-language-types';
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
 
 const completion: ApidomCompletionItem[] = [
   {
@@ -16,6 +17,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: 'A reference to a Header.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'description',
@@ -29,6 +31,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'A brief description of the header. This could contain examples of use. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'required',
@@ -42,6 +45,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Determines whether this header is mandatory. This property MAY be included and its default value is `false`.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'deprecated',
@@ -55,6 +59,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Specifies that a header is deprecated and SHOULD be transitioned out of usage. Default value is `false`.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'allowEmptyValue',
@@ -68,6 +73,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         "Doesn't apply for headers. Default value is `false`. Use of this property is NOT RECOMMENDED, as it is likely to be removed in a later revision.",
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'style',
@@ -80,6 +86,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: 'Describes how the header value will be serialized. Default value: `simple`.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'explode',
@@ -93,6 +100,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'When this is true, header values of type array or object generate separate headers for each value of the array or key-value pair of the map. The default value is `false`.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'allowReserved',
@@ -106,6 +114,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         "Determines whether the header value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent - encoding. This property has no effect and the default value is `false`.",
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'schema',
@@ -119,12 +128,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '[Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject) | [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#referenceObject)\n\\\n\\\nThe schema defining the type used for the header.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'schema',
@@ -138,7 +142,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '[Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject)\n\\\n\\\nThe schema defining the type used for the header.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'example',
@@ -152,6 +156,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         "Example of the header's potential value. The example SHOULD match the specified schema and encoding properties if present. The `example` field is mutually exclusive of the `examples` field. Furthermore, if referencing a `schema` that contains an example, the `example` value SHALL *override* the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.",
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'examples',
@@ -165,12 +170,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         "Map[`string`, [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#exampleObject) &#124; [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#referenceObject)]\n\\\n\\\nExamples of the header's potential value. Each example SHOULD contain a value in the correct format as specified in the header encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL *override* the example provided by the schema.",
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'examples',
@@ -184,7 +184,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         "Map[`string`, [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#exampleObject) &#124; [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#referenceObject)]\n\\\n\\\nExamples of the header's potential value. Each example SHOULD contain a value in the correct format as specified in the header encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL *override* the example provided by the schema.",
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'content',
@@ -198,12 +198,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Map[string, [Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)]\n\\\n\\\nA map containing the representations for the header. The key is the media type and the value describes it. The map MUST only contain one entry.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'content',
@@ -217,7 +212,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Map[string, [Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)]\n\\\n\\\nA map containing the representations for the header. The key is the media type and the value describes it. The map MUST only contain one entry.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/header/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/header/documentation.ts
@@ -1,3 +1,5 @@
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
+
 /**
  * Omitted fixed fields for OpenAPI 3.1.0:
  *  - schema
@@ -11,87 +13,75 @@ const documentation = [
   {
     target: 'description',
     docs: 'A brief description of the header. This could contain examples of use. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'required',
     docs: 'Determines whether this header is mandatory. This property MAY be included and its default value is `false`.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'deprecated',
     docs: 'Specifies that a header is deprecated and SHOULD be transitioned out of usage. Default value is `false`.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'allowEmptyValue',
     docs: "Doesn't apply for headers. Default value is `false`. Use of this property is NOT RECOMMENDED, as it is likely to be removed in a later revision.",
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'style',
     docs: 'Describes how the header value will be serialized. Default value: `simple`.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'explode',
     docs: 'When this is true, header values of type array or object generate separate headers for each value of the array or key-value pair of the map. The default value is `false`.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'allowReserved',
     docs: "Determines whether the header value SHOULD allow reserved characters, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2) `:/?#[]@!$&'()*+,;=` to be included without percent - encoding. This property has no effect and the default value is `false`.",
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'schema',
     docs: '[Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject) | [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#referenceObject)\n\\\n\\\nThe schema defining the type used for the header.',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'example',
     docs: "Example of the header's potential value. The example SHOULD match the specified schema and encoding properties if present. The `example` field is mutually exclusive of the `examples` field. Furthermore, if referencing a `schema` that contains an example, the `example` value SHALL *override* the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.",
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'examples',
     docs: "Map[`string`, [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#exampleObject) &#124; [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#referenceObject)]\n\\\n\\\nExamples of the header's potential value. Each example SHOULD contain a value in the correct format as specified in the header encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL *override* the example provided by the schema.",
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'examples',
     docs: "Map[`string`, [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#exampleObject) &#124; [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#referenceObject)]\n\\\n\\\nExamples of the header's potential value. Each example SHOULD contain a value in the correct format as specified in the header encoding. The `examples` field is mutually exclusive of the `example` field. Furthermore, if referencing a `schema` that contains an example, the `examples` value SHALL *override* the example provided by the schema.",
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     target: 'content',
     docs: 'Map[string, [Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)]\n\\\n\\\nA map containing the representations for the header. The key is the media type and the value describes it. The map MUST only contain one entry.',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'content',
     docs: 'Map[string, [Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)]\n\\\n\\\nA map containing the representations for the header. The key is the media type and the value describes it. The map MUST only contain one entry.',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     docs: '#### [Header Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#headerObject)\n\nThe Header Object follows the structure of the [Parameter Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject) with the following changes:\n\n1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.\n1. `in` MUST NOT be specified, it is implicitly in `header`.\n1. All traits that are affected by the location MUST be applicable to a location of `header` (for example, [`style`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterStyle)).\n\n##### Header Object Example\n\nA simple header of type `integer`:\n\n\n\\\nJSON\n```json\n{\n  "description": "The number of allowed requests in the current period",\n  "schema": {\n    "type": "integer"\n  }\n}\n```\n\n\n\\\nYAML\n```yaml\ndescription: The number of allowed requests in the current period\nschema:\n  type: integer\n```',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     docs: '#### [Header Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#headerObject)\n\nThe Header Object follows the structure of the [Parameter Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterObject) with the following changes:\n\n 1. `name` MUST NOT be specified, it is given in the corresponding `headers` map.\n  2. `in` MUST NOT be specified, it is implicitly in `header`.\n  3. All traits that are affected by the location MUST be applicable to a location of `header` (for example, [`style`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterStyle)).\n\n##### Header Object Example\n\n\\\nA simple header of type `integer`:\n\n\\\nJSON\n```json\n{\n  "description": "The number of allowed requests in the current period",\n  "schema": {\n    "type": "integer"\n  }\n}\n```\n\n\\\nYAML\n```yaml\ndescription: The number of allowed requests in the current period\nschema:\n  type: integer\n```\n',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/header/lint/allow-empty-value--type.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/allow-empty-value--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const allowEmptyValueTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_ALLOW_EMPTY_VALUE_TYPE,
@@ -13,6 +14,7 @@ const allowEmptyValueTypeLint: LinterMeta = {
   marker: 'value',
   target: 'allowEmptyValue',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default allowEmptyValueTypeLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/allow-reserved--type.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/allow-reserved--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const allowReservedTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_ALLOW_RESERVED_TYPE,
@@ -13,6 +14,7 @@ const allowReservedTypeLint: LinterMeta = {
   marker: 'value',
   target: 'allowReserved',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default allowReservedTypeLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/allowed-fields-3-0.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/allowed-fields-3-0.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI30 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const allowedFields3_0Lint: LinterMeta = {
@@ -28,12 +29,7 @@ const allowedFields3_0Lint: LinterMeta = {
     'x-',
   ],
   marker: 'key',
-  targetSpecs: [
-    { namespace: 'openapi', version: '3.0.0' },
-    { namespace: 'openapi', version: '3.0.1' },
-    { namespace: 'openapi', version: '3.0.2' },
-    { namespace: 'openapi', version: '3.0.3' },
-  ],
+  targetSpecs: OpenAPI30,
 };
 
 export default allowedFields3_0Lint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/allowed-fields-3-1.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/allowed-fields-3-1.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI31 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const allowedFields3_1Lint: LinterMeta = {
@@ -33,7 +34,7 @@ const allowedFields3_1Lint: LinterMeta = {
       params: ['$ref'],
     },
   ],
-  targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  targetSpecs: OpenAPI31,
 };
 
 export default allowedFields3_1Lint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/content--allowed-fields-3-0.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/content--allowed-fields-3-0.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI30 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const contentAllowedFields3_0Lint: LinterMeta = {
@@ -22,12 +23,7 @@ const contentAllowedFields3_0Lint: LinterMeta = {
       params: [['content']],
     },
   ],
-  targetSpecs: [
-    { namespace: 'openapi', version: '3.0.0' },
-    { namespace: 'openapi', version: '3.0.1' },
-    { namespace: 'openapi', version: '3.0.2' },
-    { namespace: 'openapi', version: '3.0.3' },
-  ],
+  targetSpecs: OpenAPI30,
 };
 
 export default contentAllowedFields3_0Lint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/content--allowed-fields-3-1.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/content--allowed-fields-3-1.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI31 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const contentAllowedFields3_1Lint: LinterMeta = {
@@ -26,7 +27,7 @@ const contentAllowedFields3_1Lint: LinterMeta = {
       params: ['$ref'],
     },
   ],
-  targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  targetSpecs: OpenAPI31,
 };
 
 export default contentAllowedFields3_1Lint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/content--values-type.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/content--values-type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const contentValuesTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_CONTENT_VALUES_TYPE,
@@ -14,6 +15,7 @@ const contentValuesTypeLint: LinterMeta = {
   markerTarget: 'content',
   target: 'content',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default contentValuesTypeLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/deprecated--type.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/deprecated--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const deprecatedTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_DEPRECATED_TYPE,
@@ -13,6 +14,7 @@ const deprecatedTypeLint: LinterMeta = {
   marker: 'value',
   target: 'deprecated',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default deprecatedTypeLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/description--type.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/description--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const descriptionTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_DESCRIPTION_TYPE,
@@ -13,6 +14,7 @@ const descriptionTypeLint: LinterMeta = {
   marker: 'value',
   target: 'description',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default descriptionTypeLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/examples--mutually-exclusive.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/examples--mutually-exclusive.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const examplesMutuallyExclusiveLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_EXAMPLES_MUTUALLY_EXCLUSIVE,
@@ -18,6 +19,7 @@ const examplesMutuallyExclusiveLint: LinterMeta = {
       params: [['example']],
     },
   ],
+  targetSpecs: OpenAPI3,
 };
 
 export default examplesMutuallyExclusiveLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/examples--values-type.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/examples--values-type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const examplesValuesTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_EXAMPLES_VALUES_TYPE,
@@ -14,6 +15,7 @@ const examplesValuesTypeLint: LinterMeta = {
   markerTarget: 'examples',
   target: 'examples',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default examplesValuesTypeLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/explode--type.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/explode--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const explodeTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_EXPLODE_TYPE,
@@ -13,6 +14,7 @@ const explodeTypeLint: LinterMeta = {
   marker: 'value',
   target: 'explode',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default explodeTypeLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/required--type.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/required--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const requiredTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_REQUIRED_TYPE,
@@ -13,6 +14,7 @@ const requiredTypeLint: LinterMeta = {
   marker: 'value',
   target: 'required',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default requiredTypeLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/required-fields.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/required-fields.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const requiredFieldsLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_REQUIRED_FIELDS,
@@ -31,6 +32,7 @@ const requiredFieldsLint: LinterMeta = {
       },
     ],
   },
+  targetSpecs: OpenAPI3,
 };
 
 export default requiredFieldsLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/schema--mutually-exclusive.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/schema--mutually-exclusive.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const schemaMutuallyExclusiveLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_SCHEMA_MUTUALLY_EXCLUSIVE,
@@ -18,6 +19,7 @@ const schemaMutuallyExclusiveLint: LinterMeta = {
       params: [['content']],
     },
   ],
+  targetSpecs: OpenAPI3,
 };
 
 export default schemaMutuallyExclusiveLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/schema--type.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/schema--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const schemaTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_SCHEMA_TYPE,
@@ -13,6 +14,7 @@ const schemaTypeLint: LinterMeta = {
   marker: 'value',
   target: 'schema',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default schemaTypeLint;

--- a/packages/apidom-ls/src/config/openapi/header/lint/style--type.ts
+++ b/packages/apidom-ls/src/config/openapi/header/lint/style--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const styleTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_HEADER_FIELD_STYLE_TYPE,
@@ -13,6 +14,7 @@ const styleTypeLint: LinterMeta = {
   marker: 'value',
   target: 'style',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default styleTypeLint;

--- a/packages/apidom-ls/src/config/openapi/info/completion.ts
+++ b/packages/apidom-ls/src/config/openapi/info/completion.ts
@@ -3,6 +3,7 @@ import {
   CompletionFormat,
   CompletionType,
 } from '../../../apidom-language-types';
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
 
 const completion: ApidomCompletionItem[] = [
   {
@@ -16,6 +17,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: '**REQUIRED.** The title of the API.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'summary',
@@ -28,7 +30,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: 'A short summary of the API.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'description',
@@ -42,6 +44,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'A description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'termsOfService',
@@ -54,6 +57,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: 'A URL to the Terms of Service for the API. This MUST be in the form of a URL.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'contact',
@@ -67,12 +71,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '[Contact Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#contactObject)\n\\\n\\\nThe contact information for the exposed API.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'contact',
@@ -86,7 +85,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '[Contact Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#contactObject)\n\\\n\\\nThe contact information for the exposed API.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'license',
@@ -100,12 +99,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '[License Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#licenseObject)\n\\\n\\\nThe license information for the exposed API.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'license',
@@ -119,7 +113,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '[License Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#licenseObject)\n\\\n\\\nThe license information for the exposed API.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'version',
@@ -133,12 +127,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '**REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oasVersion) or the API implementation version).',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'version',
@@ -152,7 +141,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '**REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oasVersion) or the API implementation version).',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/info/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/info/documentation.ts
@@ -1,3 +1,5 @@
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
+
 /**
  * Omitted fixed fields:
  *  - contact
@@ -13,47 +15,40 @@ const documentation = [
   {
     target: 'title',
     docs: '**REQUIRED.** The title of the API.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'summary',
     docs: 'A short summary of the API.',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     target: 'description',
     docs: 'A description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'termsOfService',
     docs: 'A URL to the Terms of Service for the API. This MUST be in the form of a URL.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'version',
     docs: '**REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oasVersion) or the API implementation version).',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'version',
     docs: '**REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oasVersion) or the API implementation version).',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     docs: '#### [Info Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#infoObject)\n\nThe object provides metadata about the API.\nThe metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.\n\n##### Fixed Fields\n\nField Name | Type | Description\n---|:---:|---\ntitle | `string` | **REQUIRED**. The title of the API.\ndescription | `string` | A short description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.\ntermsOfService | `string` | A URL to the Terms of Service for the API. MUST be in the format of a URL.\ncontact | [Contact Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#contactObject) | The contact information for the exposed API.\nlicense | [License Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#licenseObject) | The license information for the exposed API.\nversion | `string` | **REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oasVersion) or the API implementation version).\n\n\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions).\n\n##### Info Object Example\n\n\n\\\nJSON\n```json\n{\n  "title": "Sample Pet Store App",\n  "description": "This is a sample server for a pet store.",\n  "termsOfService": "http://example.com/terms/",\n  "contact": {\n    "name": "API Support",\n    "url": "http://www.example.com/support",\n    "email": "support@example.com"\n  },\n  "license": {\n    "name": "Apache 2.0",\n    "url": "https://www.apache.org/licenses/LICENSE-2.0.html"\n  },\n  "version": "1.0.1"\n}\n```\n\n\n\\\nYAML\n```yaml\ntitle: Sample Pet Store App\ndescription: This is a sample server for a pet store.\ntermsOfService: http://example.com/terms/\ncontact:\n  name: API Support\n  url: http://www.example.com/support\n  email: support@example.com\nlicense:\n  name: Apache 2.0\n  url: https://www.apache.org/licenses/LICENSE-2.0.html\nversion: 1.0.1\n```',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     docs: '#### [Info Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#infoObject)\n\nThe object provides metadata about the API.\nThe metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.\n\n##### Fixed Fields\n\nField Name | Type | Description\n---|:---:|---\ntitle | `string` | **REQUIRED**. The title of the API.\nsummary | `string` | A short summary of the API.\ndescription | `string` | A description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.\ntermsOfService | `string` | A URL to the Terms of Service for the API. This MUST be in the form of a URL.\ncontact | [Contact Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#contactObject) | The contact information for the exposed API.\nlicense | [License Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#licenseObject) | The license information for the exposed API.\nversion | `string` | **REQUIRED**. The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oasVersion) or the API implementation version).\n\n\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions).\n\n##### Info Object Example\n\n\n\\\nJSON\n```json\n{\n  "title": "Sample Pet Store App",\n  "summary": "A pet store manager.",\n  "description": "This is a sample server for a pet store.",\n  "termsOfService": "https://example.com/terms/",\n  "contact": {\n    "name": "API Support",\n    "url": "https://www.example.com/support",\n    "email": "support@example.com"\n  },\n  "license": {\n    "name": "Apache 2.0",\n    "url": "https://www.apache.org/licenses/LICENSE-2.0.html"\n  },\n  "version": "1.0.1"\n}\n```\n\n\n\\\nYAML\n```yaml\ntitle: Sample Pet Store App\nsummary: A pet store manager.\ndescription: This is a sample server for a pet store.\ntermsOfService: https://example.com/terms/\ncontact:\n  name: API Support\n  url: https://www.example.com/support\n  email: support@example.com\nlicense:\n  name: Apache 2.0\n  url: https://www.apache.org/licenses/LICENSE-2.0.html\nversion: 1.0.1\n```',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 export default documentation;

--- a/packages/apidom-ls/src/config/openapi/info/lint/allowed-fields-3-0.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/allowed-fields-3-0.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI30 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const allowedFields3_0Lint: LinterMeta = {
@@ -12,12 +13,7 @@ const allowedFields3_0Lint: LinterMeta = {
   linterFunction: 'allowedFields',
   linterParams: [['title', 'description', 'termsOfService', 'contact', 'license', 'version'], 'x-'],
   marker: 'key',
-  targetSpecs: [
-    { namespace: 'openapi', version: '3.0.0' },
-    { namespace: 'openapi', version: '3.0.1' },
-    { namespace: 'openapi', version: '3.0.2' },
-    { namespace: 'openapi', version: '3.0.3' },
-  ],
+  targetSpecs: OpenAPI30,
 };
 
 export default allowedFields3_0Lint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/allowed-fields-3-1.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/allowed-fields-3-1.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI31 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const allowedFields3_1Lint: LinterMeta = {
@@ -15,7 +16,7 @@ const allowedFields3_1Lint: LinterMeta = {
     'x-',
   ],
   marker: 'key',
-  targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  targetSpecs: OpenAPI31,
 };
 
 export default allowedFields3_1Lint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/contact--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/contact--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const contactTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_INFO_FIELD_CONTACT_TYPE,
@@ -13,6 +14,7 @@ const contactTypeLint: LinterMeta = {
   marker: 'value',
   target: 'contact',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default contactTypeLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/description--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/description--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const descriptionTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_INFO_FIELD_DESCRIPTION_TYPE,
@@ -13,6 +14,7 @@ const descriptionTypeLint: LinterMeta = {
   marker: 'value',
   target: 'description',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default descriptionTypeLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/license--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/license--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const licenseTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_INFO_FIELD_LICENSE_TYPE,
@@ -13,6 +14,7 @@ const licenseTypeLint: LinterMeta = {
   marker: 'value',
   target: 'license',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default licenseTypeLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/summary--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/summary--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI31 } from '../../target-specs';
 
 const summaryTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_1_INFO_FIELD_SUMMARY_TYPE,
@@ -13,7 +14,7 @@ const summaryTypeLint: LinterMeta = {
   marker: 'value',
   target: 'summary',
   data: {},
-  targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  targetSpecs: OpenAPI31,
 };
 
 export default summaryTypeLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/terms-of-service--format-uri.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/terms-of-service--format-uri.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const termsOfServiceFormatURILint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_INFO_FIELD_TERMS_OF_SERVICE_FORMAT_URI,
@@ -12,6 +13,7 @@ const termsOfServiceFormatURILint: LinterMeta = {
   marker: 'value',
   target: 'termsOfService',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default termsOfServiceFormatURILint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/title--required.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/title--required.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const titleRequiredLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_INFO_FIELD_TITLE_REQUIRED,
@@ -21,6 +22,7 @@ const titleRequiredLint: LinterMeta = {
       },
     ],
   },
+  targetSpecs: OpenAPI3,
 };
 
 export default titleRequiredLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/title--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/title--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const titleTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_INFO_FIELD_TITLE_TYPE,
@@ -13,6 +14,7 @@ const titleTypeLint: LinterMeta = {
   marker: 'value',
   target: 'title',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default titleTypeLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/version--required.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/version--required.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const versionRequiredLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_INFO_FIELD_VERSION_REQUIRED,
@@ -21,6 +22,7 @@ const versionRequiredLint: LinterMeta = {
       },
     ],
   },
+  targetSpecs: OpenAPI3,
 };
 
 export default versionRequiredLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/version--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/version--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const versionTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_INFO_FIELD_VERSION_TYPE,
@@ -13,6 +14,7 @@ const versionTypeLint: LinterMeta = {
   marker: 'value',
   target: 'version',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default versionTypeLint;

--- a/packages/apidom-ls/src/config/openapi/license/completion.ts
+++ b/packages/apidom-ls/src/config/openapi/license/completion.ts
@@ -3,6 +3,7 @@ import {
   CompletionFormat,
   CompletionType,
 } from '../../../apidom-language-types';
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
 
 const completion: ApidomCompletionItem[] = [
   {
@@ -16,6 +17,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: '**REQUIRED**. The license name used for the API.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'identifier',
@@ -29,7 +31,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'An [SPDX](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) license expression for the API. The `identifier` field is mutually exclusive of the `url` field.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'url',
@@ -42,12 +44,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: 'A URL to the license used for the API. MUST be in the format of a URL.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'url',
@@ -61,7 +58,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'A URL to the license used for the API. This MUST be in the form of a URL. The `url` field is mutually exclusive of the `identifier` field.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/license/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/license/documentation.ts
@@ -1,40 +1,33 @@
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
+
 const documentation = [
   {
     target: 'name',
     docs: '**REQUIRED**. The license name used for the API.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'identifier',
     docs: 'An [SPDX](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) license expression for the API. The `identifier` field is mutually exclusive of the `url` field.',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     target: 'url',
     docs: 'A URL to the license used for the API. MUST be in the format of a URL.',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'url',
     docs: 'A URL to the license used for the API. This MUST be in the form of a URL. The `url` field is mutually exclusive of the `identifier` field.',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     docs: '#### [License Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#licenseObject)\n\nLicense information for the exposed API.\n\n##### Fixed Fields\n\nField Name | Type | Description\n---|:---:|---\nname | `string` | **REQUIRED**. The license name used for the API.\nurl | `string` | A URL to the license used for the API. MUST be in the format of a URL.\n\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions).\n\n##### License Object Example\n\n\n\\\nJSON\n```json\n{\n  "name": "Apache 2.0",\n  "url": "https://www.apache.org/licenses/LICENSE-2.0.html"\n}\n```\n\n\n\\\nYAML\n```yaml\nname: Apache 2.0\nurl: https://www.apache.org/licenses/LICENSE-2.0.html\n```',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     docs: '#### [License Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#licenseObject)\n\nLicense information for the exposed API.\n\n##### Fixed Fields\n\nField Name | Type | Description\n---|:---:|---\nname | `string` | **REQUIRED**. The license name used for the API.\nidentifier | `string` | An [SPDX](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) license expression for the API. The `identifier` field is mutually exclusive of the `url` field.\nurl | `string` | A URL to the license used for the API. This MUST be in the form of a URL. The `url` field is mutually exclusive of the `identifier` field.\n\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions).\n\n##### License Object Example\n\n\n\\\nJSON\n```json\n{\n  "name": "Apache 2.0",\n  "identifier": "Apache-2.0"\n}\n```\n\n\n\\\nYAML\n```yaml\nname: Apache 2.0\nidentifier: Apache-2.0\n```',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/license/lint/allowed-fields-3-0.ts
+++ b/packages/apidom-ls/src/config/openapi/license/lint/allowed-fields-3-0.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI30 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const allowedFields3_0Lint: LinterMeta = {
@@ -12,12 +13,7 @@ const allowedFields3_0Lint: LinterMeta = {
   linterFunction: 'allowedFields',
   linterParams: [['name', 'url'], 'x-'],
   marker: 'key',
-  targetSpecs: [
-    { namespace: 'openapi', version: '3.0.0' },
-    { namespace: 'openapi', version: '3.0.1' },
-    { namespace: 'openapi', version: '3.0.2' },
-    { namespace: 'openapi', version: '3.0.3' },
-  ],
+  targetSpecs: OpenAPI30,
 };
 
 export default allowedFields3_0Lint;

--- a/packages/apidom-ls/src/config/openapi/license/lint/allowed-fields-3-1.ts
+++ b/packages/apidom-ls/src/config/openapi/license/lint/allowed-fields-3-1.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI31 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const allowedFields3_1Lint: LinterMeta = {
@@ -12,7 +13,7 @@ const allowedFields3_1Lint: LinterMeta = {
   linterFunction: 'allowedFields',
   linterParams: [['name', 'url', 'identifier'], 'x-'],
   marker: 'key',
-  targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  targetSpecs: OpenAPI31,
 };
 
 export default allowedFields3_1Lint;

--- a/packages/apidom-ls/src/config/openapi/license/lint/identifier--mutually-exclusive.ts
+++ b/packages/apidom-ls/src/config/openapi/license/lint/identifier--mutually-exclusive.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI31 } from '../../target-specs';
 
 const identifierMutuallyExclusiveLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_1_LICENSE_FIELD_IDENTIFIER_MUTUALLY_EXCLUSIVE,
@@ -18,7 +19,7 @@ const identifierMutuallyExclusiveLint: LinterMeta = {
       params: [['url']],
     },
   ],
-  targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  targetSpecs: OpenAPI31,
 };
 
 export default identifierMutuallyExclusiveLint;

--- a/packages/apidom-ls/src/config/openapi/license/lint/identifier--type.ts
+++ b/packages/apidom-ls/src/config/openapi/license/lint/identifier--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI31 } from '../../target-specs';
 
 const identifierTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_1_LICENSE_FIELD_IDENTIFIER_TYPE,
@@ -13,7 +14,7 @@ const identifierTypeLint: LinterMeta = {
   marker: 'value',
   target: 'name',
   data: {},
-  targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  targetSpecs: OpenAPI31,
 };
 
 export default identifierTypeLint;

--- a/packages/apidom-ls/src/config/openapi/license/lint/name--required.ts
+++ b/packages/apidom-ls/src/config/openapi/license/lint/name--required.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const nameRequiredLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_LICENSE_FIELD_NAME_REQUIRED,
@@ -21,6 +22,7 @@ const nameRequiredLint: LinterMeta = {
       },
     ],
   },
+  targetSpecs: OpenAPI3,
 };
 
 export default nameRequiredLint;

--- a/packages/apidom-ls/src/config/openapi/license/lint/name--type.ts
+++ b/packages/apidom-ls/src/config/openapi/license/lint/name--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const nameTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_LICENSE_FIELD_NAME_TYPE,
@@ -13,6 +14,7 @@ const nameTypeLint: LinterMeta = {
   marker: 'value',
   target: 'name',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default nameTypeLint;

--- a/packages/apidom-ls/src/config/openapi/license/lint/url--format-uri.ts
+++ b/packages/apidom-ls/src/config/openapi/license/lint/url--format-uri.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const urlFormatURILint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_LICENSE_FIELD_URL_FORMAT_URI,
@@ -12,6 +13,7 @@ const urlFormatURILint: LinterMeta = {
   marker: 'value',
   target: 'url',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default urlFormatURILint;

--- a/packages/apidom-ls/src/config/openapi/link/completion.ts
+++ b/packages/apidom-ls/src/config/openapi/link/completion.ts
@@ -3,6 +3,7 @@ import {
   CompletionFormat,
   CompletionType,
 } from '../../../apidom-language-types';
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
 
 const completion: ApidomCompletionItem[] = [
   {
@@ -16,6 +17,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: 'A reference to a Link.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'operationRef',
@@ -29,12 +31,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operationObject) in the OpenAPI definition.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'operationRef',
@@ -48,7 +45,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operationObject) in the OpenAPI definition. See the rules for resolving [Relative References](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#relativeReferencesURI).',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'operationId',
@@ -62,6 +59,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'The name of an existing, resolvable OAS operation, as defined with a unique `operationId`. This field is mutually exclusive of the `operationRef` field.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'parameters',
@@ -75,12 +73,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Map[`string`, Any &#124; [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#runtimeExpression)]\n\\\n\\\nA map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation. The parameter name can be qualified using the [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'parameters',
@@ -94,7 +87,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Map[`string`, Any &#124; [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#runtimeExpression)]\n\\\n\\\nA map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation. The parameter name can be qualified using the [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'requestBody',
@@ -108,12 +101,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Any &#124; [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#runtimeExpression)\n\\\n\\\nA literal value or [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#runtimeExpression) to use as a request body when calling the target operation.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'requestBody',
@@ -127,7 +115,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Any &#124; [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#runtimeExpression)\n\\\n\\\nA literal value or [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#runtimeExpression) to use as a request body when calling the target operation.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'description',
@@ -141,6 +129,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'A description of the link. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'server',
@@ -154,12 +143,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '[Server Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#serverObject)\n\\\n\\\nA server object to be used by the target operation.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'server',
@@ -173,7 +157,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '[Server Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#serverObject)\n\\\n\\\nA server object to be used by the target operation.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/link/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/link/documentation.ts
@@ -1,3 +1,5 @@
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
+
 /**
  * Omitted fixed fields:
  *  - server
@@ -12,68 +14,50 @@ const documentation = [
   {
     target: 'operationRef',
     docs: 'A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operationObject) in the OpenAPI definition.',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'operationRef',
     docs: 'A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operationObject) in the OpenAPI definition. See the rules for resolving [Relative References](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#relativeReferencesURI).',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     target: 'operationId',
     docs: 'The name of an existing, resolvable OAS operation, as defined with a unique `operationId`. This field is mutually exclusive of the `operationRef` field.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'parameters',
     docs: 'Map[`string`, Any &#124; [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#runtimeExpression)]\n\\\n\\\nA map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation. The parameter name can be qualified using the [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'parameters',
     docs: 'Map[`string`, Any &#124; [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#runtimeExpression)]\n\\\n\\\nA map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation. The parameter name can be qualified using the [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     target: 'requestBody',
     docs: 'Any &#124; [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#runtimeExpression)\n\\\n\\\nA literal value or [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#runtimeExpression) to use as a request body when calling the target operation.',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'requestBody',
     docs: 'Any &#124; [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#runtimeExpression)\n\\\n\\\nA literal value or [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#runtimeExpression) to use as a request body when calling the target operation.',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     target: 'description',
     docs: 'A description of the link. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
+    targetSpecs: OpenAPI3,
   },
   {
     docs: "#### [Link Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md)\n\nThe `Link object` represents a possible design-time link for a response.\nThe presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.\n\nUnlike _dynamic_ links (i.e. links provided **in** the response payload), the OAS linking mechanism does not require link information in the runtime response.\n\nFor computing links, and providing instructions to execute them, a [runtime expression](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#runtimeExpression) is used for accessing values in an operation and using them as parameters while invoking the linked operation.\n\n##### Fixed Fields\n\nField Name  |  Type  | Description\n---|:---:|---\noperationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operationObject) in the OpenAPI definition.\noperationId  | `string` | The name of an _existing_, resolvable OAS operation, as defined with a unique `operationId`.  This field is mutually exclusive of the `operationRef` field.\nparameters   | Map[`string`, Any \\| [{expression}](#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation.  The parameter name can be qualified using the [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).\nrequestBody | Any \\| [{expression}](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#runtimeExpression) | A literal value or [{expression}](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#runtimeExpression) to use as a request body when calling the target operation.\ndescription  | `string` | A description of the link. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.\nserver       | [Server Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#serverObject) | A server object to be used by the target operation.\n\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions).\n\nA linked operation MUST be identified using either an `operationRef` or `operationId`.\nIn the case of an `operationId`, it MUST be unique and resolved in the scope of the OAS document.\nBecause of the potential for name clashes, the `operationRef` syntax is preferred\nfor specifications with external references.\n\n##### Examples\n\nComputing a link from a request operation where the `$request.path.id` is used to pass a request parameter to the linked operation.\n\n\n\\\nYAML\n```yaml\npaths:\n  /users/{id}:\n    parameters:\n    - name: id\n      in: path\n      required: true\n      description: the user identifier, as userId\n      schema:\n        type: string\n    get:\n      responses:\n        '200':\n          description: the user being returned\n          content:\n            application/json:\n              schema:\n                type: object\n                properties:\n                  uuid: # the unique user id\n                    type: string\n                    format: uuid\n          links:\n            address:\n              # the target link operationId\n              operationId: getUserAddress\n              parameters:\n                # get the `id` field from the request path parameter named `id`\n                userId: $request.path.id\n  # the path item of the linked operation\n  /users/{userid}/address:\n    parameters:\n    - name: userid\n      in: path\n      required: true\n      description: the user identifier, as userId\n      schema:\n        type: string\n    # linked operation\n    get:\n      operationId: getUserAddress\n      responses:\n        '200':\n          description: the user's address\n```\n\nWhen a runtime expression fails to evaluate, no parameter value is passed to the target operation.\n\nValues from the response body can be used to drive a linked operation.\n\n```yaml\nlinks:\n  address:\n    operationId: getUserAddressByUUID\n    parameters:\n      # get the `uuid` field from the `uuid` field in the response body\n      userUuid: $response.body#/uuid\n```\n\nClients follow all links at their discretion.\nNeither permissions, nor the capability to make a successful call to that link, is guaranteed\nsolely by the existence of a relationship.",
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     docs: "#### [Link Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#linkObject)\nThe `Link object` represents a possible design-time link for a response. The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.\n\n\\\nUnlike *dynamic* links (i.e.links provided in the response payload), the OAS linking mechanism does not require link information in the runtime response.\n\n\\\nFor computing links, and providing instructions to execute them, a [runtime expression](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#runtimeExpression) is used for accessing values in an operation and using them as parameters while invoking the linked operation.\n\n##### Fixed Fields\n\nField Name | Type | Description\n---|:---:|---\noperationRef | `string` | A relative or absolute URI reference to an OAS operation. This field is mutually exclusive of the `operationId` field, and MUST point to an [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operationObject). Relative `operationRef` values MAY be used to locate an existing [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operationObject) in the OpenAPI definition. See the rules for resolving [Relative References](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#relativeReferencesURI).\noperationId | `string` | The name of an existing, resolvable OAS operation, as defined with a unique `operationId`. This field is mutually exclusive of the `operationRef` field.\nparameters | Map[`string`, Any &#124; [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#runtimeExpression)] | A map representing parameters to pass to an operation as specified with `operationId` or identified via `operationRef`. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation. The parameter name can be qualified using the [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterIn) `[{in}.]{name}` for operations that use the same parameter name in different locations (e.g. path.id).\nrequestBody | Any &#124; [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#runtimeExpression) | A literal value or [`{expression}`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#runtimeExpression) to use as a request body when calling the target operation.\ndescription | `string` | A description of the link. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.\nserver | [Server Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#serverObject) | A server object to be used by the target operation.\n\n\\\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions).\n\n\\\nA linked operation MUST be identified using either an `operationRef` or `operationId`. In the case of an `operationId`, it MUST be unique and resolved in the scope of the OAS document. Because of the potential for name clashes, the `operationRef` syntax is preferred for OpenAPI documents with external references.\n\n##### Examples\n\nComputing a link from a request operation where the `$request.path.id` is used to pass a request parameter to the linked operation.\n\n\\\nYAML\n```yaml\npaths:\n  /users/{id}:\n    parameters:\n    - name: id\n      in: path\n      required: true\n      description: the user identifier, as userId \n      schema:\n        type: string\n    get:\n      responses:\n        '200':\n          description: the user being returned\n          content:\n            application/json:\n              schema:\n                type: object\n                properties:\n                  uuid: # the unique user id\n                    type: string\n                    format: uuid\n          links:\n            address:\n              # the target link operationId\n              operationId: getUserAddress\n              parameters:\n                # get the `id` field from the request path parameter named `id`\n                userId: $request.path.id\n  # the path item of the linked operation\n  /users/{userid}/address:\n    parameters:\n    - name: userid\n      in: path\n      required: true\n      description: the user identifier, as userId \n      schema:\n        type: string\n    # linked operation\n    get:\n      operationId: getUserAddress\n      responses:\n        '200':\n          description: the user's address\n```\n\n\\\nWhen a runtime expression fails to evaluate, no parameter value is passed to the target operation.\n\n\\\nValues from the response body can be used to drive a linked operation.\n\n\\\nYAML\n```yaml\nlinks:\n  address:\n    operationId: getUserAddressByUUID\n    parameters:\n      # get the `uuid` field from the `uuid` field in the response body\n      userUuid: $response.body#/uuid\n```\n\n##### OperationRef Examples\n\nAs references to `operationId` MAY NOT be possible (the operationId is an optional field in an [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operationObject)), references MAY also be made through a relative `operationRef`:\n\n\\\nYAML\n```yaml\nlinks:\n  UserRepositories:\n    # returns array of '#/components/schemas/repository'\n    operationRef: '#/paths/~12.0~1repositories~1{username}/get'\n    parameters:\n      username: $response.body#/username\n```\n\n\\\nor an absolute `operationRef`:\n\n\\\nYAML\n```yaml\nlinks:\n  UserRepositories:\n    # returns array of '#/components/schemas/repository'\n    operationRef: 'https://na2.gigantic-server.com/#/paths/~12.0~1repositories~1{username}/get'\n    parameters:\n      username: $response.body#/username\n```\n\n\\\nNote that in the use of `operationRef`, the *escaped forward-slash* is necessary when using JSON references.",
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/link/lint/allowed-fields-3-0.ts
+++ b/packages/apidom-ls/src/config/openapi/link/lint/allowed-fields-3-0.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI30 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const allowedFields3_0Lint: LinterMeta = {
@@ -15,11 +16,6 @@ const allowedFields3_0Lint: LinterMeta = {
     'x-',
   ],
   marker: 'key',
-  targetSpecs: [
-    { namespace: 'openapi', version: '3.0.0' },
-    { namespace: 'openapi', version: '3.0.1' },
-    { namespace: 'openapi', version: '3.0.2' },
-    { namespace: 'openapi', version: '3.0.3' },
-  ],
+  targetSpecs: OpenAPI30,
 };
 export default allowedFields3_0Lint;

--- a/packages/apidom-ls/src/config/openapi/link/lint/allowed-fields-3-1.ts
+++ b/packages/apidom-ls/src/config/openapi/link/lint/allowed-fields-3-1.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI31 } from '../../target-specs';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const allowedFields3_1Lint: LinterMeta = {
@@ -21,6 +22,6 @@ const allowedFields3_1Lint: LinterMeta = {
       params: ['$ref'],
     },
   ],
-  targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+  targetSpecs: OpenAPI31,
 };
 export default allowedFields3_1Lint;

--- a/packages/apidom-ls/src/config/openapi/link/lint/description--type.ts
+++ b/packages/apidom-ls/src/config/openapi/link/lint/description--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const descriptionTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_LINK_FIELD_DESCRIPTION_TYPE,
@@ -13,6 +14,7 @@ const descriptionTypeLint: LinterMeta = {
   marker: 'value',
   target: 'description',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default descriptionTypeLint;

--- a/packages/apidom-ls/src/config/openapi/link/lint/operation-id--type.ts
+++ b/packages/apidom-ls/src/config/openapi/link/lint/operation-id--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const operationIdTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_LINK_FIELD_OPERATION_ID_TYPE,
@@ -13,6 +14,7 @@ const operationIdTypeLint: LinterMeta = {
   marker: 'value',
   target: 'operationId',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default operationIdTypeLint;

--- a/packages/apidom-ls/src/config/openapi/link/lint/operation-ref--format-uri.ts
+++ b/packages/apidom-ls/src/config/openapi/link/lint/operation-ref--format-uri.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const operationRefFormatURILint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_LINK_FIELD_OPERATION_REF_FORMAT_URI,
@@ -12,6 +13,7 @@ const operationRefFormatURILint: LinterMeta = {
   marker: 'value',
   target: 'operationRef',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default operationRefFormatURILint;

--- a/packages/apidom-ls/src/config/openapi/link/lint/operation-ref--mutually-exclusive.ts
+++ b/packages/apidom-ls/src/config/openapi/link/lint/operation-ref--mutually-exclusive.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const operationRefMutuallyExclusiveLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_LINK_FIELD_OPERATION_REF_MUTUALLY_EXCLUSIVE,
@@ -18,6 +19,7 @@ const operationRefMutuallyExclusiveLint: LinterMeta = {
       params: [['operationRef']],
     },
   ],
+  targetSpecs: OpenAPI3,
 };
 
 export default operationRefMutuallyExclusiveLint;

--- a/packages/apidom-ls/src/config/openapi/link/lint/server--type.ts
+++ b/packages/apidom-ls/src/config/openapi/link/lint/server--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const serverTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_LINK_FIELD_SERVER_TYPE,
@@ -13,6 +14,7 @@ const serverTypeLint: LinterMeta = {
   marker: 'value',
   target: 'server',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default serverTypeLint;

--- a/packages/apidom-ls/src/config/openapi/media-type/completion.ts
+++ b/packages/apidom-ls/src/config/openapi/media-type/completion.ts
@@ -3,6 +3,7 @@ import {
   CompletionFormat,
   CompletionType,
 } from '../../../apidom-language-types';
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
 
 const completion: ApidomCompletionItem[] = [
   {
@@ -17,12 +18,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '[Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject) | [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#referenceObject)\n\\\n\\\nThe schema defining the content of the request, response, or parameter.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'schema',
@@ -36,7 +32,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         '[Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject) | [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#referenceObject)\n\\\n\\\nThe schema defining the content of the request, response, or parameter.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'example',
@@ -50,6 +46,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.',
     },
+    targetSpecs: OpenAPI3,
   },
   {
     label: 'examples',
@@ -63,12 +60,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Map[ `string`, [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#exampleObject) &#124; [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#referenceObject)]\n\\\n\\\nExamples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'examples',
@@ -82,7 +74,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Map[ `string`, [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#exampleObject) &#124; [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#referenceObject)]\n\\\n\\\nExamples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     label: 'encoding',
@@ -96,12 +88,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Map[`string`, [Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#encodingObject)]\n\\\n\\\nA map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.',
     },
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     label: 'encoding',
@@ -115,7 +102,7 @@ const completion: ApidomCompletionItem[] = [
       value:
         'Map[`string`, [Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#encodingObject)]\n\\\n\\\nA map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.',
     },
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/media-type/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/media-type/documentation.ts
@@ -1,3 +1,5 @@
+import { OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
+
 /**
  * Omitted fixed fields:
  *  - schema
@@ -12,36 +14,27 @@ const documentation = [
   {
     target: 'example',
     docs: 'Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.',
+    targetSpecs: OpenAPI3,
   },
   {
     target: 'examples',
     docs: 'Map[ `string`, [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#exampleObject) &#124; [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#referenceObject)]\n\\\n\\\nExamples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'examples',
     docs: 'Map[ `string`, [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#exampleObject) &#124; [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#referenceObject)]\n\\\n\\\nExamples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   {
     target: 'encoding',
     docs: 'Map[`string`, [Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#encodingObject)]\n\\\n\\\nA map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     target: 'encoding',
     docs: 'Map[`string`, [Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#encodingObject)]\n\\\n\\\nA map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
   /**
    * The original documentation has been trimmed in this implementation for readability purposes
@@ -50,16 +43,11 @@ const documentation = [
    */
   {
     docs: '#### [Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)\n\nEach Media Type Object provides schema and examples for the media type identified by its key.\n\n##### Fixed Fields\nField Name | Type | Description\n---|:---:|---\nschema | [Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject) \\| [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#referenceObject) | The schema defining the content of the request, response, or parameter.\nexample | Any | Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.\nexamples | Map[ `string`, [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#exampleObject) \\| [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.\nencoding | Map[`string`, [Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#encodingObject)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.\n\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions).\n\n##### Media Type Examples\n\n\n\\\nJSON\n```json\n{\n  "application/json": {\n    "schema": {\n         "$ref": "#/components/schemas/Pet"\n    },\n    "examples": {\n      "cat" : {\n        "summary": "An example of a cat",\n        "value":\n          {\n            "name": "Fluffy",\n            "petType": "Cat",\n            "color": "White",\n            "gender": "male",\n            "breed": "Persian"\n          }\n      },\n      "dog": {\n        "summary": "An example of a dog with a cat\'s name",\n        "value" :  {\n          "name": "Puma",\n          "petType": "Dog",\n          "color": "Black",\n          "gender": "Female",\n          "breed": "Mixed"\n        },\n      "frog": {\n          "$ref": "#/components/examples/frog-example"\n        }\n      }\n    }\n  }\n}\n```\n\n\n\\\nYAML\n```yaml\napplication/json:\n  schema:\n    $ref: "#/components/schemas/Pet"\n  examples:\n    cat:\n      summary: An example of a cat\n      value:\n        name: Fluffy\n        petType: Cat\n        color: White\n        gender: male\n        breed: Persian\n    dog:\n      summary: An example of a dog with a cat\'s name\n      value:\n        name: Puma\n        petType: Dog\n        color: Black\n        gender: Female\n        breed: Mixed\n    frog:\n      $ref: "#/components/examples/frog-example"\n```\n\n#### Additional documentation topics\n- [Considerations for File Uploads](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#considerations-for-file-uploads)\n\n- [Support for x-www-form-urlencoded Request Bodies](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#support-for-x-www-form-urlencoded-request-bodies)\n\n- [Special Considerations for multipart Content\n](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#special-considerations-for-multipart-content)',
-    targetSpecs: [
-      { namespace: 'openapi', version: '3.0.0' },
-      { namespace: 'openapi', version: '3.0.1' },
-      { namespace: 'openapi', version: '3.0.2' },
-      { namespace: 'openapi', version: '3.0.3' },
-    ],
+    targetSpecs: OpenAPI30,
   },
   {
     docs: '#### [Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object)\nEach Media Type Object provides schema and examples for the media type identified by its key.\n\n##### Fixed Fields\nField Name | Type | Description\n---|:---:|---\nschema | [Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject) | The schema defining the content of the request, response, or parameter.\nexample | Any | Example of the media type.  The example object SHOULD be in the correct format as specified by the media type.  The `example` field is mutually exclusive of the `examples` field.  Furthermore, if referencing a `schema` which contains an example, the `example` value SHALL _override_ the example provided by the schema.\nexamples | Map[ `string`, [Example Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#exampleObject) &#124; [Reference Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#referenceObject)] | Examples of the media type.  Each example object SHOULD  match the media type and specified schema if present.  The `examples` field is mutually exclusive of the `example` field.  Furthermore, if referencing a `schema` which contains an example, the `examples` value SHALL _override_ the example provided by the schema.\nencoding | Map[`string`, [Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#encodingObject)] | A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to `requestBody` objects when the media type is `multipart` or `application/x-www-form-urlencoded`.\n\n\\\nThis object MAY be extended with [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions).\n\n##### Media Type Examples\n\n\n\\\nJSON\n```json\n{\n  "application/json": {\n    "schema": {\n         "$ref": "#/components/schemas/Pet"\n    },\n    "examples": {\n      "cat" : {\n        "summary": "An example of a cat",\n        "value": \n          {\n            "name": "Fluffy",\n            "petType": "Cat",\n            "color": "White",\n            "gender": "male",\n            "breed": "Persian"\n          }\n      },\n      "dog": {\n        "summary": "An example of a dog with a cat\'s name",\n        "value" :  { \n          "name": "Puma",\n          "petType": "Dog",\n          "color": "Black",\n          "gender": "Female",\n          "breed": "Mixed"\n        },\n      "frog": {\n          "$ref": "#/components/examples/frog-example"\n        }\n      }\n    }\n  }\n}\n```\n\n\n\\\nYAML\n```yaml\napplication/json: \n  schema:\n    $ref: "#/components/schemas/Pet"\n  examples:\n    cat:\n      summary: An example of a cat\n      value:\n        name: Fluffy\n        petType: Cat\n        color: White\n        gender: male\n        breed: Persian\n    dog:\n      summary: An example of a dog with a cat\'s name\n      value:\n        name: Puma\n        petType: Dog\n        color: Black\n        gender: Female\n        breed: Mixed\n    frog:\n      $ref: "#/components/examples/frog-example"\n```\n\n#### Additional documentation topics\n- [Considerations for File Uploads](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#considerations-for-file-uploads)\n\n- [Support for x-www-form-urlencoded Request Bodies](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#support-for-x-www-form-urlencoded-request-bodies)\n\n- [Special Considerations for multipart Content\n](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#special-considerations-for-multipart-content)',
-    targetSpecs: [{ namespace: 'openapi', version: '3.1.0' }],
+    targetSpecs: OpenAPI31,
   },
 ];
 

--- a/packages/apidom-ls/src/config/openapi/media-type/lint/allowed-fields.ts
+++ b/packages/apidom-ls/src/config/openapi/media-type/lint/allowed-fields.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const allowedFieldsLint: LinterMeta = {
   code: ApilintCodes.NOT_ALLOWED_FIELDS,
@@ -11,6 +12,7 @@ const allowedFieldsLint: LinterMeta = {
   linterFunction: 'allowedFields',
   linterParams: [['schema', 'example', 'examples', 'encoding'], 'x-'],
   marker: 'key',
+  targetSpecs: OpenAPI3,
 };
 
 export default allowedFieldsLint;

--- a/packages/apidom-ls/src/config/openapi/media-type/lint/encoding--values-type.ts
+++ b/packages/apidom-ls/src/config/openapi/media-type/lint/encoding--values-type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const encodingValuesTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_MEDIA_TYPE_FIELD_ENCODING_VALUES_TYPE,
@@ -14,6 +15,7 @@ const encodingValuesTypeLint: LinterMeta = {
   markerTarget: 'encoding',
   target: 'encoding',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default encodingValuesTypeLint;

--- a/packages/apidom-ls/src/config/openapi/media-type/lint/examples--mutually-exclusive.ts
+++ b/packages/apidom-ls/src/config/openapi/media-type/lint/examples--mutually-exclusive.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const examplesMutuallyExclusiveLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_MEDIA_TYPE_FIELD_EXAMPLES_MUTUALLY_EXCLUSIVE,
@@ -18,6 +19,7 @@ const examplesMutuallyExclusiveLint: LinterMeta = {
       params: [['example']],
     },
   ],
+  targetSpecs: OpenAPI3,
 };
 
 export default examplesMutuallyExclusiveLint;

--- a/packages/apidom-ls/src/config/openapi/media-type/lint/examples--values-type.ts
+++ b/packages/apidom-ls/src/config/openapi/media-type/lint/examples--values-type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const examplesValuesTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_MEDIA_TYPE_FIELD_EXAMPLES_VALUES_TYPE,
@@ -14,6 +15,7 @@ const examplesValuesTypeLint: LinterMeta = {
   markerTarget: 'examples',
   target: 'examples',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default examplesValuesTypeLint;

--- a/packages/apidom-ls/src/config/openapi/media-type/lint/schema--type.ts
+++ b/packages/apidom-ls/src/config/openapi/media-type/lint/schema--type.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
+import { OpenAPI3 } from '../../target-specs';
 
 const schemaTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_MEDIA_TYPE_FIELD_SCHEMA_VALUES_TYPE,
@@ -13,6 +14,7 @@ const schemaTypeLint: LinterMeta = {
   marker: 'value',
   target: 'schema',
   data: {},
+  targetSpecs: OpenAPI3,
 };
 
 export default schemaTypeLint;

--- a/packages/apidom-ls/test/openapi-yaml.ts
+++ b/packages/apidom-ls/test/openapi-yaml.ts
@@ -22,6 +22,7 @@ import { metadata } from './metadata';
 import { OpenAPi31JsonSchemaValidationProvider } from '../src/services/validation/providers/openapi-31-json-schema-validation-provider';
 import { logLevel, logPerformance } from './test-utils';
 import testTokens from './test-tokens';
+import { OpenAPI31, OpenAPI3 } from '../src/config/openapi/target-specs';
 
 // eslint-disable-next-line import/prefer-default-export
 export function logj(e: unknown, label?: string): void {
@@ -81,12 +82,7 @@ const completionTestInput = [
             kind: 'markdown',
             value: 'A short summary of the API.',
           },
-          targetSpecs: [
-            {
-              namespace: 'openapi',
-              version: '3.1.0',
-            },
-          ],
+          targetSpecs: OpenAPI31,
         },
         {
           label: 'description',
@@ -98,6 +94,7 @@ const completionTestInput = [
             value:
               'A description of the API. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.',
           },
+          targetSpecs: OpenAPI3,
         },
         {
           label: 'termsOfService',
@@ -108,6 +105,7 @@ const completionTestInput = [
             kind: 'markdown',
             value: 'A URL to the Terms of Service for the API. This MUST be in the form of a URL.',
           },
+          targetSpecs: OpenAPI3,
         },
         {
           label: 'contact',
@@ -119,12 +117,7 @@ const completionTestInput = [
             value:
               '[Contact Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#contactObject)\n\\\n\\\nThe contact information for the exposed API.',
           },
-          targetSpecs: [
-            {
-              namespace: 'openapi',
-              version: '3.1.0',
-            },
-          ],
+          targetSpecs: OpenAPI31,
         },
         {
           label: 'license',
@@ -136,12 +129,7 @@ const completionTestInput = [
             value:
               '[License Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#licenseObject)\n\\\n\\\nThe license information for the exposed API.',
           },
-          targetSpecs: [
-            {
-              namespace: 'openapi',
-              version: '3.1.0',
-            },
-          ],
+          targetSpecs: OpenAPI31,
         },
       ],
       isIncomplete: false,


### PR DESCRIPTION
Includes:
- Example Object
- External Documentation Object
- Header Object
- Info Object
- License Object
- Link Object
- Media Type Object

Refs #3478
