### PR TITLE
feat(apidom-converter): add example plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37978,7 +37978,12 @@
       "version": "0.92.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.20.7"
+        "@babel/runtime-corejs3": "^7.20.7",
+        "@swagger-api/apidom-core": "^0.93.0",
+        "@swagger-api/apidom-ns-openapi-2": "^0.93.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.93.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.93.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.93.0"
       }
     },
     "packages/apidom-core": {

--- a/packages/apidom-converter/package.json
+++ b/packages/apidom-converter/package.json
@@ -38,7 +38,12 @@
   "author": "Vladimír Gorej",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/runtime-corejs3": "^7.20.7"
+    "@babel/runtime-corejs3": "^7.20.7",
+    "@swagger-api/apidom-core": "^0.93.0",
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.93.0",
+    "@swagger-api/apidom-ns-openapi-3-1": "^0.93.0",
+    "@swagger-api/apidom-ns-openapi-3-0": "^0.93.0",
+    "@swagger-api/apidom-ns-openapi-2": "^0.93.0"
   },
   "files": [
     "cjs/",

--- a/packages/apidom-converter/src/get-refractor.ts
+++ b/packages/apidom-converter/src/get-refractor.ts
@@ -1,0 +1,18 @@
+import { OpenApi3_1Element } from '@swagger-api/apidom-ns-openapi-3-1';
+import { OpenApi3_0Element } from '@swagger-api/apidom-ns-openapi-3-0';
+import { SwaggerElement } from '@swagger-api/apidom-ns-openapi-2';
+
+const getOpenApiRefractor = (version: string) => {
+  switch (version) {
+    case '3.1.x':
+      return OpenApi3_1Element;
+    case '3.0.x':
+      return OpenApi3_0Element;
+    case '2.0.x':
+      return SwaggerElement;
+    default:
+      throw new Error(`Unsupported OpenAPI version: ${version}`);
+  }
+};
+
+export default getOpenApiRefractor;

--- a/packages/apidom-converter/src/index.ts
+++ b/packages/apidom-converter/src/index.ts
@@ -1,3 +1,15 @@
-const foo = Symbol('foo');
+import { parse } from '@swagger-api/apidom-parser-adapter-yaml-1-2';
 
-export default foo;
+import getOpenAPIRefractor from './get-refractor';
+import getPluginsBySpec from './plugins/get-plugins-by-spec';
+
+const convert = async (yaml: string, from: string) => {
+  const apiDOM = await parse(yaml);
+  const refractor = getOpenAPIRefractor(from);
+  const openApiElement = refractor.refract(apiDOM.result, {
+    plugins: [...getPluginsBySpec(from)],
+  }) as unknown as typeof refractor;
+  return openApiElement;
+};
+
+export default convert;

--- a/packages/apidom-converter/src/plugins/get-plugins-by-spec.ts
+++ b/packages/apidom-converter/src/plugins/get-plugins-by-spec.ts
@@ -1,0 +1,16 @@
+import specDowngrade from './openapi3_1/spec-downgrade';
+
+const getPluginsBySpec = (spec: string) => {
+  switch (spec) {
+    case '3.1.x':
+      return [specDowngrade()];
+    case '3.0.x':
+      return [];
+    case '2.0.x':
+      return [];
+    default:
+      return [];
+  }
+};
+
+export default getPluginsBySpec;

--- a/packages/apidom-converter/src/plugins/openapi3_1/spec-downgrade.ts
+++ b/packages/apidom-converter/src/plugins/openapi3_1/spec-downgrade.ts
@@ -1,0 +1,13 @@
+import { OpenApi3_1Element } from '@swagger-api/apidom-ns-openapi-3-1';
+
+const plugin = () => () => {
+  return {
+    visitor: {
+      OpenApi3_1Element(openApi3_1Element: OpenApi3_1Element) {
+        openApi3_1Element.set('openapi', '3.0.0');
+      },
+    },
+  };
+};
+
+export default plugin;

--- a/packages/apidom-converter/test/plugins/spec-downgrade/__snapshots__/index.ts.snap
+++ b/packages/apidom-converter/test/plugins/spec-downgrade/__snapshots__/index.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`converter plugins spec-downgrade should downgrade OpenAPI specificaiton to 3.0.0 1`] = `
+Object {
+  openapi: 3.0.0,
+}
+`;

--- a/packages/apidom-converter/test/plugins/spec-downgrade/index.ts
+++ b/packages/apidom-converter/test/plugins/spec-downgrade/index.ts
@@ -1,0 +1,20 @@
+import dedent from 'dedent';
+import { toValue } from '@swagger-api/apidom-core';
+import { expect } from 'chai';
+
+import convert from '../../../src';
+
+describe('converter', function () {
+  context('plugins', function () {
+    context('spec-downgrade', function () {
+      specify('should downgrade OpenAPI specificaiton to 3.0.0', async function () {
+        const yamlDefinition = dedent`
+        openapi: 3.1.0
+        `;
+        const openApiElement = await convert(yamlDefinition, '3.1.x');
+
+        expect(toValue(openApiElement)).toMatchSnapshot();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Scaffolding an example of converter code. Need some feedback @char0n 

I'm also running into some issues with `npm run build` locally,  specifically `npm run build:umd:browser`. 
It seems to be caused by the import below (removing this import fixes browser build):
```typescript
import { parse } from '@swagger-api/apidom-parser-adapter-yaml-1-2';
```

Build logs: 
```zsh
ERROR in ../../node_modules/web-tree-sitter/tree-sitter.js 1:686-709
Module not found: Error: Can't resolve 'path' in '/Users/krzysztof.kowalczyk/Desktop/apidom/node_modules/web-tree-sitter'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }
 @ ../apidom-parser-adapter-yaml-1-2/es/lexical-analysis/browser.mjs 2:0-37 20:21-32 20:46-66 21:33-39
 @ ../apidom-parser-adapter-yaml-1-2/es/adapter-browser.mjs 1:0-61 4:0-46 7:22-37 16:20-35
 @ ./src/index.ts 1:0-68 5:23-28

ERROR in ../../node_modules/web-tree-sitter/tree-sitter.js 1:760-773
Module not found: Error: Can't resolve 'fs' in '/Users/krzysztof.kowalczyk/Desktop/apidom/node_modules/web-tree-sitter'
 @ ../apidom-parser-adapter-yaml-1-2/es/lexical-analysis/browser.mjs 2:0-37 20:21-32 20:46-66 21:33-39
 @ ../apidom-parser-adapter-yaml-1-2/es/adapter-browser.mjs 1:0-61 4:0-46 7:22-37 16:20-35
 @ ./src/index.ts 1:0-68 5:23-28

ERROR in ../../node_modules/web-tree-sitter/tree-sitter.wasm 1:0
Module parse failed: Unexpected character '' (1:0)
The module seem to be a WebAssembly module, but module is not flagged as WebAssembly module for webpack.
BREAKING CHANGE: Since webpack 5 WebAssembly is not enabled by default and flagged as experimental feature.
You need to enable one of the WebAssembly experiments via 'experiments.asyncWebAssembly: true' (based on async modules) or 'experiments.syncWebAssembly: true' (like webpack 4, deprecated).
For files that transpile to WebAssembly, make sure to set the module type in the 'module.rules' section of the config (e. g. 'type: "webassembly/async"').
(Source code omitted for this binary file)
 @ ../apidom-parser-adapter-yaml-1-2/es/lexical-analysis/browser-patch.mjs 4:0-62 13:42-56
 @ ../apidom-parser-adapter-yaml-1-2/es/lexical-analysis/browser.mjs 1:0-29
 @ ../apidom-parser-adapter-yaml-1-2/es/adapter-browser.mjs 1:0-61 4:0-46 7:22-37 16:20-35
 @ ./src/index.ts 1:0-68 5:23-28

ERROR in ../apidom-parser-adapter-yaml-1-2/wasm/tree-sitter-yaml.wasm 1:0
Module parse failed: Unexpected character '' (1:0)
The module seem to be a WebAssembly module, but module is not flagged as WebAssembly module for webpack.
BREAKING CHANGE: Since webpack 5 WebAssembly is not enabled by default and flagged as experimental feature.
You need to enable one of the WebAssembly experiments via 'experiments.asyncWebAssembly: true' (based on async modules) or 'experiments.syncWebAssembly: true' (like webpack 4, deprecated).
For files that transpile to WebAssembly, make sure to set the module type in the 'module.rules' section of the config (e. g. 'type: "webassembly/async"').
(Source code omitted for this binary file)
 @ ../apidom-parser-adapter-yaml-1-2/es/lexical-analysis/browser.mjs 6:0-62 20:67-81
 @ ../apidom-parser-adapter-yaml-1-2/es/adapter-browser.mjs 1:0-61 4:0-46 7:22-37 16:20-35
 @ ./src/index.ts 1:0-68 5:23-28
```
