### PR TITLE
fix(ns-workflow-1): retain meta & attributes during refracting

### DIFF
--- a/packages/apidom-ns-workflows-1/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-workflows-1/src/refractor/visitors/Visitor.ts
@@ -1,4 +1,4 @@
-import { hasElementSourceMap, Element } from '@swagger-api/apidom-core';
+import { Element, ObjectElement, deepmerge, hasElementSourceMap } from '@swagger-api/apidom-core';
 
 export interface VisitorOptions {}
 
@@ -9,13 +9,20 @@ class Visitor {
     Object.assign(this, options);
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  /* eslint-disable class-methods-use-this, no-param-reassign */
   public copyMetaAndAttributes(from: Element, to: Element) {
-    // copy sourcemaps
-    if (hasElementSourceMap(from)) {
-      to.meta.set('sourceMap', from.meta.get('sourceMap'));
+    if (from.meta.length > 0 || to.meta.length > 0) {
+      to.meta = deepmerge(to.meta, from.meta) as ObjectElement;
+      if (hasElementSourceMap(from)) {
+        // avoid deep merging of source maps
+        to.meta.set('sourceMap', from.meta.get('sourceMap'));
+      }
+    }
+    if (from.attributes.length > 0 || from.meta.length > 0) {
+      to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
     }
   }
+  /* eslint-enable- class-methods-use-this, no-param-reassign */
 }
 
 export default Visitor;

--- a/packages/apidom-ns-workflows-1/test/refractor/elements/Info/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-workflows-1/test/refractor/elements/Info/__snapshots__/index.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refractor elements InfoElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `(InfoElement)`;
+
 exports[`refractor elements InfoElement should refract to semantic ApiDOM tree 1`] = `
 (InfoElement
   (MemberElement

--- a/packages/apidom-ns-workflows-1/test/refractor/elements/Info/index.ts
+++ b/packages/apidom-ns-workflows-1/test/refractor/elements/Info/index.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { assert, expect } from 'chai';
+import { ObjectElement, toValue, sexprs } from '@swagger-api/apidom-core';
 
 import { InfoElement } from '../../../../src';
 
@@ -16,6 +16,30 @@ describe('refractor', function () {
         });
 
         expect(sexprs(infoElement)).toMatchSnapshot();
+      });
+
+      context('given generic ApiDOM element', function () {
+        let infoElement: InfoElement;
+
+        beforeEach(function () {
+          infoElement = InfoElement.refract(
+            new ObjectElement({}, { classes: ['example'] }, { attr: true }),
+          ) as InfoElement;
+        });
+
+        specify('should refract to semantic ApiDOM tree', function () {
+          expect(sexprs(infoElement)).toMatchSnapshot();
+        });
+
+        specify('should deepmerge meta', function () {
+          assert.deepEqual(toValue(infoElement.meta), {
+            classes: ['info', 'example'],
+          });
+        });
+
+        specify('should deepmerge attributes', function () {
+          assert.isTrue(infoElement.attributes.get('attr').equals(true));
+        });
       });
     });
   });


### PR DESCRIPTION
This change is specific to cases when semantic ApiDOM is refractoredfrom generic ApiDOM.

Refs #3842

