### PR TITLE
feat(converter): add Reference Object removal support in security-scheme-type plugin

### DIFF
--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type/__snapshots__/index.ts.snap
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type/__snapshots__/index.ts.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`converter strategies openapi-3-1-to-openapi-3-0-3 security-scheme-type should remove Reference Objects pointing to removable Security Scheme Objects 1`] = `
+{
+  "openapi": "3.0.3",
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "foo",
+        "operationId": "foo",
+        "security": [
+          {
+            "mutualTLS-scheme2": [
+              "read",
+              "write"
+            ]
+          },
+          {
+            "oauth2-scheme2": [
+              "read",
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "foo"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey-scheme1": {
+        "$ref": "#/components/securitySchemes/apiKey-scheme2"
+      },
+      "apiKey-scheme2": {
+        "type": "oauth2",
+        "name": "oauth2-scheme",
+        "in": "header"
+      }
+    }
+  }
+}
+`;
+
 exports[`converter strategies openapi-3-1-to-openapi-3-0-3 security-scheme-type should remove SecurityScheme object if it has "mutualTLS" type 1`] = `
 {
   "openapi": "3.0.3",

--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type/fixtures/reference-objects.json
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type/fixtures/reference-objects.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.1.0",
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "foo",
+        "operationId": "foo",
+        "security": [
+          {
+            "mutualTLS-scheme2": [
+              "read",
+              "write"
+            ]
+          },
+          {
+            "oauth2-scheme2": [
+              "read",
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "foo"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "mutualTLS-scheme1": {
+        "$ref": "#/components/securitySchemes/mutualTLS-scheme2"
+      },
+      "apiKey-scheme1": {
+        "$ref": "#/components/securitySchemes/apiKey-scheme2"
+      },
+      "mutualTLS-scheme2": {
+        "type": "mutualTLS",
+        "name": "mutualTLS-scheme",
+        "in": "header"
+      },
+      "apiKey-scheme2": {
+        "type": "oauth2",
+        "name": "oauth2-scheme",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type/index.ts
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type/index.ts
@@ -73,6 +73,21 @@ describe('converter', function () {
           assert.strictEqual(endColumn, 13);
           assert.strictEqual(endChar, 247);
         });
+
+        specify(
+          'should remove Reference Objects pointing to removable Security Scheme Objects',
+          async function () {
+            const fixturePath = path.join(__dirname, 'fixtures', 'reference-objects.json');
+            const convertedParseResult = await convert(fixturePath, {
+              convert: {
+                sourceMediaType: openAPI31MediaTypes.findBy('3.1.0', 'json'),
+                targetMediaType: openAPI30MediaTypes.findBy('3.0.3', 'json'),
+              },
+            });
+
+            expect(toJSON(convertedParseResult.api!, undefined, 2)).toMatchSnapshot();
+          },
+        );
       });
     });
   });


### PR DESCRIPTION
This change is specific to openapi-3-1-to-openapi-3-0-3 strategy.

Refs #4000

