### PR TITLE
fix(ns-json-schema): retain meta & attributes during refracting

### DIFF
--- a/packages/apidom-ns-api-design-systems/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-api-design-systems/src/refractor/visitors/Visitor.ts
@@ -22,7 +22,7 @@ class Visitor {
       to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
     }
   }
-  /* eslint-enable- class-methods-use-this, no-param-reassign */
+  /* eslint-enable class-methods-use-this, no-param-reassign */
 }
 
 export default Visitor;

--- a/packages/apidom-ns-asyncapi-2/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-asyncapi-2/src/refractor/visitors/Visitor.ts
@@ -22,7 +22,7 @@ class Visitor {
       to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
     }
   }
-  /* eslint-enable- class-methods-use-this, no-param-reassign */
+  /* eslint-enable class-methods-use-this, no-param-reassign */
 }
 
 export default Visitor;

--- a/packages/apidom-ns-json-schema-draft-4/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-json-schema-draft-4/src/refractor/visitors/Visitor.ts
@@ -1,5 +1,5 @@
 import stampit from 'stampit';
-import { hasElementSourceMap } from '@swagger-api/apidom-core';
+import { ObjectElement, hasElementSourceMap, deepmerge } from '@swagger-api/apidom-core';
 
 const Visitor = stampit({
   props: {
@@ -7,12 +7,20 @@ const Visitor = stampit({
   },
   // @ts-ignore
   methods: {
+    /* eslint-disable class-methods-use-this, no-param-reassign */
     copyMetaAndAttributes(from, to) {
-      // copy sourcemaps
-      if (hasElementSourceMap(from)) {
-        to.meta.set('sourceMap', from.meta.get('sourceMap'));
+      if (from.meta.length > 0 || to.meta.length > 0) {
+        to.meta = deepmerge(to.meta, from.meta) as ObjectElement;
+        if (hasElementSourceMap(from)) {
+          // avoid deep merging of source maps
+          to.meta.set('sourceMap', from.meta.get('sourceMap'));
+        }
+      }
+      if (from.attributes.length > 0 || from.meta.length > 0) {
+        to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
       }
     },
+    /* eslint-enable class-methods-use-this, no-param-reassign */
   },
 });
 

--- a/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/JSONSchema/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/JSONSchema/__snapshots__/index.ts.snap
@@ -248,3 +248,10 @@ exports[`refractor elements given fields of type JSONReference should refract to
             (StringElement)
             (StringElement)))))))
 `;
+
+exports[`refractor elements given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `
+(JSONSchemaDraft4Element
+  (MemberElement
+    (StringElement)
+    (ObjectElement)))
+`;

--- a/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/JSONSchema/index.ts
+++ b/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/JSONSchema/index.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { assert, expect } from 'chai';
+import { ObjectElement, sexprs, toValue } from '@swagger-api/apidom-core';
 
 import { JSONSchemaElement } from '../../../../src';
 
@@ -82,6 +82,31 @@ describe('refractor', function () {
         });
 
         expect(sexprs(jsonSchemaElement)).toMatchSnapshot();
+      });
+    });
+
+    context('given generic ApiDOM element', function () {
+      let jsonSchemaElement: JSONSchemaElement;
+
+      beforeEach(function () {
+        const propertiesKeyword = new ObjectElement({}, { classes: ['example'] }, { attr: true });
+        jsonSchemaElement = JSONSchemaElement.refract(
+          new ObjectElement({ properties: propertiesKeyword }),
+        ) as JSONSchemaElement;
+      });
+
+      specify('should refract to semantic ApiDOM tree', function () {
+        expect(sexprs(jsonSchemaElement)).toMatchSnapshot();
+      });
+
+      specify('should deepmerge meta', function () {
+        assert.deepEqual(toValue(jsonSchemaElement.properties!.meta), {
+          classes: ['json-schema-properties', 'example'],
+        });
+      });
+
+      specify('should deepmerge attributes', function () {
+        assert.isTrue(jsonSchemaElement.properties!.attributes.get('attr').equals(true));
       });
     });
   });

--- a/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/JSONSchema/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/JSONSchema/__snapshots__/index.ts.snap
@@ -864,3 +864,10 @@ exports[`refractor elements given fields of type JSONReference should refract to
             (StringElement)
             (StringElement)))))))
 `;
+
+exports[`refractor elements given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `
+(JSONSchemaDraft6Element
+  (MemberElement
+    (StringElement)
+    (ObjectElement)))
+`;

--- a/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/JSONSchema/index.ts
+++ b/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/JSONSchema/index.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { assert, expect } from 'chai';
+import { ObjectElement, sexprs, toValue } from '@swagger-api/apidom-core';
 
 import { JSONSchemaElement } from '../../../../src';
 
@@ -111,6 +111,31 @@ describe('refractor', function () {
         });
 
         expect(sexprs(jsonSchemaElement)).toMatchSnapshot();
+      });
+    });
+
+    context('given generic ApiDOM element', function () {
+      let jsonSchemaElement: JSONSchemaElement;
+
+      beforeEach(function () {
+        const propertiesKeyword = new ObjectElement({}, { classes: ['example'] }, { attr: true });
+        jsonSchemaElement = JSONSchemaElement.refract(
+          new ObjectElement({ properties: propertiesKeyword }),
+        ) as JSONSchemaElement;
+      });
+
+      specify('should refract to semantic ApiDOM tree', function () {
+        expect(sexprs(jsonSchemaElement)).toMatchSnapshot();
+      });
+
+      specify('should deepmerge meta', function () {
+        assert.deepEqual(toValue(jsonSchemaElement.properties!.meta), {
+          classes: ['json-schema-properties', 'example'],
+        });
+      });
+
+      specify('should deepmerge attributes', function () {
+        assert.isTrue(jsonSchemaElement.properties!.attributes.get('attr').equals(true));
       });
     });
   });

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONSchema/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONSchema/__snapshots__/index.ts.snap
@@ -1005,3 +1005,10 @@ exports[`refractor elements given fields of type JSONReference should refract to
             (StringElement)
             (StringElement)))))))
 `;
+
+exports[`refractor elements given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `
+(JSONSchemaDraft7Element
+  (MemberElement
+    (StringElement)
+    (ObjectElement)))
+`;

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONSchema/index.ts
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONSchema/index.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { assert, expect } from 'chai';
+import { ObjectElement, sexprs, toValue } from '@swagger-api/apidom-core';
 
 import { JSONSchemaElement } from '../../../../src';
 
@@ -123,6 +123,31 @@ describe('refractor', function () {
         });
 
         expect(sexprs(jsonSchemaElement)).toMatchSnapshot();
+      });
+    });
+
+    context('given generic ApiDOM element', function () {
+      let jsonSchemaElement: JSONSchemaElement;
+
+      beforeEach(function () {
+        const propertiesKeyword = new ObjectElement({}, { classes: ['example'] }, { attr: true });
+        jsonSchemaElement = JSONSchemaElement.refract(
+          new ObjectElement({ properties: propertiesKeyword }),
+        ) as JSONSchemaElement;
+      });
+
+      specify('should refract to semantic ApiDOM tree', function () {
+        expect(sexprs(jsonSchemaElement)).toMatchSnapshot();
+      });
+
+      specify('should deepmerge meta', function () {
+        assert.deepEqual(toValue(jsonSchemaElement.properties!.meta), {
+          classes: ['json-schema-properties', 'example'],
+        });
+      });
+
+      specify('should deepmerge attributes', function () {
+        assert.isTrue(jsonSchemaElement.properties!.attributes.get('attr').equals(true));
       });
     });
   });

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/Visitor.ts
@@ -22,7 +22,7 @@ class Visitor {
       to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
     }
   }
-  /* eslint-enable- class-methods-use-this, no-param-reassign */
+  /* eslint-enable class-methods-use-this, no-param-reassign */
 }
 
 export default Visitor;

--- a/packages/apidom-ns-openapi-3-0/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-openapi-3-0/src/refractor/visitors/Visitor.ts
@@ -22,7 +22,7 @@ class Visitor {
       to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
     }
   }
-  /* eslint-enable- class-methods-use-this, no-param-reassign */
+  /* eslint-enable class-methods-use-this, no-param-reassign */
 }
 
 export default Visitor;

--- a/packages/apidom-ns-workflows-1/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-workflows-1/src/refractor/visitors/Visitor.ts
@@ -22,7 +22,7 @@ class Visitor {
       to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement; // eslint-disable-line no-param-reassign
     }
   }
-  /* eslint-enable- class-methods-use-this, no-param-reassign */
+  /* eslint-enable class-methods-use-this, no-param-reassign */
 }
 
 export default Visitor;


### PR DESCRIPTION
This change is specific to cases when semantic ApiDOM is refractored from generic ApiDOM.

Refs #3842


