### PR TITLE
feat(converter): create unified error boundary interface

### DIFF
--- a/packages/apidom-converter/src/errors/ConvertError.ts
+++ b/packages/apidom-converter/src/errors/ConvertError.ts
@@ -1,5 +1,5 @@
-import { ApiDOMError } from '@swagger-api/apidom-error';
+import { ApiDOMStructuredError } from '@swagger-api/apidom-error';
 
-class ConvertError extends ApiDOMError {}
+class ConvertError extends ApiDOMStructuredError {}
 
 export default ConvertError;

--- a/packages/apidom-converter/src/index.ts
+++ b/packages/apidom-converter/src/index.ts
@@ -23,7 +23,11 @@ export const convertApiDOM = async (element: ParseResultElement, options = {}) =
     throw new UnmatchedConvertStrategyError(file.uri);
   }
 
-  return strategy.convert(file, mergedOptions);
+  try {
+    return strategy.convert(file, mergedOptions);
+  } catch (error) {
+    throw new ConvertError(`Error while converting file "${file.uri}"`, { cause: error, strategy });
+  }
 };
 
 const convert = async (uri: string, options = {}) => {


### PR DESCRIPTION
convert and convertApiDOM functions with now always
return ConverError instances on failure.

Refs #3998


