### PR TITLE
fix(ns-openapi-3-0): retain meta & attributes during refracting

### DIFF
--- a/packages/apidom-ns-api-design-systems/test/refractor/plugins/openapi-3-1/__snapshots__/standard-identifier-selectors.ts.snap
+++ b/packages/apidom-ns-api-design-systems/test/refractor/plugins/openapi-3-1/__snapshots__/standard-identifier-selectors.ts.snap
@@ -10,6 +10,10 @@ exports[`given OpenAPI 3.1 definition should decorate with API Design Systems St
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }

--- a/packages/apidom-ns-openapi-3-0/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-openapi-3-0/src/refractor/visitors/Visitor.ts
@@ -1,4 +1,4 @@
-import { Element, hasElementSourceMap } from '@swagger-api/apidom-core';
+import { Element, ObjectElement, deepmerge, hasElementSourceMap } from '@swagger-api/apidom-core';
 
 export interface VisitorOptions {}
 
@@ -9,13 +9,20 @@ class Visitor {
     Object.assign(this, options);
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  /* eslint-disable class-methods-use-this, no-param-reassign */
   public copyMetaAndAttributes(from: Element, to: Element) {
-    // copy sourcemaps
-    if (hasElementSourceMap(from)) {
-      to.meta.set('sourceMap', from.meta.get('sourceMap'));
+    if (from.meta.length > 0 || to.meta.length > 0) {
+      to.meta = deepmerge(to.meta, from.meta) as ObjectElement;
+      if (hasElementSourceMap(from)) {
+        // avoid deep merging of source maps
+        to.meta.set('sourceMap', from.meta.get('sourceMap'));
+      }
+    }
+    if (from.attributes.length > 0 || from.meta.length > 0) {
+      to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
     }
   }
+  /* eslint-enable- class-methods-use-this, no-param-reassign */
 }
 
 export default Visitor;

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Info/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Info/__snapshots__/index.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refractor elements InfoElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `(InfoElement)`;
+
 exports[`refractor elements InfoElement should refract to semantic ApiDOM tree 1`] = `
 (InfoElement
   (MemberElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Info/index.ts
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Info/index.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { assert, expect } from 'chai';
+import { ObjectElement, toValue, sexprs } from '@swagger-api/apidom-core';
 
 import { InfoElement } from '../../../../src';
 
@@ -17,6 +17,30 @@ describe('refractor', function () {
         });
 
         expect(sexprs(infoElement)).toMatchSnapshot();
+      });
+
+      context('given generic ApiDOM element', function () {
+        let infoElement: InfoElement;
+
+        beforeEach(function () {
+          infoElement = InfoElement.refract(
+            new ObjectElement({}, { classes: ['example'] }, { attr: true }),
+          ) as InfoElement;
+        });
+
+        specify('should refract to semantic ApiDOM tree', function () {
+          expect(sexprs(infoElement)).toMatchSnapshot();
+        });
+
+        specify('should deepmerge meta', function () {
+          assert.deepEqual(toValue(infoElement.meta), {
+            classes: ['info', 'example'],
+          });
+        });
+
+        specify('should deepmerge attributes', function () {
+          assert.isTrue(infoElement.attributes.get('attr').equals(true));
+        });
       });
     });
   });

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-operation-ids/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-operation-ids/__snapshots__/index.ts.snap
@@ -10,6 +10,10 @@ exports[`refractor plugins normalize-operation-ids given Operation Object with m
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }
@@ -183,6 +187,10 @@ exports[`refractor plugins normalize-operation-ids given Operation Object with n
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }
@@ -382,6 +390,10 @@ exports[`refractor plugins normalize-operation-ids given Operation Object with o
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }
@@ -598,6 +610,10 @@ exports[`refractor plugins normalize-operation-ids given Operation Object with o
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }
@@ -814,6 +830,10 @@ exports[`refractor plugins normalize-operation-ids given Operation Object with u
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }
@@ -1168,6 +1188,10 @@ exports[`refractor plugins normalize-operation-ids given Operation Object with u
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }
@@ -1384,6 +1408,10 @@ exports[`refractor plugins normalize-operation-ids given Operation Objects with 
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/callbacks/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/callbacks/__snapshots__/index.ts.snap
@@ -99,6 +99,10 @@ exports[`refractor plugins normalize-parameters given parameters are defined in 
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/paths/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/paths/__snapshots__/index.ts.snap
@@ -117,6 +117,10 @@ exports[`refractor plugins normalize-parameters given parameters are defined in 
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }
@@ -608,6 +612,10 @@ exports[`refractor plugins normalize-parameters given parameters are defined in 
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/web-hooks/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/web-hooks/__snapshots__/index.ts.snap
@@ -67,6 +67,10 @@ exports[`refractor plugins normalize-parameters given parameters are defined in 
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-servers/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-servers/__snapshots__/index.ts.snap
@@ -56,6 +56,10 @@ exports[`refractor plugins normalize-servers given OpenAPI.servers defined and P
         {
           "element": "string",
           "content": "api"
+        },
+        {
+          "element": "string",
+          "content": "result"
         }
       ]
     }


### PR DESCRIPTION
This change is specific to cases when semantic ApiDOM
is refractored from generic ApiDOM.

Refs #3842

