### PR TITLE
fix(ns-openapi-3-1): retain meta & attributes during refracting

### DIFF
--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Info/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Info/__snapshots__/index.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refractor elements InfoElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `(InfoElement)`;
+
 exports[`refractor elements InfoElement should refract to semantic ApiDOM tree 1`] = `
 (InfoElement
   (MemberElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Info/index.ts
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Info/index.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { assert, expect } from 'chai';
+import { ObjectElement, sexprs, toValue } from '@swagger-api/apidom-core';
 
 import { InfoElement } from '../../../../src';
 
@@ -18,6 +18,30 @@ describe('refractor', function () {
         });
 
         expect(sexprs(infoElement)).toMatchSnapshot();
+      });
+
+      context('given generic ApiDOM element', function () {
+        let infoElement: InfoElement;
+
+        beforeEach(function () {
+          infoElement = InfoElement.refract(
+            new ObjectElement({}, { classes: ['example'] }, { attr: true }),
+          ) as InfoElement;
+        });
+
+        specify('should refract to semantic ApiDOM tree', function () {
+          expect(sexprs(infoElement)).toMatchSnapshot();
+        });
+
+        specify('should deepmerge meta', function () {
+          assert.deepEqual(toValue(infoElement.meta), {
+            classes: ['info', 'example'],
+          });
+        });
+
+        specify('should deepmerge attributes', function () {
+          assert.isTrue(infoElement.attributes.get('attr').equals(true));
+        });
       });
     });
   });


### PR DESCRIPTION
This change is specific to cases when semantic ApiDOM is refractored from generic ApiDOM.

Refs #3842