### PR TITLE
fix(ns-ads): retain meta & attributes during refracting

### DIFF
--- a/packages/apidom-ns-api-design-systems/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-api-design-systems/src/refractor/visitors/Visitor.ts
@@ -1,4 +1,4 @@
-import { hasElementSourceMap, Element } from '@swagger-api/apidom-core';
+import { Element, ObjectElement, hasElementSourceMap, deepmerge } from '@swagger-api/apidom-core';
 
 export interface VisitorOptions {}
 
@@ -9,13 +9,20 @@ class Visitor {
     Object.assign(this, options);
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  /* eslint-disable class-methods-use-this, no-param-reassign */
   public copyMetaAndAttributes(from: Element, to: Element) {
-    // copy sourcemaps
-    if (hasElementSourceMap(from)) {
-      to.meta.set('sourceMap', from.meta.get('sourceMap'));
+    if (from.meta.length > 0 || to.meta.length > 0) {
+      to.meta = deepmerge(to.meta, from.meta) as ObjectElement;
+      if (hasElementSourceMap(from)) {
+        // avoid deep merging of source maps
+        to.meta.set('sourceMap', from.meta.get('sourceMap'));
+      }
+    }
+    if (from.attributes.length > 0 || from.meta.length > 0) {
+      to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
     }
   }
+  /* eslint-enable- class-methods-use-this, no-param-reassign */
 }
 
 export default Visitor;

--- a/packages/apidom-ns-api-design-systems/test/refractor/elements/Info/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-api-design-systems/test/refractor/elements/Info/__snapshots__/index.ts.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refractor elements InfoElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `
+(InfoElement
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement)))
+`;
+
 exports[`refractor elements InfoElement should refract to semantic ApiDOM tree 1`] = `
 (InfoElement
   (MemberElement

--- a/packages/apidom-ns-api-design-systems/test/refractor/elements/Info/index.ts
+++ b/packages/apidom-ns-api-design-systems/test/refractor/elements/Info/index.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { assert, expect } from 'chai';
+import { ObjectElement, sexprs } from '@swagger-api/apidom-core';
 
 import { InfoElement } from '../../../../src';
 
@@ -13,6 +13,35 @@ describe('refractor', function () {
         });
 
         expect(sexprs(infoElement)).toMatchSnapshot();
+      });
+
+      context('given generic ApiDOM element', function () {
+        let infoElement: InfoElement;
+
+        beforeEach(function () {
+          infoElement = InfoElement.refract(
+            new ObjectElement(
+              {
+                title: 'title of API Design System',
+                description: 'description of the API Design System',
+              },
+              { meta: true },
+              { attr: true },
+            ),
+          ) as InfoElement;
+        });
+
+        specify('should refract to semantic ApiDOM tree', function () {
+          expect(sexprs(infoElement)).toMatchSnapshot();
+        });
+
+        specify('should deepmerge meta', function () {
+          assert.isTrue(infoElement.meta.get('meta').equals(true));
+        });
+
+        specify('should deepmerge attributes', function () {
+          assert.isTrue(infoElement.attributes.get('attr').equals(true));
+        });
       });
     });
   });

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Contact/index.ts
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Contact/index.ts
@@ -37,11 +37,11 @@ describe('refractor', function () {
           expect(sexprs(contactElement)).toMatchSnapshot();
         });
 
-        specify('should retain attributes', function () {
+        specify('should deepmerge attributes', function () {
           assert.isTrue(contactElement.attributes.get('attr').equals(true));
         });
 
-        specify('should retain meta', function () {
+        specify('should deepmerge meta', function () {
           assert.isTrue(contactElement.meta.get('meta').equals(true));
         });
       });


### PR DESCRIPTION
This change is specific to cases when semantic ApiDOM 
is refractored from generic ApiDOM.

Refs #3842
