### PR TITLE
fix(ns-openapi-2): retain meta & attributes during refracting

### DIFF
--- a/packages/apidom-ns-openapi-2/src/refractor/index.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/index.ts
@@ -17,6 +17,7 @@ const refract = <T extends Element>(
   { specPath = ['visitors', 'document', 'objects', 'Swagger', '$visitor'], plugins = [] } = {},
 ): T => {
   const element = baseRefract(value);
+
   const resolvedSpec = dereference(specification);
 
   /**
@@ -24,8 +25,8 @@ const refract = <T extends Element>(
    * We don't allow consumers to hook into this translation.
    * Though we allow consumers to define their onw plugins on already transformed ApiDOM.
    */
-  const RootVistorClass = path(specPath, resolvedSpec) as typeof VisitorClass;
-  const rootVisitor = new RootVistorClass({ specObj: resolvedSpec });
+  const RootVisitorClass = path(specPath, resolvedSpec) as typeof VisitorClass;
+  const rootVisitor = new RootVisitorClass({ specObj: resolvedSpec });
 
   visit(element, rootVisitor);
 

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/Visitor.ts
@@ -1,4 +1,4 @@
-import { Element, hasElementSourceMap } from '@swagger-api/apidom-core';
+import { Element, cloneDeep } from '@swagger-api/apidom-core';
 
 export interface VisitorOptions {}
 
@@ -11,9 +11,14 @@ class Visitor {
 
   // eslint-disable-next-line class-methods-use-this
   public copyMetaAndAttributes(from: Element, to: Element) {
-    // copy sourcemaps
-    if (hasElementSourceMap(from)) {
-      to.meta.set('sourceMap', from.meta.get('sourceMap'));
+    // copy meta
+    if (from.meta.length > 0) {
+      to.meta = cloneDeep(from.meta); // eslint-disable-line no-param-reassign
+    }
+
+    // copy attributes
+    if (from.attributes.length > 0) {
+      to.attributes = cloneDeep(from.attributes); // eslint-disable-line no-param-reassign
     }
   }
 }

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/Visitor.ts
@@ -1,4 +1,4 @@
-import { Element, ObjectElement, mergeRight } from '@swagger-api/apidom-core';
+import { Element, ObjectElement, hasElementSourceMap, deepmerge } from '@swagger-api/apidom-core';
 
 export interface VisitorOptions {}
 
@@ -9,11 +9,20 @@ class Visitor {
     Object.assign(this, options);
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  /* eslint-disable class-methods-use-this, no-param-reassign */
   public copyMetaAndAttributes(from: Element, to: Element) {
-    to.meta = mergeRight(to.meta, from.meta) as ObjectElement; // eslint-disable-line no-param-reassign
-    to.attributes = mergeRight(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
+    if (from.meta.length > 0 || to.meta.length > 0) {
+      to.meta = deepmerge(to.meta, from.meta) as ObjectElement;
+      if (hasElementSourceMap(from)) {
+        // avoid deep merging of source maps
+        to.meta.set('sourceMap', from.meta.get('sourceMap'));
+      }
+    }
+    if (from.attributes.length > 0 || from.meta.length > 0) {
+      to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
+    }
   }
+  /* eslint-enable- class-methods-use-this, no-param-reassign */
 }
 
 export default Visitor;

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/Visitor.ts
@@ -1,4 +1,4 @@
-import { Element, cloneDeep } from '@swagger-api/apidom-core';
+import { Element, ObjectElement, mergeRight } from '@swagger-api/apidom-core';
 
 export interface VisitorOptions {}
 
@@ -11,15 +11,8 @@ class Visitor {
 
   // eslint-disable-next-line class-methods-use-this
   public copyMetaAndAttributes(from: Element, to: Element) {
-    // copy meta
-    if (from.meta.length > 0) {
-      to.meta = cloneDeep(from.meta); // eslint-disable-line no-param-reassign
-    }
-
-    // copy attributes
-    if (from.attributes.length > 0) {
-      to.attributes = cloneDeep(from.attributes); // eslint-disable-line no-param-reassign
-    }
+    to.meta = mergeRight(to.meta, from.meta) as ObjectElement; // eslint-disable-line no-param-reassign
+    to.attributes = mergeRight(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
   }
 }
 

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Contact/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Contact/__snapshots__/index.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refractor elements ContactElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `
+(ContactElement
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement)))
+`;
+
 exports[`refractor elements ContactElement should refract to semantic ApiDOM tree 1`] = `
 (ContactElement
   (MemberElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Contact/index.ts
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Contact/index.ts
@@ -1,5 +1,5 @@
 import { assert, expect } from 'chai';
-import { includesClasses, sexprs } from '@swagger-api/apidom-core';
+import { includesClasses, sexprs, ObjectElement } from '@swagger-api/apidom-core';
 
 import { ContactElement } from '../../../../src';
 
@@ -14,6 +14,36 @@ describe('refractor', function () {
         });
 
         expect(sexprs(contactElement)).toMatchSnapshot();
+      });
+
+      context('given generic ApiDOM element', function () {
+        let contactElement: ContactElement;
+
+        beforeEach(function () {
+          contactElement = ContactElement.refract(
+            new ObjectElement(
+              {
+                name: 'API Support',
+                url: 'https://www.example.com/support',
+                email: 'support@example.com',
+              },
+              { meta: true },
+              { attr: true },
+            ),
+          ) as ContactElement;
+        });
+
+        specify('should refract to semantic ApiDOM tree', function () {
+          expect(sexprs(contactElement)).toMatchSnapshot();
+        });
+
+        specify('should retain attributes', function () {
+          assert.isTrue(contactElement.attributes.get('attr').equals(true));
+        });
+
+        specify('should retain meta', function () {
+          assert.isTrue(contactElement.meta.get('meta').equals(true));
+        });
       });
 
       specify('should support specification extensions', function () {

--- a/packages/apidom-ns-openapi-3-0/src/refractor/index.ts
+++ b/packages/apidom-ns-openapi-3-0/src/refractor/index.ts
@@ -24,8 +24,8 @@ const refract = <T extends Element>(
    * We don't allow consumers to hook into this translation.
    * Though we allow consumers to define their onw plugins on already transformed ApiDOM.
    */
-  const RootVistorClass = path(specPath, resolvedSpec) as typeof VisitorClass;
-  const rootVisitor = new RootVistorClass({ specObj: resolvedSpec });
+  const RootVisitorClass = path(specPath, resolvedSpec) as typeof VisitorClass;
+  const rootVisitor = new RootVisitorClass({ specObj: resolvedSpec });
 
   visit(element, rootVisitor);
 


### PR DESCRIPTION
Refs #3842
