### PR TITLE
feat(reference): change Reference from stamp to TypeScript class

### DIFF
--- a/packages/apidom-converter/src/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type.ts
+++ b/packages/apidom-converter/src/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type.ts
@@ -65,12 +65,15 @@ const securitySchemeTypeRefractorPlugin =
            * to Security Scheme Objects that are going to be removed.
            */
           const baseURI = url.cwd();
-          const rootReference = Reference({ uri: baseURI, value: cloneDeep(parseResultElement!) });
+          const rootReference = new Reference({
+            uri: baseURI,
+            value: cloneDeep(parseResultElement!),
+          });
           for (const memberElement of element.securitySchemes) {
             if (!isReferenceElement(memberElement.value)) continue; // eslint-disable-line no-continue
 
             const { value: referenceElement } = memberElement;
-            const reference = Reference({
+            const reference = new Reference({
               uri: `${baseURI}#reference`,
               value: new ParseResultElement([referenceElement]),
             });

--- a/packages/apidom-ls/src/services/validation/validation-service.ts
+++ b/packages/apidom-ls/src/services/validation/validation-service.ts
@@ -234,11 +234,11 @@ export class DefaultValidationService implements ValidationService {
     const baseURI = validationContext?.baseURI
       ? validationContext?.baseURI
       : 'https://smartbear.com/';
-    const apiReference = Reference({ uri: baseURI, value: cloneDeep(result) });
+    const apiReference = new Reference({ uri: baseURI, value: cloneDeep(result)! });
     const cachedParsers = options.parse.parsers.map(DefaultValidationService.createCachedParser);
 
     for (const [fragmentId, refEl] of refElements.entries()) {
-      const referenceElementReference = Reference({
+      const referenceElementReference = new Reference({
         uri: `${baseURI}#reference${fragmentId}`,
         value: refEl,
       });
@@ -336,11 +336,11 @@ export class DefaultValidationService implements ValidationService {
     const baseURI = validationContext?.baseURI
       ? validationContext?.baseURI
       : 'https://smartbear.com/';
-    const apiReference = Reference({ uri: baseURI, value: cloneDeep(result) });
+    const apiReference = new Reference({ uri: baseURI, value: cloneDeep(result) });
     const cachedParsers = options.parse.parsers.map(DefaultValidationService.createCachedParser);
 
     for (const [fragmentId, refEl] of refElements.entries()) {
-      const referenceElementReference = Reference({
+      const referenceElementReference = new Reference({
         uri: `${baseURI}#reference${fragmentId}`,
         value: refEl,
       });

--- a/packages/apidom-reference/src/Reference.ts
+++ b/packages/apidom-reference/src/Reference.ts
@@ -1,26 +1,26 @@
-import { ParseResultElement } from '@swagger-api/apidom-core';
+import { Element } from '@swagger-api/apidom-core';
 
 import { ReferenceSet } from './types';
 
-export interface ReferenceOptions {
+export interface ReferenceOptions<T = Element> {
   readonly uri: string;
   readonly depth?: number;
   readonly refSet?: ReferenceSet;
-  readonly value: ParseResultElement;
+  readonly value: T;
 }
 
-class Reference {
+class Reference<T = Element> {
   public readonly uri: string;
 
   public readonly depth: number;
 
-  public readonly value: ParseResultElement;
+  public readonly value: T;
 
   public refSet?: ReferenceSet;
 
   public readonly errors: Array<Error>;
 
-  constructor({ uri, depth = 0, refSet, value }: ReferenceOptions) {
+  constructor({ uri, depth = 0, refSet, value }: ReferenceOptions<T>) {
     this.uri = uri;
     this.value = value;
     this.depth = depth;

--- a/packages/apidom-reference/src/Reference.ts
+++ b/packages/apidom-reference/src/Reference.ts
@@ -1,25 +1,32 @@
-import stampit from 'stampit';
+import { ParseResultElement } from '@swagger-api/apidom-core';
 
-import { Reference as IReference } from './types';
+import { ReferenceSet } from './types';
 
-const Reference: stampit.Stamp<IReference> = stampit({
-  props: {
-    uri: '',
-    value: null,
-    depth: 0,
-    refSet: null,
-    errors: [],
-  },
-  init(
-    this: IReference,
-    { depth = this.depth, refSet = this.refSet, uri = this.uri, value = this.value } = {},
-  ) {
+export interface ReferenceOptions {
+  readonly uri: string;
+  readonly depth?: number;
+  readonly refSet?: ReferenceSet;
+  readonly value: ParseResultElement;
+}
+
+class Reference {
+  public readonly uri: string;
+
+  public readonly depth: number;
+
+  public readonly value: ParseResultElement;
+
+  public refSet?: ReferenceSet;
+
+  public readonly errors: Array<Error>;
+
+  constructor({ uri, depth = 0, refSet, value }: ReferenceOptions) {
     this.uri = uri;
     this.value = value;
     this.depth = depth;
     this.refSet = refSet;
     this.errors = [];
-  },
-});
+  }
+}
 
 export default Reference;

--- a/packages/apidom-reference/src/ReferenceSet.ts
+++ b/packages/apidom-reference/src/ReferenceSet.ts
@@ -2,7 +2,8 @@ import stampit from 'stampit';
 import { propEq } from 'ramda';
 import { isNotUndefined, isString } from 'ramda-adjunct';
 
-import { Reference as IReference, ReferenceSet as IReferenceSet } from './types';
+import { ReferenceSet as IReferenceSet } from './types';
+import type Reference from './Reference';
 
 const ReferenceSet: stampit.Stamp<IReferenceSet> = stampit({
   props: {
@@ -12,7 +13,7 @@ const ReferenceSet: stampit.Stamp<IReferenceSet> = stampit({
   },
   init({ refs = [] } = {}) {
     this.refs = [];
-    refs.forEach((ref: IReference) => this.add(ref));
+    refs.forEach((ref: Reference) => this.add(ref));
   },
   methods: {
     get size(): number {
@@ -20,7 +21,7 @@ const ReferenceSet: stampit.Stamp<IReferenceSet> = stampit({
       return this.refs.length;
     },
 
-    add(reference: IReference): IReferenceSet {
+    add(reference: Reference): IReferenceSet {
       if (!this.has(reference)) {
         this.refs.push(reference);
         this.rootRef = this.rootRef === null ? reference : this.rootRef;
@@ -36,12 +37,12 @@ const ReferenceSet: stampit.Stamp<IReferenceSet> = stampit({
       return this;
     },
 
-    has(thing: string | IReference): boolean {
+    has(thing: string | Reference): boolean {
       const uri = isString(thing) ? thing : thing.uri;
       return isNotUndefined(this.find(propEq(uri, 'uri')));
     },
 
-    find(callback): IReference | undefined {
+    find(callback): Reference | undefined {
       return this.refs.find(callback);
     },
 
@@ -50,8 +51,8 @@ const ReferenceSet: stampit.Stamp<IReferenceSet> = stampit({
     },
 
     clean() {
-      this.refs.forEach((ref: IReference) => {
-        ref.refSet = null; // eslint-disable-line no-param-reassign
+      this.refs.forEach((ref: Reference) => {
+        ref.refSet = undefined; // eslint-disable-line no-param-reassign
       });
       this.rootRef = null;
       this.refs = [];

--- a/packages/apidom-reference/src/dereference/strategies/apidom/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/apidom/index.ts
@@ -35,7 +35,7 @@ const ApiDOMDereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit(
 
         // determine the initial reference
         if (!immutableRefSet.has(file.uri)) {
-          reference = Reference({ uri: file.uri, value: file.parseResult });
+          reference = new Reference({ uri: file.uri, value: file.parseResult! });
           immutableRefSet.add(reference);
         } else {
           // pre-computed refSet was provided as configuration option
@@ -48,11 +48,12 @@ const ApiDOMDereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit(
          */
         if (options.dereference.immutable) {
           immutableRefSet.refs
-            .map((ref) =>
-              Reference({
-                ...ref,
-                value: cloneDeep(ref.value),
-              }),
+            .map(
+              (ref) =>
+                new Reference({
+                  ...ref,
+                  value: cloneDeep(ref.value),
+                }),
             )
             .forEach((ref) => mutableRefsSet.add(ref));
           reference = mutableRefsSet.find((ref) => ref.uri === file.uri);
@@ -68,11 +69,12 @@ const ApiDOMDereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit(
         if (options.dereference.immutable) {
           mutableRefsSet.refs
             .filter((ref) => ref.uri.startsWith('immutable://'))
-            .map((ref) =>
-              Reference({
-                ...ref,
-                uri: ref.uri.replace(/^immutable:\/\//, ''),
-              }),
+            .map(
+              (ref) =>
+                new Reference({
+                  ...ref,
+                  uri: ref.uri.replace(/^immutable:\/\//, ''),
+                }),
             )
             .forEach((ref) => immutableRefSet.add(ref));
           reference = immutableRefSet.find((ref) => ref.uri === file.uri);

--- a/packages/apidom-reference/src/dereference/strategies/apidom/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/apidom/visitor.ts
@@ -16,7 +16,6 @@ import {
 } from '@swagger-api/apidom-core';
 import { uriToPointer as uriToElementID } from '@swagger-api/apidom-json-pointer';
 
-import { Reference as IReference } from '../../../types';
 import MaximumResolveDepthError from '../../../errors/MaximumResolveDepthError';
 import * as url from '../../../util/url';
 import parse from '../../../parse';
@@ -53,7 +52,7 @@ const ApiDOMDereferenceVisitor = stampit({
       return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
     },
 
-    async toReference(uri: string): Promise<IReference> {
+    async toReference(uri: string): Promise<Reference> {
       // detect maximum depth of resolution
       if (this.reference.depth >= this.options.resolve.maxDepth) {
         throw new MaximumResolveDepthError(
@@ -75,7 +74,7 @@ const ApiDOMDereferenceVisitor = stampit({
       });
 
       // register new mutable reference with a refSet
-      const mutableReference = Reference({
+      const mutableReference = new Reference({
         uri: baseURI,
         value: cloneDeep(parseResult),
         depth: this.reference.depth + 1,
@@ -84,7 +83,7 @@ const ApiDOMDereferenceVisitor = stampit({
 
       if (this.options.dereference.immutable) {
         // register new immutable reference with a refSet
-        const immutableReference = Reference({
+        const immutableReference = new Reference({
           uri: `immutable://${baseURI}`,
           value: parseResult,
           depth: this.reference.depth + 1,

--- a/packages/apidom-reference/src/dereference/strategies/asyncapi-2/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/asyncapi-2/index.ts
@@ -45,7 +45,7 @@ const AsyncApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampi
         let reference;
 
         if (!immutableRefSet.has(file.uri)) {
-          reference = Reference({ uri: file.uri, value: file.parseResult });
+          reference = new Reference({ uri: file.uri, value: file.parseResult! });
           immutableRefSet.add(reference);
         } else {
           // pre-computed refSet was provided as configuration option
@@ -58,11 +58,12 @@ const AsyncApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampi
          */
         if (options.dereference.immutable) {
           immutableRefSet.refs
-            .map((ref) =>
-              Reference({
-                ...ref,
-                value: cloneDeep(ref.value),
-              }),
+            .map(
+              (ref) =>
+                new Reference({
+                  ...ref,
+                  value: cloneDeep(ref.value),
+                }),
             )
             .forEach((ref) => mutableRefsSet.add(ref));
           reference = mutableRefsSet.find((ref) => ref.uri === file.uri);
@@ -81,11 +82,12 @@ const AsyncApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampi
         if (options.dereference.immutable) {
           mutableRefsSet.refs
             .filter((ref) => ref.uri.startsWith('immutable://'))
-            .map((ref) =>
-              Reference({
-                ...ref,
-                uri: ref.uri.replace(/^immutable:\/\//, ''),
-              }),
+            .map(
+              (ref) =>
+                new Reference({
+                  ...ref,
+                  uri: ref.uri.replace(/^immutable:\/\//, ''),
+                }),
             )
             .forEach((ref) => immutableRefSet.add(ref));
           reference = immutableRefSet.find((ref) => ref.uri === file.uri);

--- a/packages/apidom-reference/src/dereference/strategies/asyncapi-2/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/asyncapi-2/visitor.ts
@@ -27,7 +27,6 @@ import {
   ReferenceElement,
 } from '@swagger-api/apidom-ns-asyncapi-2';
 
-import { Reference as IReference } from '../../../types';
 import MaximumDereferenceDepthError from '../../../errors/MaximumDereferenceDepthError';
 import MaximumResolveDepthError from '../../../errors/MaximumResolveDepthError';
 import { AncestorLineage } from '../../util';
@@ -70,7 +69,7 @@ const AsyncApi2DereferenceVisitor = stampit({
       return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
     },
 
-    async toReference(uri: string): Promise<IReference> {
+    async toReference(uri: string): Promise<Reference> {
       // detect maximum depth of resolution
       if (this.reference.depth >= this.options.resolve.maxDepth) {
         throw new MaximumResolveDepthError(
@@ -92,7 +91,7 @@ const AsyncApi2DereferenceVisitor = stampit({
       });
 
       // register new mutable reference with a refSet
-      const mutableReference = Reference({
+      const mutableReference = new Reference({
         uri: baseURI,
         value: cloneDeep(parseResult),
         depth: this.reference.depth + 1,
@@ -101,7 +100,7 @@ const AsyncApi2DereferenceVisitor = stampit({
 
       if (this.options.dereference.immutable) {
         // register new immutable reference with a refSet
-        const immutableReference = Reference({
+        const immutableReference = new Reference({
           uri: `immutable://${baseURI}`,
           value: parseResult,
           depth: this.reference.depth + 1,

--- a/packages/apidom-reference/src/dereference/strategies/openapi-2/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-2/index.ts
@@ -45,7 +45,7 @@ const OpenApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit
         let reference;
 
         if (!immutableRefSet.has(file.uri)) {
-          reference = Reference({ uri: file.uri, value: file.parseResult });
+          reference = new Reference({ uri: file.uri, value: file.parseResult! });
           immutableRefSet.add(reference);
         } else {
           // pre-computed refSet was provided as configuration option
@@ -58,11 +58,12 @@ const OpenApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit
          */
         if (options.dereference.immutable) {
           immutableRefSet.refs
-            .map((ref) =>
-              Reference({
-                ...ref,
-                value: cloneDeep(ref.value),
-              }),
+            .map(
+              (ref) =>
+                new Reference({
+                  ...ref,
+                  value: cloneDeep(ref.value),
+                }),
             )
             .forEach((ref) => mutableRefsSet.add(ref));
           reference = mutableRefsSet.find((ref) => ref.uri === file.uri);
@@ -81,11 +82,12 @@ const OpenApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit
         if (options.dereference.immutable) {
           mutableRefsSet.refs
             .filter((ref) => ref.uri.startsWith('immutable://'))
-            .map((ref) =>
-              Reference({
-                ...ref,
-                uri: ref.uri.replace(/^immutable:\/\//, ''),
-              }),
+            .map(
+              (ref) =>
+                new Reference({
+                  ...ref,
+                  uri: ref.uri.replace(/^immutable:\/\//, ''),
+                }),
             )
             .forEach((ref) => immutableRefSet.add(ref));
           reference = immutableRefSet.find((ref) => ref.uri === file.uri);

--- a/packages/apidom-reference/src/dereference/strategies/openapi-2/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-2/visitor.ts
@@ -28,7 +28,6 @@ import {
   JSONReferenceElement,
 } from '@swagger-api/apidom-ns-openapi-2';
 
-import { Reference as IReference } from '../../../types';
 import MaximumDereferenceDepthError from '../../../errors/MaximumDereferenceDepthError';
 import MaximumResolveDepthError from '../../../errors/MaximumResolveDepthError';
 import { AncestorLineage } from '../../util';
@@ -71,7 +70,7 @@ const OpenApi2DereferenceVisitor = stampit({
       return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
     },
 
-    async toReference(uri: string): Promise<IReference> {
+    async toReference(uri: string): Promise<Reference> {
       // detect maximum depth of resolution
       if (this.reference.depth >= this.options.resolve.maxDepth) {
         throw new MaximumResolveDepthError(
@@ -93,7 +92,7 @@ const OpenApi2DereferenceVisitor = stampit({
       });
 
       // register new mutable reference with a refSet
-      const mutableReference = Reference({
+      const mutableReference = new Reference({
         uri: baseURI,
         value: cloneDeep(parseResult),
         depth: this.reference.depth + 1,
@@ -102,7 +101,7 @@ const OpenApi2DereferenceVisitor = stampit({
 
       if (this.options.dereference.immutable) {
         // register new immutable reference with a refSet
-        const immutableReference = Reference({
+        const immutableReference = new Reference({
           uri: `immutable://${baseURI}`,
           value: parseResult,
           depth: this.reference.depth + 1,

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/index.ts
@@ -47,7 +47,7 @@ const OpenApi3_0DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
 
         // determine the initial reference
         if (!immutableRefSet.has(file.uri)) {
-          reference = Reference({ uri: file.uri, value: file.parseResult });
+          reference = new Reference({ uri: file.uri, value: file.parseResult! });
           immutableRefSet.add(reference);
         } else {
           // pre-computed refSet was provided as configuration option
@@ -60,11 +60,12 @@ const OpenApi3_0DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
          */
         if (options.dereference.immutable) {
           immutableRefSet.refs
-            .map((ref) =>
-              Reference({
-                ...ref,
-                value: cloneDeep(ref.value),
-              }),
+            .map(
+              (ref) =>
+                new Reference({
+                  ...ref,
+                  value: cloneDeep(ref.value),
+                }),
             )
             .forEach((ref) => mutableRefsSet.add(ref));
           reference = mutableRefsSet.find((ref) => ref.uri === file.uri);
@@ -83,11 +84,12 @@ const OpenApi3_0DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
         if (options.dereference.immutable) {
           mutableRefsSet.refs
             .filter((ref) => ref.uri.startsWith('immutable://'))
-            .map((ref) =>
-              Reference({
-                ...ref,
-                uri: ref.uri.replace(/^immutable:\/\//, ''),
-              }),
+            .map(
+              (ref) =>
+                new Reference({
+                  ...ref,
+                  uri: ref.uri.replace(/^immutable:\/\//, ''),
+                }),
             )
             .forEach((ref) => immutableRefSet.add(ref));
           reference = immutableRefSet.find((ref) => ref.uri === file.uri);

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
@@ -31,7 +31,6 @@ import {
   isReferenceLikeElement,
 } from '@swagger-api/apidom-ns-openapi-3-0';
 
-import { Reference as IReference } from '../../../types';
 import MaximumDereferenceDepthError from '../../../errors/MaximumDereferenceDepthError';
 import MaximumResolveDepthError from '../../../errors/MaximumResolveDepthError';
 import * as url from '../../../util/url';
@@ -75,7 +74,7 @@ const OpenApi3_0DereferenceVisitor = stampit({
       return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
     },
 
-    async toReference(uri: string): Promise<IReference> {
+    async toReference(uri: string): Promise<Reference> {
       // detect maximum depth of resolution
       if (this.reference.depth >= this.options.resolve.maxDepth) {
         throw new MaximumResolveDepthError(
@@ -97,7 +96,7 @@ const OpenApi3_0DereferenceVisitor = stampit({
       });
 
       // register new mutable reference with a refSet
-      const mutableReference = Reference({
+      const mutableReference = new Reference({
         uri: baseURI,
         value: cloneDeep(parseResult),
         depth: this.reference.depth + 1,
@@ -106,7 +105,7 @@ const OpenApi3_0DereferenceVisitor = stampit({
 
       if (this.options.dereference.immutable) {
         // register new immutable reference with a refSet
-        const immutableReference = Reference({
+        const immutableReference = new Reference({
           uri: `immutable://${baseURI}`,
           value: parseResult,
           depth: this.reference.depth + 1,

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/index.ts
@@ -47,7 +47,7 @@ const OpenApi3_1DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
         let reference;
 
         if (!immutableRefSet.has(file.uri)) {
-          reference = Reference({ uri: file.uri, value: file.parseResult });
+          reference = new Reference({ uri: file.uri, value: file.parseResult! });
           immutableRefSet.add(reference);
         } else {
           // pre-computed refSet was provided as configuration option
@@ -60,11 +60,12 @@ const OpenApi3_1DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
          */
         if (options.dereference.immutable) {
           immutableRefSet.refs
-            .map((ref) =>
-              Reference({
-                ...ref,
-                value: cloneDeep(ref.value),
-              }),
+            .map(
+              (ref) =>
+                new Reference({
+                  ...ref,
+                  value: cloneDeep(ref.value),
+                }),
             )
             .forEach((ref) => mutableRefsSet.add(ref));
           reference = mutableRefsSet.find((ref) => ref.uri === file.uri);
@@ -83,11 +84,12 @@ const OpenApi3_1DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
         if (options.dereference.immutable) {
           mutableRefsSet.refs
             .filter((ref) => ref.uri.startsWith('immutable://'))
-            .map((ref) =>
-              Reference({
-                ...ref,
-                uri: ref.uri.replace(/^immutable:\/\//, ''),
-              }),
+            .map(
+              (ref) =>
+                new Reference({
+                  ...ref,
+                  uri: ref.uri.replace(/^immutable:\/\//, ''),
+                }),
             )
             .forEach((ref) => immutableRefSet.add(ref));
           reference = immutableRefSet.find((ref) => ref.uri === file.uri);

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
@@ -38,7 +38,7 @@ import {
 
 import { isAnchor, uriToAnchor, evaluate as $anchorEvaluate } from './selectors/$anchor';
 import { evaluate as uriEvaluate } from './selectors/uri';
-import { Reference as IReference, Resolver as IResolver } from '../../../types';
+import { Resolver as IResolver } from '../../../types';
 import MaximumDereferenceDepthError from '../../../errors/MaximumDereferenceDepthError';
 import MaximumResolveDepthError from '../../../errors/MaximumResolveDepthError';
 import * as url from '../../../util/url';
@@ -85,7 +85,7 @@ const OpenApi3_1DereferenceVisitor = stampit({
       return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
     },
 
-    async toReference(uri: string): Promise<IReference> {
+    async toReference(uri: string): Promise<Reference> {
       // detect maximum depth of resolution
       if (this.reference.depth >= this.options.resolve.maxDepth) {
         throw new MaximumResolveDepthError(
@@ -107,7 +107,7 @@ const OpenApi3_1DereferenceVisitor = stampit({
       });
 
       // register new mutable reference with a refSet
-      const mutableReference = Reference({
+      const mutableReference = new Reference({
         uri: baseURI,
         value: cloneDeep(parseResult),
         depth: this.reference.depth + 1,
@@ -116,7 +116,7 @@ const OpenApi3_1DereferenceVisitor = stampit({
 
       if (this.options.dereference.immutable) {
         // register new immutable reference with a refSet
-        const immutableReference = Reference({
+        const immutableReference = new Reference({
           uri: `immutable://${baseURI}`,
           value: parseResult,
           depth: this.reference.depth + 1,

--- a/packages/apidom-reference/src/types.ts
+++ b/packages/apidom-reference/src/types.ts
@@ -1,6 +1,7 @@
 import { Element, ParseResultElement, RefElement } from '@swagger-api/apidom-core';
 
 import type File from './File';
+import type Reference from './Reference';
 
 export interface Resolver {
   // name: string; - causing issues with stamps
@@ -50,14 +51,6 @@ export interface BundleStrategy {
 
 export interface ComposableResolveStrategy extends ResolveStrategy {
   readonly strategies: Array<ResolveStrategy>;
-}
-
-export interface Reference {
-  uri: string;
-  depth: number;
-  value: ParseResultElement;
-  refSet: null | ReferenceSet;
-  errors: Array<Error>;
 }
 
 export interface ReferenceSet {

--- a/packages/apidom-reference/test/dereference/strategies/openapi-2/json-reference-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-2/json-reference-object/index.ts
@@ -462,19 +462,19 @@ describe('dereference', function () {
 
             const rootURI = path.join(fixturePath, 'root.json');
             const rootParseResult = await parse(rootURI, { mediaType: mediaTypes.latest('json') });
-            const rootRef = Reference({ uri: rootURI, value: rootParseResult });
+            const rootRef = new Reference({ uri: rootURI, value: rootParseResult });
 
             const ex1URI = path.join(fixturePath, 'ex1.json');
             const ex1ParseResult = await parse(ex1URI, { mediaType: 'application/json' });
-            const ex1Ref = Reference({ uri: ex1URI, value: ex1ParseResult });
+            const ex1Ref = new Reference({ uri: ex1URI, value: ex1ParseResult });
 
             const ex2URI = path.join(fixturePath, 'ex2.json');
             const ex2ParseResult = await parse(ex2URI, { mediaType: 'application/json' });
-            const ex2Ref = Reference({ uri: ex2URI, value: ex2ParseResult });
+            const ex2Ref = new Reference({ uri: ex2URI, value: ex2ParseResult });
 
             const ex3URI = path.join(fixturePath, 'ex3.json');
             const ex3ParseResult = await parse(ex3URI, { mediaType: 'application/json' });
-            const ex3Ref = Reference({ uri: ex3URI, value: ex3ParseResult });
+            const ex3Ref = new Reference({ uri: ex3URI, value: ex3ParseResult });
 
             const refSet = ReferenceSet({ refs: [rootRef, ex1Ref, ex2Ref, ex3Ref] });
 

--- a/packages/apidom-reference/test/dereference/strategies/openapi-2/reference-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-2/reference-object/index.ts
@@ -316,19 +316,19 @@ describe('dereference', function () {
 
             const rootURI = path.join(fixturePath, 'root.json');
             const rootParseResult = await parse(rootURI, { mediaType: mediaTypes.latest('json') });
-            const rootRef = Reference({ uri: rootURI, value: rootParseResult });
+            const rootRef = new Reference({ uri: rootURI, value: rootParseResult });
 
             const ex1URI = path.join(fixturePath, 'ex1.json');
             const ex1ParseResult = await parse(ex1URI, { mediaType: 'application/json' });
-            const ex1Ref = Reference({ uri: ex1URI, value: ex1ParseResult });
+            const ex1Ref = new Reference({ uri: ex1URI, value: ex1ParseResult });
 
             const ex2URI = path.join(fixturePath, 'ex2.json');
             const ex2ParseResult = await parse(ex2URI, { mediaType: 'application/json' });
-            const ex2Ref = Reference({ uri: ex2URI, value: ex2ParseResult });
+            const ex2Ref = new Reference({ uri: ex2URI, value: ex2ParseResult });
 
             const ex3URI = path.join(fixturePath, 'ex3.json');
             const ex3ParseResult = await parse(ex3URI, { mediaType: 'application/json' });
-            const ex3Ref = Reference({ uri: ex3URI, value: ex3ParseResult });
+            const ex3Ref = new Reference({ uri: ex3URI, value: ex3ParseResult });
 
             const refSet = ReferenceSet({ refs: [rootRef, ex1Ref, ex2Ref, ex3Ref] });
 

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/index.ts
@@ -398,8 +398,8 @@ describe('dereference', function () {
             // @ts-ignore
             const referenceElement = parseResult.api?.components.parameters.get('externalRef');
             const refSet = ReferenceSet();
-            const rootFileReference = Reference({ uri, value: parseResult });
-            const referenceElementReference = Reference({
+            const rootFileReference = new Reference({ uri, value: parseResult });
+            const referenceElementReference = new Reference({
               uri: `${uri}#/single-reference-object`,
               value: new ParseResultElement([referenceElement]),
             });

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/index.ts
@@ -562,7 +562,7 @@ describe('dereference', function () {
               parse: { mediaType: mediaTypes.latest('json') },
             });
             const uri = 'https://example.com/';
-            const reference = Reference({ uri, value: parseResult });
+            const reference = new Reference({ uri, value: parseResult });
             const refSet = ReferenceSet({ refs: [reference] });
 
             const actual = await dereference(uri, {
@@ -706,7 +706,7 @@ describe('dereference', function () {
                 parse: { mediaType: mediaTypes.latest('json') },
               });
               const uri = 'https://example.com/';
-              const reference = Reference({ uri, value: parseResult });
+              const reference = new Reference({ uri, value: parseResult });
               const refSet = ReferenceSet({ refs: [reference] });
 
               const actual = await dereference(uri, {


### PR DESCRIPTION
Refs #3481

BREAKING CHANGE: Reference from apidom-reference package became a class and requires to be instantiated with new operator.

