### PR TITLE
feat(reference): change ReferenceSet from stamp to TypeScript class

### DIFF
--- a/packages/apidom-converter/src/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type.ts
+++ b/packages/apidom-converter/src/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type.ts
@@ -77,7 +77,7 @@ const securitySchemeTypeRefractorPlugin =
               uri: `${baseURI}#reference`,
               value: new ParseResultElement([referenceElement]),
             });
-            const refSet = ReferenceSet({ refs: [reference, rootReference] });
+            const refSet = new ReferenceSet({ refs: [reference, rootReference] });
             // eslint-disable-next-line no-await-in-loop
             const dereferenced = await dereferenceApiDOM(referenceElement, {
               resolve: { baseURI: reference.uri },

--- a/packages/apidom-ls/src/services/validation/validation-service.ts
+++ b/packages/apidom-ls/src/services/validation/validation-service.ts
@@ -242,7 +242,7 @@ export class DefaultValidationService implements ValidationService {
         uri: `${baseURI}#reference${fragmentId}`,
         value: refEl,
       });
-      const refSet = ReferenceSet({ refs: [referenceElementReference, apiReference] });
+      const refSet = new ReferenceSet({ refs: [referenceElementReference, apiReference] });
 
       try {
         const promise = dereferenceApiDOM(refEl, {
@@ -344,7 +344,7 @@ export class DefaultValidationService implements ValidationService {
         uri: `${baseURI}#reference${fragmentId}`,
         value: refEl,
       });
-      const refSet = ReferenceSet({ refs: [referenceElementReference, apiReference] });
+      const refSet = new ReferenceSet({ refs: [referenceElementReference, apiReference] });
 
       try {
         // eslint-disable-next-line no-await-in-loop

--- a/packages/apidom-reference/src/Reference.ts
+++ b/packages/apidom-reference/src/Reference.ts
@@ -1,6 +1,6 @@
 import { Element } from '@swagger-api/apidom-core';
 
-import { ReferenceSet } from './types';
+import ReferenceSet from './ReferenceSet';
 
 export interface ReferenceOptions<T = Element> {
   readonly uri: string;

--- a/packages/apidom-reference/src/ReferenceSet.ts
+++ b/packages/apidom-reference/src/ReferenceSet.ts
@@ -15,9 +15,9 @@ class ReferenceSet {
   public readonly circular: boolean;
 
   constructor({ refs = [], circular = false }: ReferenceSetOptions = {}) {
-    this.refs = refs;
+    this.refs = [];
     this.circular = circular;
-    refs.forEach((ref: Reference) => this.add(ref));
+    refs.forEach(this.add.bind(this));
   }
 
   get size(): number {

--- a/packages/apidom-reference/src/dereference/strategies/apidom/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/apidom/index.ts
@@ -29,7 +29,7 @@ const ApiDOMDereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit(
 
       async dereference(file: File, options: IReferenceOptions): Promise<Element> {
         const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
-        const mutableRefsSet = new ReferenceSet();
+        const mutableRefSet = new ReferenceSet();
         let refSet = immutableRefSet;
         let reference;
 
@@ -55,9 +55,9 @@ const ApiDOMDereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit(
                   value: cloneDeep(ref.value),
                 }),
             )
-            .forEach((ref) => mutableRefsSet.add(ref));
-          reference = mutableRefsSet.find((ref) => ref.uri === file.uri);
-          refSet = mutableRefsSet;
+            .forEach((ref) => mutableRefSet.add(ref));
+          reference = mutableRefSet.find((ref) => ref.uri === file.uri);
+          refSet = mutableRefSet;
         }
 
         const visitor = ApiDOMDereferenceVisitor({ reference, options });
@@ -67,7 +67,7 @@ const ApiDOMDereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit(
          * If immutable option is set, replay refs from the refSet.
          */
         if (options.dereference.immutable) {
-          mutableRefsSet.refs
+          mutableRefSet.refs
             .filter((ref) => ref.uri.startsWith('immutable://'))
             .map(
               (ref) =>
@@ -89,7 +89,7 @@ const ApiDOMDereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit(
           immutableRefSet.clean();
         }
 
-        mutableRefsSet.clean();
+        mutableRefSet.clean();
 
         return dereferencedElement;
       },

--- a/packages/apidom-reference/src/dereference/strategies/apidom/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/apidom/index.ts
@@ -28,8 +28,8 @@ const ApiDOMDereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit(
       },
 
       async dereference(file: File, options: IReferenceOptions): Promise<Element> {
-        const immutableRefSet = options.dereference.refSet ?? ReferenceSet();
-        const mutableRefsSet = ReferenceSet();
+        const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
+        const mutableRefsSet = new ReferenceSet();
         let refSet = immutableRefSet;
         let reference;
 
@@ -61,7 +61,7 @@ const ApiDOMDereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit(
         }
 
         const visitor = ApiDOMDereferenceVisitor({ reference, options });
-        const dereferencedElement = await visitAsync(refSet.rootRef.value, visitor);
+        const dereferencedElement = await visitAsync(refSet.rootRef!.value, visitor);
 
         /**
          * If immutable option is set, replay refs from the refSet.

--- a/packages/apidom-reference/src/dereference/strategies/asyncapi-2/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/asyncapi-2/index.ts
@@ -39,8 +39,8 @@ const AsyncApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampi
 
       async dereference(file: File, options: IReferenceOptions): Promise<Element> {
         const namespace = createNamespace(asyncApi2Namespace);
-        const immutableRefSet = options.dereference.refSet ?? ReferenceSet();
-        const mutableRefsSet = ReferenceSet();
+        const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
+        const mutableRefsSet = new ReferenceSet();
         let refSet = immutableRefSet;
         let reference;
 
@@ -71,7 +71,7 @@ const AsyncApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampi
         }
 
         const visitor = AsyncApi2DereferenceVisitor({ reference, namespace, options });
-        const dereferencedElement = await visitAsync(refSet.rootRef.value, visitor, {
+        const dereferencedElement = await visitAsync(refSet.rootRef!.value, visitor, {
           keyMap,
           nodeTypeGetter: getNodeType,
         });

--- a/packages/apidom-reference/src/dereference/strategies/asyncapi-2/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/asyncapi-2/index.ts
@@ -40,7 +40,7 @@ const AsyncApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampi
       async dereference(file: File, options: IReferenceOptions): Promise<Element> {
         const namespace = createNamespace(asyncApi2Namespace);
         const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
-        const mutableRefsSet = new ReferenceSet();
+        const mutableRefSet = new ReferenceSet();
         let refSet = immutableRefSet;
         let reference;
 
@@ -65,9 +65,9 @@ const AsyncApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampi
                   value: cloneDeep(ref.value),
                 }),
             )
-            .forEach((ref) => mutableRefsSet.add(ref));
-          reference = mutableRefsSet.find((ref) => ref.uri === file.uri);
-          refSet = mutableRefsSet;
+            .forEach((ref) => mutableRefSet.add(ref));
+          reference = mutableRefSet.find((ref) => ref.uri === file.uri);
+          refSet = mutableRefSet;
         }
 
         const visitor = AsyncApi2DereferenceVisitor({ reference, namespace, options });
@@ -80,7 +80,7 @@ const AsyncApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampi
          * If immutable option is set, replay refs from the refSet.
          */
         if (options.dereference.immutable) {
-          mutableRefsSet.refs
+          mutableRefSet.refs
             .filter((ref) => ref.uri.startsWith('immutable://'))
             .map(
               (ref) =>
@@ -102,7 +102,7 @@ const AsyncApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampi
           immutableRefSet.clean();
         }
 
-        mutableRefsSet.clean();
+        mutableRefSet.clean();
 
         return dereferencedElement;
       },

--- a/packages/apidom-reference/src/dereference/strategies/openapi-2/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-2/index.ts
@@ -39,8 +39,8 @@ const OpenApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit
 
       async dereference(file: File, options: IReferenceOptions): Promise<Element> {
         const namespace = createNamespace(openApi2Namespace);
-        const immutableRefSet = options.dereference.refSet ?? ReferenceSet();
-        const mutableRefsSet = ReferenceSet();
+        const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
+        const mutableRefsSet = new ReferenceSet();
         let refSet = immutableRefSet;
         let reference;
 
@@ -71,7 +71,7 @@ const OpenApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit
         }
 
         const visitor = OpenApi2DereferenceVisitor({ reference, namespace, options });
-        const dereferencedElement = await visitAsync(refSet.rootRef.value, visitor, {
+        const dereferencedElement = await visitAsync(refSet.rootRef!.value, visitor, {
           keyMap,
           nodeTypeGetter: getNodeType,
         });

--- a/packages/apidom-reference/src/dereference/strategies/openapi-2/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-2/index.ts
@@ -40,7 +40,7 @@ const OpenApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit
       async dereference(file: File, options: IReferenceOptions): Promise<Element> {
         const namespace = createNamespace(openApi2Namespace);
         const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
-        const mutableRefsSet = new ReferenceSet();
+        const mutableRefSet = new ReferenceSet();
         let refSet = immutableRefSet;
         let reference;
 
@@ -65,9 +65,9 @@ const OpenApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit
                   value: cloneDeep(ref.value),
                 }),
             )
-            .forEach((ref) => mutableRefsSet.add(ref));
-          reference = mutableRefsSet.find((ref) => ref.uri === file.uri);
-          refSet = mutableRefsSet;
+            .forEach((ref) => mutableRefSet.add(ref));
+          reference = mutableRefSet.find((ref) => ref.uri === file.uri);
+          refSet = mutableRefSet;
         }
 
         const visitor = OpenApi2DereferenceVisitor({ reference, namespace, options });
@@ -80,7 +80,7 @@ const OpenApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit
          * If immutable option is set, replay refs from the refSet.
          */
         if (options.dereference.immutable) {
-          mutableRefsSet.refs
+          mutableRefSet.refs
             .filter((ref) => ref.uri.startsWith('immutable://'))
             .map(
               (ref) =>
@@ -102,7 +102,7 @@ const OpenApi2DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stampit
           immutableRefSet.clean();
         }
 
-        mutableRefsSet.clean();
+        mutableRefSet.clean();
 
         return dereferencedElement;
       },

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/index.ts
@@ -41,7 +41,7 @@ const OpenApi3_0DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
       async dereference(file: File, options: IReferenceOptions): Promise<Element> {
         const namespace = createNamespace(openApi3_0Namespace);
         const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
-        const mutableRefsSet = new ReferenceSet();
+        const mutableRefSet = new ReferenceSet();
         let refSet = immutableRefSet;
         let reference;
 
@@ -67,9 +67,9 @@ const OpenApi3_0DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
                   value: cloneDeep(ref.value),
                 }),
             )
-            .forEach((ref) => mutableRefsSet.add(ref));
-          reference = mutableRefsSet.find((ref) => ref.uri === file.uri);
-          refSet = mutableRefsSet;
+            .forEach((ref) => mutableRefSet.add(ref));
+          reference = mutableRefSet.find((ref) => ref.uri === file.uri);
+          refSet = mutableRefSet;
         }
 
         const visitor = OpenApi3_0DereferenceVisitor({ reference, namespace, options });
@@ -82,7 +82,7 @@ const OpenApi3_0DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
          * If immutable option is set, replay refs from the refSet.
          */
         if (options.dereference.immutable) {
-          mutableRefsSet.refs
+          mutableRefSet.refs
             .filter((ref) => ref.uri.startsWith('immutable://'))
             .map(
               (ref) =>
@@ -104,7 +104,7 @@ const OpenApi3_0DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
           immutableRefSet.clean();
         }
 
-        mutableRefsSet.clean();
+        mutableRefSet.clean();
 
         return dereferencedElement;
       },

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/index.ts
@@ -40,8 +40,8 @@ const OpenApi3_0DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
 
       async dereference(file: File, options: IReferenceOptions): Promise<Element> {
         const namespace = createNamespace(openApi3_0Namespace);
-        const immutableRefSet = options.dereference.refSet ?? ReferenceSet();
-        const mutableRefsSet = ReferenceSet();
+        const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
+        const mutableRefsSet = new ReferenceSet();
         let refSet = immutableRefSet;
         let reference;
 
@@ -73,7 +73,7 @@ const OpenApi3_0DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
         }
 
         const visitor = OpenApi3_0DereferenceVisitor({ reference, namespace, options });
-        const dereferencedElement = await visitAsync(refSet.rootRef.value, visitor, {
+        const dereferencedElement = await visitAsync(refSet.rootRef!.value, visitor, {
           keyMap,
           nodeTypeGetter: getNodeType,
         });

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/index.ts
@@ -41,8 +41,8 @@ const OpenApi3_1DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
 
       async dereference(file: File, options: IReferenceOptions): Promise<Element> {
         const namespace = createNamespace(openApi3_1Namespace);
-        const immutableRefSet = options.dereference.refSet ?? ReferenceSet();
-        const mutableRefsSet = ReferenceSet();
+        const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
+        const mutableRefsSet = new ReferenceSet();
         let refSet = immutableRefSet;
         let reference;
 
@@ -73,7 +73,7 @@ const OpenApi3_1DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
         }
 
         const visitor = OpenApi3_1DereferenceVisitor({ reference, namespace, options });
-        const dereferencedElement = await visitAsync(refSet.rootRef.value, visitor, {
+        const dereferencedElement = await visitAsync(refSet.rootRef!.value, visitor, {
           keyMap,
           nodeTypeGetter: getNodeType,
         });

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/index.ts
@@ -42,7 +42,7 @@ const OpenApi3_1DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
       async dereference(file: File, options: IReferenceOptions): Promise<Element> {
         const namespace = createNamespace(openApi3_1Namespace);
         const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
-        const mutableRefsSet = new ReferenceSet();
+        const mutableRefSet = new ReferenceSet();
         let refSet = immutableRefSet;
         let reference;
 
@@ -67,9 +67,9 @@ const OpenApi3_1DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
                   value: cloneDeep(ref.value),
                 }),
             )
-            .forEach((ref) => mutableRefsSet.add(ref));
-          reference = mutableRefsSet.find((ref) => ref.uri === file.uri);
-          refSet = mutableRefsSet;
+            .forEach((ref) => mutableRefSet.add(ref));
+          reference = mutableRefSet.find((ref) => ref.uri === file.uri);
+          refSet = mutableRefSet;
         }
 
         const visitor = OpenApi3_1DereferenceVisitor({ reference, namespace, options });
@@ -82,7 +82,7 @@ const OpenApi3_1DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
          * If immutable option is set, replay refs from the refSet.
          */
         if (options.dereference.immutable) {
-          mutableRefsSet.refs
+          mutableRefSet.refs
             .filter((ref) => ref.uri.startsWith('immutable://'))
             .map(
               (ref) =>
@@ -104,7 +104,7 @@ const OpenApi3_1DereferenceStrategy: stampit.Stamp<IDereferenceStrategy> = stamp
           immutableRefSet.clean();
         }
 
-        mutableRefsSet.clean();
+        mutableRefSet.clean();
 
         return dereferencedElement;
       },

--- a/packages/apidom-reference/src/index.ts
+++ b/packages/apidom-reference/src/index.ts
@@ -1,8 +1,8 @@
 import { ParseResultElement, Element } from '@swagger-api/apidom-core';
 
 import File from './File';
+import ReferenceSet from './ReferenceSet';
 import * as url from './util/url';
-import { ReferenceSet as IReferenceSet } from './types';
 import defaultOptions from './options';
 import { merge as mergeOptions } from './options/util';
 import parseFn from './parse';
@@ -11,7 +11,7 @@ import { readFile as readFileFn } from './resolve/util';
 import dereferenceFn, { dereferenceApiDOM as dereferenceApiDOMFn } from './dereference';
 import bundleFn from './bundle';
 
-export { url, File };
+export { url };
 
 export { default as Parser } from './parse/parsers/Parser';
 
@@ -27,8 +27,12 @@ export { default as BundleStrategy } from './bundle/strategies/BundleStrategy';
 export { default as options } from './options';
 export { merge as mergeOptions } from './options/util';
 
+export { File };
 export { default as Reference } from './Reference';
-export { default as ReferenceSet } from './ReferenceSet';
+export { ReferenceSet };
+export type { FileOptions } from './File';
+export type { ReferenceOptions } from './Reference';
+export type { ReferenceSetOptions } from './ReferenceSet';
 
 export { default as BundleError } from './errors/BundleError';
 export { default as MaximumBundleDepthError } from './errors/MaximumBundleDepthError';
@@ -63,7 +67,7 @@ export const parse = async (uri: string, options = {}): Promise<ParseResultEleme
   return parseFn(uri, mergedOptions);
 };
 
-export const resolve = async (uri: string, options = {}): Promise<IReferenceSet> => {
+export const resolve = async (uri: string, options = {}): Promise<ReferenceSet> => {
   const mergedOptions = mergeOptions(defaultOptions, options);
   return resolveFn(uri, mergedOptions);
 };
@@ -71,7 +75,7 @@ export const resolve = async (uri: string, options = {}): Promise<IReferenceSet>
 export const resolveApiDOM = async <T extends Element>(
   element: T,
   options = {},
-): Promise<IReferenceSet> => {
+): Promise<ReferenceSet> => {
   const mergedOptions = mergeOptions(defaultOptions, options);
   return resolveApiDOMFn(element, mergedOptions);
 };

--- a/packages/apidom-reference/src/resolve/index.ts
+++ b/packages/apidom-reference/src/resolve/index.ts
@@ -7,10 +7,11 @@ import {
 } from '@swagger-api/apidom-core';
 
 import { merge as mergeOptions } from '../options/util';
-import { ReferenceOptions as IReferenceOptions, ReferenceSet as IReferenceSet } from '../types';
+import { ReferenceOptions as IReferenceOptions } from '../types';
 import parse from '../parse';
 import * as plugins from '../util/plugins';
 import File from '../File';
+import ReferenceSet from '../ReferenceSet';
 import ResolveError from '../errors/ResolverError';
 import UnmatchedResolveStrategyError from '../errors/UnmatchedResolveStrategyError';
 import * as url from '../util/url';
@@ -21,7 +22,7 @@ import * as url from '../util/url';
 export const resolveApiDOM = async <T extends Element>(
   element: T,
   options: IReferenceOptions,
-): Promise<IReferenceSet> => {
+): Promise<ReferenceSet> => {
   // @ts-ignore
   let parseResult: ParseResultElement = element;
 
@@ -62,7 +63,7 @@ export const resolveApiDOM = async <T extends Element>(
 /**
  * Resolves a file with all its external references.
  */
-const resolve = async (uri: string, options: IReferenceOptions): Promise<IReferenceSet> => {
+const resolve = async (uri: string, options: IReferenceOptions): Promise<ReferenceSet> => {
   const parseResult = await parse(uri, options);
   const mergedOptions = mergeOptions(options, { resolve: { baseURI: url.sanitize(uri) } });
 

--- a/packages/apidom-reference/src/resolve/strategies/apidom/index.ts
+++ b/packages/apidom-reference/src/resolve/strategies/apidom/index.ts
@@ -38,7 +38,7 @@ const ApiDOMResolveStrategy: stampit.Stamp<IResolveStrategy> = stampit(ResolveSt
         );
       }
 
-      const refSet = ReferenceSet();
+      const refSet = new ReferenceSet();
       const mergedOptions = mergeOptions(options, {
         resolve: { internal: false },
         dereference: { refSet },

--- a/packages/apidom-reference/src/resolve/strategies/asyncapi-2/index.ts
+++ b/packages/apidom-reference/src/resolve/strategies/asyncapi-2/index.ts
@@ -38,7 +38,7 @@ const AsyncApi2ResolveStrategy: stampit.Stamp<IResolveStrategy> = stampit(Resolv
         );
       }
 
-      const refSet = ReferenceSet();
+      const refSet = new ReferenceSet();
       const mergedOptions = mergeOptions(options, {
         resolve: { internal: false },
         dereference: { refSet },

--- a/packages/apidom-reference/src/resolve/strategies/openapi-2/index.ts
+++ b/packages/apidom-reference/src/resolve/strategies/openapi-2/index.ts
@@ -38,7 +38,7 @@ const OpenApi2ResolveStrategy: stampit.Stamp<IResolveStrategy> = stampit(Resolve
         );
       }
 
-      const refSet = ReferenceSet();
+      const refSet = new ReferenceSet();
       const mergedOptions = mergeOptions(options, {
         resolve: { internal: false },
         dereference: { refSet },

--- a/packages/apidom-reference/src/resolve/strategies/openapi-3-0/index.ts
+++ b/packages/apidom-reference/src/resolve/strategies/openapi-3-0/index.ts
@@ -39,7 +39,7 @@ const OpenApi3_0ResolveStrategy: stampit.Stamp<IResolveStrategy> = stampit(Resol
         );
       }
 
-      const refSet = ReferenceSet();
+      const refSet = new ReferenceSet();
       const mergedOptions = mergeOptions(options, {
         resolve: { internal: false },
         dereference: { refSet },

--- a/packages/apidom-reference/src/resolve/strategies/openapi-3-1/index.ts
+++ b/packages/apidom-reference/src/resolve/strategies/openapi-3-1/index.ts
@@ -39,7 +39,7 @@ const OpenApi3_1ResolveStrategy: stampit.Stamp<IResolveStrategy> = stampit(Resol
         );
       }
 
-      const refSet = ReferenceSet();
+      const refSet = new ReferenceSet();
       const mergedOptions = mergeOptions(options, {
         resolve: { internal: false },
         dereference: { refSet },

--- a/packages/apidom-reference/src/types.ts
+++ b/packages/apidom-reference/src/types.ts
@@ -1,7 +1,7 @@
 import { Element, ParseResultElement, RefElement } from '@swagger-api/apidom-core';
 
 import type File from './File';
-import type Reference from './Reference';
+import type ReferenceSet from './ReferenceSet';
 
 export interface Resolver {
   // name: string; - causing issues with stamps
@@ -51,20 +51,6 @@ export interface BundleStrategy {
 
 export interface ComposableResolveStrategy extends ResolveStrategy {
   readonly strategies: Array<ResolveStrategy>;
-}
-
-export interface ReferenceSet {
-  rootRef: Reference;
-  refs: Array<Reference>;
-  circular: boolean;
-  readonly size: number;
-
-  add(reference: Reference): ReferenceSet;
-  merge(anotherRefSet: ReferenceSet): ReferenceSet;
-  has(uri: string): boolean;
-  find(callback: (reference: Reference) => boolean): undefined | Reference;
-  values(): IterableIterator<Reference>;
-  clean(): void;
 }
 
 export interface ReferenceParseOptions {

--- a/packages/apidom-reference/test/dereference/strategies/openapi-2/json-reference-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-2/json-reference-object/index.ts
@@ -476,7 +476,7 @@ describe('dereference', function () {
             const ex3ParseResult = await parse(ex3URI, { mediaType: 'application/json' });
             const ex3Ref = new Reference({ uri: ex3URI, value: ex3ParseResult });
 
-            const refSet = ReferenceSet({ refs: [rootRef, ex1Ref, ex2Ref, ex3Ref] });
+            const refSet = new ReferenceSet({ refs: [rootRef, ex1Ref, ex2Ref, ex3Ref] });
 
             const actual = await dereference(rootURI, {
               dereference: { refSet },

--- a/packages/apidom-reference/test/dereference/strategies/openapi-2/reference-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-2/reference-object/index.ts
@@ -330,7 +330,7 @@ describe('dereference', function () {
             const ex3ParseResult = await parse(ex3URI, { mediaType: 'application/json' });
             const ex3Ref = new Reference({ uri: ex3URI, value: ex3ParseResult });
 
-            const refSet = ReferenceSet({ refs: [rootRef, ex1Ref, ex2Ref, ex3Ref] });
+            const refSet = new ReferenceSet({ refs: [rootRef, ex1Ref, ex2Ref, ex3Ref] });
 
             const actual = await dereference(rootURI, {
               dereference: { refSet },

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/reference-object/index.ts
@@ -397,7 +397,7 @@ describe('dereference', function () {
             });
             // @ts-ignore
             const referenceElement = parseResult.api?.components.parameters.get('externalRef');
-            const refSet = ReferenceSet();
+            const refSet = new ReferenceSet();
             const rootFileReference = new Reference({ uri, value: parseResult });
             const referenceElementReference = new Reference({
               uri: `${uri}#/single-reference-object`,

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/schema-object/index.ts
@@ -563,7 +563,7 @@ describe('dereference', function () {
             });
             const uri = 'https://example.com/';
             const reference = new Reference({ uri, value: parseResult });
-            const refSet = ReferenceSet({ refs: [reference] });
+            const refSet = new ReferenceSet({ refs: [reference] });
 
             const actual = await dereference(uri, {
               dereference: { refSet },
@@ -707,7 +707,7 @@ describe('dereference', function () {
               });
               const uri = 'https://example.com/';
               const reference = new Reference({ uri, value: parseResult });
-              const refSet = ReferenceSet({ refs: [reference] });
+              const refSet = new ReferenceSet({ refs: [reference] });
 
               const actual = await dereference(uri, {
                 dereference: { refSet },


### PR DESCRIPTION
Refs #3481

BREAKING CHANGE: ReferenceSet from apidom-reference package became a class and requires to be instantiated with new operator.

