### PR TITLE
fix(ls): Fix regex in Swagger 2.0 basePath linting rule

### DIFF
--- a/packages/apidom-ls/src/config/openapi/swagger/lint/base-path--pattern.ts
+++ b/packages/apidom-ls/src/config/openapi/swagger/lint/base-path--pattern.ts
@@ -10,7 +10,7 @@ const basePathPatternLint: LinterMeta = {
   message: '"basePath" value MUST be a relative URI Referencing starting with a leading slash (/).',
   severity: DiagnosticSeverity.Error,
   linterFunction: 'apilintValueRegex',
-  linterParams: ['^/(?:[^/s][^s]*)?$'],
+  linterParams: ['^/(?:[^/\s][^\s]*)?$'],
   target: 'basePath',
   marker: 'value',
   data: {},

--- a/packages/apidom-ls/src/config/openapi/swagger/lint/base-path--pattern.ts
+++ b/packages/apidom-ls/src/config/openapi/swagger/lint/base-path--pattern.ts
@@ -10,7 +10,7 @@ const basePathPatternLint: LinterMeta = {
   message: '"basePath" value MUST be a relative URI Referencing starting with a leading slash (/).',
   severity: DiagnosticSeverity.Error,
   linterFunction: 'apilintValueRegex',
-  linterParams: ['^/(?:[^/\s][^\s]*)?$'],
+  linterParams: ['^/(?:[^/\\s][^\\s]*)?$'],
   target: 'basePath',
   marker: 'value',
   data: {},


### PR DESCRIPTION
Refs #3565 

This PR fixes the regex in the `OPENAPI2_SWAGGER_FIELD_BASE_PATH_PATTERN` linting rule so that it matches on whitespace characters instead of the letter 's'

