### PR TITLE
fix(ls): fix path template parameter matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29401,9 +29401,9 @@
       }
     },
     "node_modules/openapi-path-templating": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-1.3.0.tgz",
-      "integrity": "sha512-nXA8Y5jvZc8mSxDNgy8ov4BQayshc2G6ZDThMOtghbQS5iOUq1lukOTVzvnFMcyl7fithDgvyuA+V8O0W/CASw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-1.4.0.tgz",
+      "integrity": "sha512-Yves8IYEtqwhvjoMQx3LFjnA69sh/r61r2yJlEUmPlhCemh2EVuTPDdwfNOqbHV8Fl1hg1qaLWQ4xzCMIX7wPw==",
       "dependencies": {
         "apg-lite": "^1.0.2",
         "prettier": "^3.1.1"
@@ -38088,7 +38088,7 @@
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.89.0",
         "@swagger-api/apidom-reference": "^0.89.0",
         "@types/ramda": "~0.29.6",
-        "openapi-path-templating": "^1.3.0",
+        "openapi-path-templating": "^1.4.0",
         "ramda": "~0.29.1",
         "ramda-adjunct": "^4.1.1",
         "vscode-languageserver-protocol": "^3.17.2",

--- a/packages/apidom-ls/package.json
+++ b/packages/apidom-ls/package.json
@@ -116,7 +116,7 @@
     "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.89.0",
     "@swagger-api/apidom-reference": "^0.89.0",
     "@types/ramda": "~0.29.6",
-    "openapi-path-templating": "^1.3.0",
+    "openapi-path-templating": "^1.4.0",
     "ramda": "~0.29.1",
     "ramda-adjunct": "^4.1.1",
     "vscode-languageserver-protocol": "^3.17.2",

--- a/packages/apidom-ls/src/services/validation/linter-functions.ts
+++ b/packages/apidom-ls/src/services/validation/linter-functions.ts
@@ -1049,11 +1049,10 @@ export const standardLinterfunctions: FunctionItem[] = [
           }
         });
 
-        const allowedLocation = ['path', 'query'];
         const pathTemplateResolveParams: { [key: string]: 'placeholder' } = {};
 
         parameterElements.forEach((parameter) => {
-          if (allowedLocation.includes(toValue((parameter as ObjectElement).get('in')))) {
+          if (toValue((parameter as ObjectElement).get('in')) === 'path') {
             pathTemplateResolveParams[toValue((parameter as ObjectElement).get('name'))] =
               'placeholder';
           }


### PR DESCRIPTION
No matches are now registered for template expressions defined inside query parameters.

URLs with fragments are now supported, but no matches are registered for template expressiones defined inside fragments.

Refs #3517

