### PR TITLE
refactor(ls): make rules scoping forward incompatible

### DIFF
--- a/packages/apidom-ls/src/config/openapi/contact/completion.ts
+++ b/packages/apidom-ls/src/config/openapi/contact/completion.ts
@@ -3,7 +3,7 @@ import {
   CompletionFormat,
   CompletionType,
 } from '../../../apidom-language-types';
-import { OpenAPI, OpenAPI2, OpenAPI3 } from '../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../target-specs';
 
 const completion: ApidomCompletionItem[] = [
   {
@@ -17,7 +17,7 @@ const completion: ApidomCompletionItem[] = [
       kind: 'markdown',
       value: 'The identifying name of the contact person/organization.',
     },
-    targetSpecs: OpenAPI,
+    targetSpecs: [...OpenAPI2, ...OpenAPI3],
   },
   {
     label: 'url',

--- a/packages/apidom-ls/src/config/openapi/contact/documentation.ts
+++ b/packages/apidom-ls/src/config/openapi/contact/documentation.ts
@@ -1,10 +1,10 @@
-import { OpenAPI, OpenAPI2, OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
+import { OpenAPI2, OpenAPI30, OpenAPI31, OpenAPI3 } from '../target-specs';
 
 const documentation = [
   {
     target: 'name',
     docs: 'The identifying name of the contact person/organization.',
-    targetSpecs: OpenAPI,
+    targetSpecs: [...OpenAPI2, ...OpenAPI3],
   },
   {
     target: 'url',

--- a/packages/apidom-ls/src/config/openapi/contact/lint/allowed-fields.ts
+++ b/packages/apidom-ls/src/config/openapi/contact/lint/allowed-fields.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const allowedFieldsLint: LinterMeta = {
   code: ApilintCodes.NOT_ALLOWED_FIELDS,
@@ -12,7 +12,7 @@ const allowedFieldsLint: LinterMeta = {
   linterFunction: 'allowedFields',
   linterParams: [['name', 'url', 'email'], 'x-'],
   marker: 'key',
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default allowedFieldsLint;

--- a/packages/apidom-ls/src/config/openapi/contact/lint/email--format-email.ts
+++ b/packages/apidom-ls/src/config/openapi/contact/lint/email--format-email.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const emailFormatEmailLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_CONTACT_FIELD_EMAIL_FORMAT_EMAIL,
@@ -14,7 +14,7 @@ const emailFormatEmailLint: LinterMeta = {
   marker: 'value',
   target: 'email',
   data: {},
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default emailFormatEmailLint;

--- a/packages/apidom-ls/src/config/openapi/contact/lint/name--type.ts
+++ b/packages/apidom-ls/src/config/openapi/contact/lint/name--type.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const nameTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_CONTACT_FIELD_NAME_TYPE,
@@ -14,7 +14,7 @@ const nameTypeLint: LinterMeta = {
   marker: 'value',
   target: 'name',
   data: {},
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default nameTypeLint;

--- a/packages/apidom-ls/src/config/openapi/contact/lint/url--format-uri.ts
+++ b/packages/apidom-ls/src/config/openapi/contact/lint/url--format-uri.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const urlFormatURILint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_CONTACT_FIELD_URL_FORMAT_URI,
@@ -13,7 +13,7 @@ const urlFormatURILint: LinterMeta = {
   marker: 'value',
   target: 'url',
   data: {},
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default urlFormatURILint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/contact--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/contact--type.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const contactTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_INFO_FIELD_CONTACT_TYPE,
@@ -14,7 +14,7 @@ const contactTypeLint: LinterMeta = {
   marker: 'value',
   target: 'contact',
   data: {},
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default contactTypeLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/description--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/description--type.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const descriptionTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_INFO_FIELD_DESCRIPTION_TYPE,
@@ -14,7 +14,7 @@ const descriptionTypeLint: LinterMeta = {
   marker: 'value',
   target: 'description',
   data: {},
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default descriptionTypeLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/license--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/license--type.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const licenseTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_INFO_FIELD_LICENSE_TYPE,
@@ -14,7 +14,7 @@ const licenseTypeLint: LinterMeta = {
   marker: 'value',
   target: 'license',
   data: {},
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default licenseTypeLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/title--required.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/title--required.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const titleRequiredLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_INFO_FIELD_TITLE_REQUIRED,
@@ -22,7 +22,7 @@ const titleRequiredLint: LinterMeta = {
       },
     ],
   },
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default titleRequiredLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/title--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/title--type.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const titleTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI3_0_INFO_FIELD_TITLE_TYPE,
@@ -14,7 +14,7 @@ const titleTypeLint: LinterMeta = {
   marker: 'value',
   target: 'title',
   data: {},
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default titleTypeLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/version--required.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/version--required.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const versionRequiredLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_INFO_FIELD_VERSION_REQUIRED,
@@ -22,7 +22,7 @@ const versionRequiredLint: LinterMeta = {
       },
     ],
   },
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default versionRequiredLint;

--- a/packages/apidom-ls/src/config/openapi/info/lint/version--type.ts
+++ b/packages/apidom-ls/src/config/openapi/info/lint/version--type.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const versionTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_INFO_FIELD_VERSION_TYPE,
@@ -14,7 +14,7 @@ const versionTypeLint: LinterMeta = {
   marker: 'value',
   target: 'version',
   data: {},
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default versionTypeLint;

--- a/packages/apidom-ls/src/config/openapi/license/lint/name--required.ts
+++ b/packages/apidom-ls/src/config/openapi/license/lint/name--required.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const nameRequiredLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_LICENSE_FIELD_NAME_REQUIRED,
@@ -22,7 +22,7 @@ const nameRequiredLint: LinterMeta = {
       },
     ],
   },
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default nameRequiredLint;

--- a/packages/apidom-ls/src/config/openapi/license/lint/name--type.ts
+++ b/packages/apidom-ls/src/config/openapi/license/lint/name--type.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const nameTypeLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_LICENSE_FIELD_NAME_TYPE,
@@ -14,7 +14,7 @@ const nameTypeLint: LinterMeta = {
   marker: 'value',
   target: 'name',
   data: {},
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default nameTypeLint;

--- a/packages/apidom-ls/src/config/openapi/path-template/lint/value--valid.ts
+++ b/packages/apidom-ls/src/config/openapi/path-template/lint/value--valid.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const valueValidLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_PATH_TEMPLATE_VALUE_VALID,
@@ -11,7 +11,7 @@ const valueValidLint: LinterMeta = {
   severity: DiagnosticSeverity.Error,
   linterFunction: 'apilintOpenAPIPathTemplateValid',
   marker: 'value',
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
   conditions: [
     {
       function: 'apilintOpenAPIPathTemplateWellFormed',

--- a/packages/apidom-ls/src/config/openapi/path-template/lint/value--well-formed.ts
+++ b/packages/apidom-ls/src/config/openapi/path-template/lint/value--well-formed.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import ApilintCodes from '../../../codes';
 import { LinterMeta } from '../../../../apidom-language-types';
-import { OpenAPI } from '../../target-specs';
+import { OpenAPI2, OpenAPI3 } from '../../target-specs';
 
 const valueWellFormedLint: LinterMeta = {
   code: ApilintCodes.OPENAPI2_PATH_TEMPLATE_VALUE_WELL_FORMED,
@@ -12,7 +12,7 @@ const valueWellFormedLint: LinterMeta = {
   linterFunction: 'apilintOpenAPIPathTemplateWellFormed',
   linterParams: [false],
   marker: 'value',
-  targetSpecs: OpenAPI,
+  targetSpecs: [...OpenAPI2, ...OpenAPI3],
 };
 
 export default valueWellFormedLint;

--- a/packages/apidom-ls/src/config/openapi/target-specs.ts
+++ b/packages/apidom-ls/src/config/openapi/target-specs.ts
@@ -8,5 +8,3 @@ export const OpenAPI303 = [{ namespace: 'openapi', version: '3.0.3' }];
 export const OpenAPI30 = [...OpenAPI300, ...OpenAPI301, ...OpenAPI302, ...OpenAPI303];
 export const OpenAPI31 = [{ namespace: 'openapi', version: '3.1.0' }];
 export const OpenAPI3 = [...OpenAPI30, ...OpenAPI31];
-
-export const OpenAPI = [...OpenAPI2, ...OpenAPI3];


### PR DESCRIPTION
This will make sure that when OpenAPI 4.0 lands
existing rules will not be used, unless we
explicitly allow it.

Refs #3104
