### PR TITLE
feat(reference): change parsers from stamps to TypeScript classes

### DIFF
--- a/packages/apidom-reference/src/configuration/saturated.ts
+++ b/packages/apidom-reference/src/configuration/saturated.ts
@@ -5,21 +5,21 @@ import OpenApi3_0ResolveStrategy from '../resolve/strategies/openapi-3-0';
 import OpenApi3_1ResolveStrategy from '../resolve/strategies/openapi-3-1';
 import AsyncApi2ResolveStrategy from '../resolve/strategies/asyncapi-2';
 import ApiDOMResolveStrategy from '../resolve/strategies/apidom';
-import ApiDesignSystemsJsonParser from '../parse/parsers/api-design-systems-json';
-import ApiDesignSystemsYamlParser from '../parse/parsers/api-design-systems-yaml';
-import OpenApiJson2Parser from '../parse/parsers/openapi-json-2';
-import OpenApiYaml2Parser from '../parse/parsers/openapi-yaml-2';
-import OpenApiJson3_0Parser from '../parse/parsers/openapi-json-3-0';
-import OpenApiYaml3_0Parser from '../parse/parsers/openapi-yaml-3-0';
-import OpenApiJson3_1Parser from '../parse/parsers/openapi-json-3-1';
-import OpenApiYaml3_1Parser from '../parse/parsers/openapi-yaml-3-1';
-import AsyncApiJson2Parser from '../parse/parsers/asyncapi-json-2';
-import AsyncApiYaml2Parser from '../parse/parsers/asyncapi-yaml-2';
-import WorkflowsJson1Parser from '../parse/parsers/workflows-json-1';
-import WorkflowsYaml1Parser from '../parse/parsers/workflows-yaml-1';
-import ApiDOMJsonParser from '../parse/parsers/apidom-json';
-import JsonParser from '../parse/parsers/json';
-import YamlParser from '../parse/parsers/yaml-1-2';
+import APIDesignSystemsJSONParser from '../parse/parsers/api-design-systems-json';
+import APIDesignSystemsYAMLParser from '../parse/parsers/api-design-systems-yaml';
+import OpenAPIJSON2Parser from '../parse/parsers/openapi-json-2';
+import OpenAPIYAML2Parser from '../parse/parsers/openapi-yaml-2';
+import OpenAPIJSON3_0Parser from '../parse/parsers/openapi-json-3-0';
+import OpenAPIYAML3_0Parser from '../parse/parsers/openapi-yaml-3-0';
+import OpenAPIJSON3_1Parser from '../parse/parsers/openapi-json-3-1';
+import OpenAPIYAML3_1Parser from '../parse/parsers/openapi-yaml-3-1';
+import AsyncAPIJSON2Parser from '../parse/parsers/asyncapi-json-2';
+import AsyncAPIYAML2Parser from '../parse/parsers/asyncapi-yaml-2';
+import WorkflowsJSON1Parser from '../parse/parsers/workflows-json-1';
+import WorkflowsYAML1Parser from '../parse/parsers/workflows-yaml-1';
+import APIDOMJSONParser from '../parse/parsers/apidom-json';
+import JSONParser from '../parse/parsers/json';
+import YAMLParser from '../parse/parsers/yaml-1-2';
 import BinaryParser from '../parse/parsers/binary/index-node';
 import ApiDOMDereferenceStrategy from '../dereference/strategies/apidom';
 import OpenApi2DereferenceStrategy from '../dereference/strategies/openapi-2';
@@ -30,22 +30,22 @@ import OpenApi3_1BundleStrategy from '../bundle/strategies/openapi-3-1';
 import { options } from '../index';
 
 options.parse.parsers = [
-  OpenApiJson2Parser({ allowEmpty: true, sourceMap: false }),
-  OpenApiYaml2Parser({ allowEmpty: true, sourceMap: false }),
-  OpenApiJson3_0Parser({ allowEmpty: true, sourceMap: false }),
-  OpenApiYaml3_0Parser({ allowEmpty: true, sourceMap: false }),
-  OpenApiJson3_1Parser({ allowEmpty: true, sourceMap: false }),
-  OpenApiYaml3_1Parser({ allowEmpty: true, sourceMap: false }),
-  AsyncApiJson2Parser({ allowEmpty: true, sourceMap: false }),
-  AsyncApiYaml2Parser({ allowEmpty: true, sourceMap: false }),
-  WorkflowsJson1Parser({ allowEmpty: true, sourceMap: false }),
-  WorkflowsYaml1Parser({ allowEmpty: true, sourceMap: false }),
-  ApiDesignSystemsJsonParser({ allowEmpty: true, sourceMap: false }),
-  ApiDesignSystemsYamlParser({ allowEmpty: true, sourceMap: false }),
-  ApiDOMJsonParser({ allowEmpty: true, sourceMap: false }),
-  JsonParser({ allowEmpty: true, sourceMap: false }),
-  YamlParser({ allowEmpty: true, sourceMap: false }),
-  BinaryParser({ allowEmpty: true }),
+  new OpenAPIJSON2Parser({ allowEmpty: true, sourceMap: false }),
+  new OpenAPIYAML2Parser({ allowEmpty: true, sourceMap: false }),
+  new OpenAPIJSON3_0Parser({ allowEmpty: true, sourceMap: false }),
+  new OpenAPIYAML3_0Parser({ allowEmpty: true, sourceMap: false }),
+  new OpenAPIJSON3_1Parser({ allowEmpty: true, sourceMap: false }),
+  new OpenAPIYAML3_1Parser({ allowEmpty: true, sourceMap: false }),
+  new AsyncAPIJSON2Parser({ allowEmpty: true, sourceMap: false }),
+  new AsyncAPIYAML2Parser({ allowEmpty: true, sourceMap: false }),
+  new WorkflowsJSON1Parser({ allowEmpty: true, sourceMap: false }),
+  new WorkflowsYAML1Parser({ allowEmpty: true, sourceMap: false }),
+  new APIDesignSystemsJSONParser({ allowEmpty: true, sourceMap: false }),
+  new APIDesignSystemsYAMLParser({ allowEmpty: true, sourceMap: false }),
+  new APIDOMJSONParser({ allowEmpty: true, sourceMap: false }),
+  new JSONParser({ allowEmpty: true, sourceMap: false }),
+  new YAMLParser({ allowEmpty: true, sourceMap: false }),
+  new BinaryParser({ allowEmpty: true }),
 ];
 
 options.resolve.resolvers = [

--- a/packages/apidom-reference/src/parse/index.ts
+++ b/packages/apidom-reference/src/parse/index.ts
@@ -4,7 +4,8 @@ import { ParseResultElement } from '@swagger-api/apidom-core';
 import * as url from '../util/url';
 import File from '../File';
 import * as plugins from '../util/plugins';
-import { ReferenceOptions as IReferenceOptions, Parser as IParser } from '../types';
+import { ReferenceOptions as IReferenceOptions } from '../types';
+import Parser from './parsers/Parser';
 import ParseError from '../errors/ParseError';
 import UnmatchedResolverError from '../errors/UnmatchedResolverError';
 import { readFile } from '../resolve/util';
@@ -18,7 +19,7 @@ const parseFile = async (file: File, options: IReferenceOptions): Promise<ParseR
     return Object.assign(clonedParser, options.parse.parserOpts);
   });
 
-  const parsers: IParser[] = await plugins.filter('canParse', [file, options], optsBoundParsers);
+  const parsers: Parser[] = await plugins.filter('canParse', [file, options], optsBoundParsers);
 
   // we couldn't find any parser for this File
   if (isEmpty(parsers)) {

--- a/packages/apidom-reference/src/parse/parsers/Parser.ts
+++ b/packages/apidom-reference/src/parse/parsers/Parser.ts
@@ -1,52 +1,54 @@
-import stampit from 'stampit';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { NotImplementedError } from '@swagger-api/apidom-error';
 
-import { Parser as IParser } from '../../types';
+import File from '../../File';
 
-const Parser: stampit.Stamp<IParser> = stampit({
-  props: {
-    name: '',
-    /**
-     * Whether to allow "empty" files. This includes zero-byte files.
-     */
-    allowEmpty: true,
+export interface ParserOptions {
+  readonly name: string;
+  readonly allowEmpty?: boolean;
+  readonly sourceMap?: boolean;
+  readonly fileExtensions?: string[];
+  readonly mediaTypes?: string[];
+}
 
-    /**
-     * Whether to generate source map during parsing.
-     */
-    sourceMap: false,
-    /**
-     * List of supported file extensions.
-     */
-    fileExtensions: [],
-    /**
-     * List of supported media types.
-     */
-    mediaTypes: [],
-  },
-  init(
-    this: IParser,
-    {
-      allowEmpty = this.allowEmpty,
-      sourceMap = this.sourceMap,
-      fileExtensions = this.fileExtensions,
-      mediaTypes = this.mediaTypes,
-    } = {},
-  ) {
+abstract class Parser {
+  public readonly name: string;
+
+  /**
+   * Whether to allow "empty" files. This includes zero-byte files.
+   */
+  public allowEmpty: boolean;
+
+  /**
+   * Whether to generate source map during parsing.
+   */
+  public sourceMap: boolean;
+
+  /**
+   * List of supported file extensions.
+   */
+  public fileExtensions: string[];
+
+  /**
+   * List of supported media types.
+   */
+  public mediaTypes: string[];
+
+  constructor({
+    name,
+    allowEmpty = true,
+    sourceMap = false,
+    fileExtensions = [],
+    mediaTypes = [],
+  }: ParserOptions) {
+    this.name = name;
     this.allowEmpty = allowEmpty;
     this.sourceMap = sourceMap;
     this.fileExtensions = fileExtensions;
     this.mediaTypes = mediaTypes;
-  },
-  methods: {
-    async canParse(): Promise<boolean> {
-      throw new NotImplementedError('canParse method in Parser stamp is not yet implemented.');
-    },
-    async parse(): Promise<ParseResultElement> {
-      throw new NotImplementedError('parse method in Parser stamp is not yet implemented.');
-    },
-  },
-});
+  }
+
+  abstract canParse(file: File): boolean | Promise<boolean>;
+  abstract parse(file: File): ParseResultElement | Promise<ParseResultElement>;
+}
 
 export default Parser;

--- a/packages/apidom-reference/src/parse/parsers/api-design-systems-json/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/api-design-systems-json/index.ts
@@ -1,47 +1,51 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
 import {
   parse,
-  mediaTypes,
+  mediaTypes as ADSMediaTypes,
   detect,
 } from '@swagger-api/apidom-parser-adapter-api-design-systems-json';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-const ApiDesignSystemsJsonParser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'api-design-systems-json',
-    fileExtensions: ['.json'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+export interface APIDesignSystemsJSONParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class APIDesignSystemsJSONParser extends Parser {
+  public syntacticAnalysis?: 'direct' | 'indirect';
 
-      try {
-        const parserOpts = pick(['sourceMap', 'syntacticAnalysis', 'refractorOpts'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  public refractorOpts!: object;
 
-export default ApiDesignSystemsJsonParser;
+  constructor(options?: APIDesignSystemsJSONParserOptions) {
+    const { fileExtensions = ['.json'], mediaTypes = ADSMediaTypes, ...rest } = options ?? {};
+
+    super({ ...rest, name: 'api-design-systems-json', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'syntacticAnalysis', 'refractorOpts'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+
+export default APIDesignSystemsJSONParser;

--- a/packages/apidom-reference/src/parse/parsers/api-design-systems-yaml/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/api-design-systems-yaml/index.ts
@@ -1,47 +1,53 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
 import {
   parse,
-  mediaTypes,
+  mediaTypes as ADSMediaTypes,
   detect,
 } from '@swagger-api/apidom-parser-adapter-api-design-systems-yaml';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-const ApiDesignSystemsYamlParser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'api-design-systems-yaml',
-    fileExtensions: ['.yaml', '.yml'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+export interface APIDesignSystemsYAMLParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class APIDesignSystemsYAMLParser extends Parser {
+  public refractorOpts!: object;
 
-      try {
-        const parserOpts = pick(['sourceMap', 'refractorOpts'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  constructor(options?: APIDesignSystemsYAMLParserOptions) {
+    const {
+      fileExtensions = ['.yaml', '.yml'],
+      mediaTypes = ADSMediaTypes,
+      ...rest
+    } = options ?? {};
 
-export default ApiDesignSystemsYamlParser;
+    super({ ...rest, name: 'api-design-systems-yaml', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'refractorOpts'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+
+export default APIDesignSystemsYAMLParser;

--- a/packages/apidom-reference/src/parse/parsers/apidom-json/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/apidom-json/index.ts
@@ -1,65 +1,74 @@
-import stampit from 'stampit';
 import {
+  Namespace,
   ParseResultElement,
   isParseResultElement,
   namespace as baseNamespace,
 } from '@swagger-api/apidom-core';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-const ApiDOMJsonParser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'apidom-json',
-    fileExtensions: ['.json'],
-    mediaTypes: ['application/vnd.apidom', 'application/vnd.apidom+json'],
-    namespace: baseNamespace,
-  },
-  init({ namespace } = {}) {
-    this.namespace = namespace ?? this.namespace;
-  },
-  methods: {
-    canParse(file: File): boolean {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+export interface ApiDOMJSONParserOptions extends Omit<ParserOptions, 'name'> {
+  readonly namespace?: Namespace;
+}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        try {
-          return this.namespace.fromRefract(JSON.parse(file.toString())) && true;
-        } catch {
-          return false;
-        }
-      }
-      return false;
-    },
-    parse(file: File): ParseResultElement {
-      const source = file.toString();
-      const namespace = this['apidom-json']?.namespace ?? this.namespace;
+class ApiDOMJSONParser extends Parser {
+  public namespace: Namespace;
 
-      // allow empty files
-      if (this.allowEmpty && source.trim() === '') {
-        return new ParseResultElement();
-      }
+  public ['apidom-json']!: { namespace?: Namespace };
 
+  constructor(options?: ApiDOMJSONParserOptions) {
+    const {
+      fileExtensions = ['.json'],
+      mediaTypes = ['application/vnd.apidom', 'application/vnd.apidom+json'],
+      namespace = baseNamespace,
+      ...rest
+    } = options ?? {};
+
+    super({ ...rest, name: 'apidom-json', fileExtensions, mediaTypes });
+    this.namespace = namespace;
+  }
+
+  canParse(file: File): boolean {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
       try {
-        const element = namespace.fromRefract(JSON.parse(source));
-
-        if (!isParseResultElement(element)) {
-          element.classes.push('result');
-          return new ParseResultElement([element]);
-        }
-
-        return element;
-      } catch (error: unknown) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+        return this.namespace.fromRefract(JSON.parse(file.toString())) && true;
+      } catch {
+        return false;
       }
-    },
-  },
-});
+    }
+    return false;
+  }
 
-export default ApiDOMJsonParser;
+  parse(file: File): ParseResultElement {
+    const source = file.toString();
+    const namespace = this['apidom-json']?.namespace ?? this.namespace;
+
+    // allow empty files
+    if (this.allowEmpty && source.trim() === '') {
+      return new ParseResultElement();
+    }
+
+    try {
+      const element = namespace.fromRefract(JSON.parse(source));
+
+      if (!isParseResultElement(element)) {
+        element.classes.push('result');
+        return new ParseResultElement([element]);
+      }
+
+      return element;
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+
+export default ApiDOMJSONParser;

--- a/packages/apidom-reference/src/parse/parsers/asyncapi-json-2/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/asyncapi-json-2/index.ts
@@ -1,43 +1,51 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse, mediaTypes, detect } from '@swagger-api/apidom-parser-adapter-asyncapi-json-2';
+import {
+  parse,
+  mediaTypes as AsyncAPI2MediaTypes,
+  detect,
+} from '@swagger-api/apidom-parser-adapter-asyncapi-json-2';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-const AsyncApiJson2Parser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'asyncapi-json-2',
-    fileExtensions: ['.json'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+export interface AsyncAPIJSON2ParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class AsyncAPIJSON2Parser extends Parser {
+  public syntacticAnalysis?: 'direct' | 'indirect';
 
-      try {
-        const parserOpts = pick(['sourceMap', 'syntacticAnalysis', 'refractorOpts'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  public refractorOpts!: object;
 
-export default AsyncApiJson2Parser;
+  constructor(options?: AsyncAPIJSON2ParserOptions) {
+    const { fileExtensions = ['.json'], mediaTypes = AsyncAPI2MediaTypes, ...rest } = options ?? {};
+
+    super({ ...rest, name: 'asyncapi-json-2', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'syntacticAnalysis', 'refractorOpts'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+
+export default AsyncAPIJSON2Parser;

--- a/packages/apidom-reference/src/parse/parsers/binary/index-browser.ts
+++ b/packages/apidom-reference/src/parse/parsers/binary/index-browser.ts
@@ -1,9 +1,7 @@
-import stampit from 'stampit';
 import { ParseResultElement, StringElement } from '@swagger-api/apidom-core';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
 /**
@@ -11,46 +9,46 @@ import File from '../../../File';
  * as a binary data and will be encoded to Base64 format.
  */
 
-const BinaryParser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'binary',
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+export interface BinaryParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      return hasSupportedFileExtension;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      try {
-        /**
-         * More information about binary strings and btoa function in following link:
-         *   https://developer.mozilla.org/en-US/docs/Web/API/btoa
-         *
-         * @example
-         * ArrayBuffer to base64 conversion:
-         *
-         * const binaryString = String.fromCharCode.apply(null, file.data);
-         * base64String = btoa(binaryString);
-         */
-        const binaryString = unescape(encodeURIComponent(file.toString()));
-        const base64String = btoa(binaryString);
+class BinaryParser extends Parser {
+  constructor(options?: BinaryParserOptions) {
+    super({ ...(options ?? {}), name: 'binary' });
+  }
 
-        const parseResultElement = new ParseResultElement();
+  canParse(file: File): boolean {
+    return this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+  }
 
-        if (base64String.length !== 0) {
-          const base64StringElement = new StringElement(base64String);
-          base64StringElement.classes.push('result');
-          parseResultElement.push(base64StringElement);
-        }
+  // eslint-disable-next-line class-methods-use-this
+  parse(file: File): ParseResultElement {
+    try {
+      /**
+       * More information about binary strings and btoa function in following link:
+       *   https://developer.mozilla.org/en-US/docs/Web/API/btoa
+       *
+       * @example
+       * ArrayBuffer to base64 conversion:
+       *
+       * const binaryString = String.fromCharCode.apply(null, file.data);
+       * base64String = btoa(binaryString);
+       */
+      const binaryString = unescape(encodeURIComponent(file.toString()));
+      const base64String = btoa(binaryString);
 
-        return parseResultElement;
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+      const parseResultElement = new ParseResultElement();
+
+      if (base64String.length !== 0) {
+        const base64StringElement = new StringElement(base64String);
+        base64StringElement.classes.push('result');
+        parseResultElement.push(base64StringElement);
       }
-    },
-  },
-});
+
+      return parseResultElement;
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
 
 export default BinaryParser;

--- a/packages/apidom-reference/src/parse/parsers/binary/index-node.ts
+++ b/packages/apidom-reference/src/parse/parsers/binary/index-node.ts
@@ -1,10 +1,8 @@
 import { Buffer } from '#buffer'; // eslint-disable-line import/order
-import stampit from 'stampit';
 import { ParseResultElement, StringElement } from '@swagger-api/apidom-core';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
 /**
@@ -12,42 +10,42 @@ import File from '../../../File';
  * as a binary data and will be encoded to Base64 format.
  */
 
-const BinaryParser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'binary',
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+export interface BinaryParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      return hasSupportedFileExtension;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      let base64String: string;
+class BinaryParser extends Parser {
+  constructor(options?: BinaryParserOptions) {
+    super({ ...(options ?? {}), name: 'binary' });
+  }
 
-      try {
-        // @ts-ignore
-        base64String = Buffer.from(file.data).toString('base64');
-      } catch {
-        base64String = Buffer.from(file.toString()).toString('base64');
+  canParse(file: File): boolean {
+    return this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  parse(file: File): ParseResultElement {
+    let base64String: string;
+
+    try {
+      type BufferData = Parameters<typeof Buffer.from>[0];
+      base64String = Buffer.from(file.data as BufferData).toString('base64');
+    } catch {
+      base64String = Buffer.from(file.toString()).toString('base64');
+    }
+
+    try {
+      const parseResultElement = new ParseResultElement();
+
+      if (base64String.length !== 0) {
+        const base64StringElement = new StringElement(base64String);
+        base64StringElement.classes.push('result');
+        parseResultElement.push(base64StringElement);
       }
 
-      try {
-        const parseResultElement = new ParseResultElement();
-
-        if (base64String.length !== 0) {
-          const base64StringElement = new StringElement(base64String);
-          base64StringElement.classes.push('result');
-          parseResultElement.push(base64StringElement);
-        }
-
-        return parseResultElement;
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+      return parseResultElement;
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
 
 export default BinaryParser;

--- a/packages/apidom-reference/src/parse/parsers/json/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/json/index.ts
@@ -1,43 +1,49 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse, mediaTypes, detect } from '@swagger-api/apidom-parser-adapter-json';
+import {
+  parse,
+  mediaTypes as JSONMediaTypes,
+  detect,
+} from '@swagger-api/apidom-parser-adapter-json';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-const JsonParser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'json',
-    fileExtensions: ['.json'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+export interface JSONParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class JSONParser extends Parser {
+  public syntacticAnalysis?: 'direct' | 'indirect';
 
-      try {
-        const parserOpts = pick(['sourceMap', 'syntacticAnalysis'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  constructor(options?: JSONParserOptions) {
+    const { fileExtensions = ['.json'], mediaTypes = JSONMediaTypes, ...rest } = options ?? {};
 
-export default JsonParser;
+    super({ ...rest, name: 'json', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'syntacticAnalysis'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+
+export default JSONParser;

--- a/packages/apidom-reference/src/parse/parsers/openapi-json-2/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/openapi-json-2/index.ts
@@ -1,43 +1,51 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse, mediaTypes, detect } from '@swagger-api/apidom-parser-adapter-openapi-json-2';
+import {
+  parse,
+  mediaTypes as OpenAPI2MediaTypes,
+  detect,
+} from '@swagger-api/apidom-parser-adapter-openapi-json-2';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-const OpenApiJson2Parser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'openapi-json-2',
-    fileExtensions: ['.json'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+export interface OpenAPIJSON2ParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class OpenAPIJSON2Parser extends Parser {
+  public syntacticAnalysis?: 'direct' | 'indirect';
 
-      try {
-        const parserOpts = pick(['sourceMap', 'syntacticAnalysis', 'refractorOpts'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  public refractorOpts!: object;
 
-export default OpenApiJson2Parser;
+  constructor(options?: OpenAPIJSON2ParserOptions) {
+    const { fileExtensions = ['.json'], mediaTypes = OpenAPI2MediaTypes, ...rest } = options ?? {};
+
+    super({ ...rest, name: 'openapi-json-2', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'syntacticAnalysis', 'refractorOpts'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+
+export default OpenAPIJSON2Parser;

--- a/packages/apidom-reference/src/parse/parsers/openapi-json-3-1/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/openapi-json-3-1/index.ts
@@ -1,44 +1,57 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse, mediaTypes, detect } from '@swagger-api/apidom-parser-adapter-openapi-json-3-1';
+import {
+  parse,
+  mediaTypes as OpenAPI3_1MediaTypes,
+  detect,
+} from '@swagger-api/apidom-parser-adapter-openapi-json-3-1';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const OpenApiJson3_1Parser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'openapi-json-3-1',
-    fileExtensions: ['.json'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface OpenAPIJSON3_1ParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class OpenAPIJSON3_1Parser extends Parser {
+  public syntacticAnalysis?: 'direct' | 'indirect';
 
-      try {
-        const parserOpts = pick(['sourceMap', 'syntacticAnalysis', 'refractorOpts'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  public refractorOpts!: object;
 
-export default OpenApiJson3_1Parser;
+  constructor(options?: OpenAPIJSON3_1ParserOptions) {
+    const {
+      fileExtensions = ['.json'],
+      mediaTypes = OpenAPI3_1MediaTypes,
+      ...rest
+    } = options ?? {};
+
+    super({ ...rest, name: 'openapi-json-3-1', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'syntacticAnalysis', 'refractorOpts'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export default OpenAPIJSON3_1Parser;

--- a/packages/apidom-reference/src/parse/parsers/openapi-yaml-2/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/openapi-yaml-2/index.ts
@@ -1,43 +1,53 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse, mediaTypes, detect } from '@swagger-api/apidom-parser-adapter-openapi-yaml-2';
+import {
+  parse,
+  mediaTypes as OpenAPIYAML2MediaTypes,
+  detect,
+} from '@swagger-api/apidom-parser-adapter-openapi-yaml-2';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-const OpenApiYaml2Parser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'openapi-yaml-2',
-    fileExtensions: ['.yaml', '.yml'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+export interface OpenAPIYAML2ParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class OpenAPIYAML2Parser extends Parser {
+  public refractorOpts!: object;
 
-      try {
-        const parserOpts = pick(['sourceMap', 'refractorOpts'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  constructor(options?: OpenAPIYAML2ParserOptions) {
+    const {
+      fileExtensions = ['.yaml', '.yml'],
+      mediaTypes = OpenAPIYAML2MediaTypes,
+      ...rest
+    } = options ?? {};
 
-export default OpenApiYaml2Parser;
+    super({ ...rest, name: 'openapi-yaml-2', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'refractorOpts'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+
+export default OpenAPIYAML2Parser;

--- a/packages/apidom-reference/src/parse/parsers/openapi-yaml-3-0/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/openapi-yaml-3-0/index.ts
@@ -1,44 +1,55 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse, mediaTypes, detect } from '@swagger-api/apidom-parser-adapter-openapi-yaml-3-0';
+import {
+  parse,
+  mediaTypes as OpenAPIYAML3_0MediaTypes,
+  detect,
+} from '@swagger-api/apidom-parser-adapter-openapi-yaml-3-0';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const OpenApiYaml3_0Parser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'openapi-yaml-3-0',
-    fileExtensions: ['.yaml', '.yml'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface OpenAPIYAML3_0ParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class OpenAPIYAML3_0Parser extends Parser {
+  public refractorOpts!: object;
 
-      try {
-        const parserOpts = pick(['sourceMap', 'refractorOpts'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  constructor(options?: OpenAPIYAML3_0ParserOptions) {
+    const {
+      fileExtensions = ['.yaml', '.yml'],
+      mediaTypes = OpenAPIYAML3_0MediaTypes,
+      ...rest
+    } = options ?? {};
 
-export default OpenApiYaml3_0Parser;
+    super({ ...rest, name: 'openapi-yaml-3-0', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'refractorOpts'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export default OpenAPIYAML3_0Parser;

--- a/packages/apidom-reference/src/parse/parsers/openapi-yaml-3-1/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/openapi-yaml-3-1/index.ts
@@ -1,44 +1,55 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse, mediaTypes, detect } from '@swagger-api/apidom-parser-adapter-openapi-yaml-3-1';
+import {
+  parse,
+  mediaTypes as OpenAPIYAML3_1MediaTypes,
+  detect,
+} from '@swagger-api/apidom-parser-adapter-openapi-yaml-3-1';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const OpenApiYaml3_1Parser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'openapi-yaml-3-1',
-    fileExtensions: ['.yaml', '.yml'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface OpenAPIYAML3_1ParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class OpenAPIYAML3_1Parser extends Parser {
+  public refractorOpts!: object;
 
-      try {
-        const parserOpts = pick(['sourceMap', 'refractorOpts'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  constructor(options?: OpenAPIYAML3_1ParserOptions) {
+    const {
+      fileExtensions = ['.yaml', '.yml'],
+      mediaTypes = OpenAPIYAML3_1MediaTypes,
+      ...rest
+    } = options ?? {};
 
-export default OpenApiYaml3_1Parser;
+    super({ ...rest, name: 'openapi-yaml-3-1', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'refractorOpts'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export default OpenAPIYAML3_1Parser;

--- a/packages/apidom-reference/src/parse/parsers/workflows-json-1/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/workflows-json-1/index.ts
@@ -1,43 +1,55 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse, mediaTypes, detect } from '@swagger-api/apidom-parser-adapter-workflows-json-1';
+import {
+  parse,
+  mediaTypes as Workflows1MediaTypes,
+  detect,
+} from '@swagger-api/apidom-parser-adapter-workflows-json-1';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-const WorkflowsJson1Parser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'workflows-json-1',
-    fileExtensions: ['.json'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+export interface WorkflowsJSON1ParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class WorkflowsJSON1Parser extends Parser {
+  public syntacticAnalysis?: 'direct' | 'indirect';
 
-      try {
-        const parserOpts = pick(['sourceMap', 'syntacticAnalysis', 'refractorOpts'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  public refractorOpts!: object;
 
-export default WorkflowsJson1Parser;
+  constructor(options?: WorkflowsJSON1ParserOptions) {
+    const {
+      fileExtensions = ['.json'],
+      mediaTypes = Workflows1MediaTypes,
+      ...rest
+    } = options ?? {};
+
+    super({ ...rest, name: 'workflows-json-1', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'syntacticAnalysis', 'refractorOpts'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+
+export default WorkflowsJSON1Parser;

--- a/packages/apidom-reference/src/parse/parsers/workflows-yaml-1/index.ts
+++ b/packages/apidom-reference/src/parse/parsers/workflows-yaml-1/index.ts
@@ -1,43 +1,53 @@
-import stampit from 'stampit';
 import { pick } from 'ramda';
 import { ParseResultElement } from '@swagger-api/apidom-core';
-import { parse, mediaTypes, detect } from '@swagger-api/apidom-parser-adapter-workflows-yaml-1';
+import {
+  parse,
+  mediaTypes as WorkflowsYAML1MediaTypes,
+  detect,
+} from '@swagger-api/apidom-parser-adapter-workflows-yaml-1';
 
 import ParserError from '../../../errors/ParserError';
-import { Parser as IParser } from '../../../types';
-import Parser from '../Parser';
+import Parser, { ParserOptions } from '../Parser';
 import File from '../../../File';
 
-const WorkflowsYaml1Parser: stampit.Stamp<IParser> = stampit(Parser, {
-  props: {
-    name: 'workflows-yaml-1',
-    fileExtensions: ['.yaml', '.yml'],
-    mediaTypes,
-  },
-  methods: {
-    async canParse(file: File): Promise<boolean> {
-      const hasSupportedFileExtension =
-        this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
-      const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+export interface WorkflowsYAML1ParserOptions extends Omit<ParserOptions, 'name'> {}
 
-      if (!hasSupportedFileExtension) return false;
-      if (hasSupportedMediaType) return true;
-      if (!hasSupportedMediaType) {
-        return detect(file.toString());
-      }
-      return false;
-    },
-    async parse(file: File): Promise<ParseResultElement> {
-      const source = file.toString();
+class WorkflowsYAML1Parser extends Parser {
+  public refractorOpts!: object;
 
-      try {
-        const parserOpts = pick(['sourceMap', 'refractorOpts'], this);
-        return await parse(source, parserOpts);
-      } catch (error: any) {
-        throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
-      }
-    },
-  },
-});
+  constructor(options?: WorkflowsYAML1ParserOptions) {
+    const {
+      fileExtensions = ['.yaml', '.yml'],
+      mediaTypes = WorkflowsYAML1MediaTypes,
+      ...rest
+    } = options ?? {};
 
-export default WorkflowsYaml1Parser;
+    super({ ...rest, name: 'workflows-yaml-1', fileExtensions, mediaTypes });
+  }
+
+  async canParse(file: File): Promise<boolean> {
+    const hasSupportedFileExtension =
+      this.fileExtensions.length === 0 ? true : this.fileExtensions.includes(file.extension);
+    const hasSupportedMediaType = this.mediaTypes.includes(file.mediaType);
+
+    if (!hasSupportedFileExtension) return false;
+    if (hasSupportedMediaType) return true;
+    if (!hasSupportedMediaType) {
+      return detect(file.toString());
+    }
+    return false;
+  }
+
+  async parse(file: File): Promise<ParseResultElement> {
+    const source = file.toString();
+
+    try {
+      const parserOpts = pick(['sourceMap', 'refractorOpts'], this);
+      return await parse(source, parserOpts);
+    } catch (error: unknown) {
+      throw new ParserError(`Error parsing "${file.uri}"`, { cause: error });
+    }
+  }
+}
+
+export default WorkflowsYAML1Parser;

--- a/packages/apidom-reference/src/types.ts
+++ b/packages/apidom-reference/src/types.ts
@@ -1,20 +1,9 @@
-import { Element, ParseResultElement, RefElement } from '@swagger-api/apidom-core';
+import { Element, RefElement } from '@swagger-api/apidom-core';
 
 import type File from './File';
 import type ReferenceSet from './ReferenceSet';
 import type Resolver from './resolve/resolvers/Resolver';
-
-export interface Parser {
-  // name: string; - causing issues with stamps
-  allowEmpty: boolean;
-  sourceMap: boolean;
-  fileExtensions: string[];
-  mediaTypes: string[];
-  decoder: TextDecoder;
-
-  canParse(file: File): boolean | Promise<boolean>;
-  parse(file: File): Promise<ParseResultElement>;
-}
+import type Parser from './parse/parsers/Parser';
 
 export interface ResolveStrategy {
   canResolve(file: File): boolean;

--- a/packages/apidom-reference/test/parse/index.ts
+++ b/packages/apidom-reference/test/parse/index.ts
@@ -10,7 +10,7 @@ import parse from '../../src/parse';
 import ParseError from '../../src/errors/ParseError';
 import ResolveError from '../../src/errors/ResolveError';
 import UnmatchedResolverError from '../../src/errors/UnmatchedResolverError';
-import OpenApiJson3_1Parser from '../../src/parse/parsers/openapi-json-3-1';
+import OpenAPIJSON3_1Parser from '../../src/parse/parsers/openapi-json-3-1';
 
 describe('parse', function () {
   context('given URI with hash', function () {
@@ -108,7 +108,7 @@ describe('parse', function () {
       const options = mergeOptions(defaultOptions, {
         parse: {
           mediaType: mediaTypes.latest('json'),
-          parsers: [OpenApiJson3_1Parser({ allowEmpty: false })],
+          parsers: [new OpenAPIJSON3_1Parser({ allowEmpty: false })],
         },
       });
 

--- a/packages/apidom-reference/test/parse/parsers/api-design-systems-json/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/api-design-systems-json/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-api-design-systems-json';
 
 import File from '../../../../src/File';
-import ApiDesignSystemsJsonParser from '../../../../src/parse/parsers/api-design-systems-json';
+import APIDesignSystemsJSONParser from '../../../../src/parse/parsers/api-design-systems-json';
 
 describe('parsers', function () {
-  context('ApiDesignSystemsJsonParser', function () {
+  context('APIDesignSystemsJSONParser', function () {
     context('canParse', function () {
       context('given file with .json extension', function () {
         context('and with proper media type', function () {
@@ -23,7 +23,7 @@ describe('parsers', function () {
               mediaType: mediaTypes.latest(),
               data: '{"version": "2021-05-07"}',
             });
-            const parser = ApiDesignSystemsJsonParser();
+            const parser = new APIDesignSystemsJSONParser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -36,7 +36,7 @@ describe('parsers', function () {
               uri: '/path/to/api-design-systems.json',
               mediaType: 'application/vnd.oai.openapi+json;version=3.1.0',
             });
-            const parser = ApiDesignSystemsJsonParser();
+            const parser = new APIDesignSystemsJSONParser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -49,7 +49,7 @@ describe('parsers', function () {
             uri: '/path/to/api-design-systems.yaml',
             mediaType: mediaTypes.latest(),
           });
-          const parser = ApiDesignSystemsJsonParser();
+          const parser = new APIDesignSystemsJSONParser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -61,7 +61,7 @@ describe('parsers', function () {
             uri: '/path/to/api-design-systems',
             mediaType: mediaTypes.latest(),
           });
-          const parser = ApiDesignSystemsJsonParser();
+          const parser = new APIDesignSystemsJSONParser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -75,7 +75,7 @@ describe('parsers', function () {
               uri: '/path/to/api-design-systems.json',
               data: fs.readFileSync(url),
             });
-            const parser = ApiDesignSystemsJsonParser();
+            const parser = new APIDesignSystemsJSONParser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -88,7 +88,7 @@ describe('parsers', function () {
               uri: '/path/to/api-design-systems.json',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = ApiDesignSystemsJsonParser();
+            const parser = new APIDesignSystemsJSONParser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -106,7 +106,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = ApiDesignSystemsJsonParser();
+          const parser = new APIDesignSystemsJSONParser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -122,7 +122,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = ApiDesignSystemsJsonParser();
+          const parser = new APIDesignSystemsJSONParser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -136,7 +136,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest(),
           });
-          const parser = ApiDesignSystemsJsonParser();
+          const parser = new APIDesignSystemsJSONParser();
           const parseResult = await parser.parse(file);
           const numberElement: NumberElement = parseResult.get(0);
 
@@ -152,7 +152,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest(),
           });
-          const parser = ApiDesignSystemsJsonParser();
+          const parser = new APIDesignSystemsJSONParser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -170,7 +170,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest(),
             });
-            const parser = ApiDesignSystemsJsonParser({ sourceMap: true });
+            const parser = new APIDesignSystemsJSONParser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.result?.meta.get('sourceMap')));
@@ -186,7 +186,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest(),
             });
-            const parser = ApiDesignSystemsJsonParser({ sourceMap: false });
+            const parser = new APIDesignSystemsJSONParser({ sourceMap: false });
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/api-design-systems-yaml/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/api-design-systems-yaml/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-api-design-systems-yaml';
 
 import File from '../../../../src/File';
-import ApiDesignSystemsYamlParser from '../../../../src/parse/parsers/api-design-systems-yaml';
+import APIDesignSystemsYAMLParser from '../../../../src/parse/parsers/api-design-systems-yaml';
 
 describe('parsers', function () {
-  context('ApiDesignSystemsYamlParser', function () {
+  context('APIDesignSystemsYAMLParser', function () {
     context('canParse', function () {
       context('given file with .yaml extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/api-design-systems.yaml',
               mediaType: mediaTypes.latest(),
             });
-            const parser = ApiDesignSystemsYamlParser();
+            const parser = new APIDesignSystemsYAMLParser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/api-design-systems.yaml',
               mediaType: 'application/vnd.oai.openapi+json;version=3.1.0',
             });
-            const parser = ApiDesignSystemsYamlParser();
+            const parser = new APIDesignSystemsYAMLParser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -52,7 +52,7 @@ describe('parsers', function () {
               uri: '/path/to/api-design-systems.yml',
               mediaType: mediaTypes.latest(),
             });
-            const parser = ApiDesignSystemsYamlParser();
+            const parser = new APIDesignSystemsYAMLParser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -65,7 +65,7 @@ describe('parsers', function () {
               uri: '/path/to/api-design-systems.yaml',
               mediaType: 'application/vnd.oai.openapi+json;version=3.1.0',
             });
-            const parser = ApiDesignSystemsYamlParser();
+            const parser = new APIDesignSystemsYAMLParser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -78,7 +78,7 @@ describe('parsers', function () {
             uri: '/path/to/api-design-systems.txt',
             mediaType: mediaTypes.latest(),
           });
-          const parser = ApiDesignSystemsYamlParser();
+          const parser = new APIDesignSystemsYAMLParser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -90,7 +90,7 @@ describe('parsers', function () {
             uri: '/path/to/api-design-systems',
             mediaType: mediaTypes.latest(),
           });
-          const parser = ApiDesignSystemsYamlParser();
+          const parser = new APIDesignSystemsYAMLParser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -104,7 +104,7 @@ describe('parsers', function () {
               uri: '/path/to/api-design-systems.yaml',
               data: fs.readFileSync(url),
             });
-            const parser = ApiDesignSystemsYamlParser();
+            const parser = new APIDesignSystemsYAMLParser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -117,7 +117,7 @@ describe('parsers', function () {
               uri: '/path/to/api-design-systems.yaml',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = ApiDesignSystemsYamlParser();
+            const parser = new APIDesignSystemsYAMLParser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -131,7 +131,7 @@ describe('parsers', function () {
           const uri = path.join(__dirname, 'fixtures', 'api-design-systems.yaml');
           const data = fs.readFileSync(uri).toString();
           const file = new File({ uri, data, mediaType: mediaTypes.latest() });
-          const parser = ApiDesignSystemsYamlParser();
+          const parser = new APIDesignSystemsYAMLParser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -143,7 +143,7 @@ describe('parsers', function () {
           const uri = path.join(__dirname, 'fixtures', 'api-design-systems.yaml');
           const data = fs.readFileSync(uri);
           const file = new File({ uri, data, mediaType: mediaTypes.latest() });
-          const parser = ApiDesignSystemsYamlParser();
+          const parser = new APIDesignSystemsYAMLParser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -157,7 +157,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest(),
           });
-          const parser = ApiDesignSystemsYamlParser();
+          const parser = new APIDesignSystemsYAMLParser();
           const parseResult = await parser.parse(file);
           const numberElement: NumberElement = parseResult.get(0);
 
@@ -173,7 +173,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest(),
           });
-          const parser = ApiDesignSystemsYamlParser();
+          const parser = new APIDesignSystemsYAMLParser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -191,7 +191,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest(),
             });
-            const parser = ApiDesignSystemsYamlParser({ sourceMap: true });
+            const parser = new APIDesignSystemsYAMLParser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.result?.meta.get('sourceMap')));
@@ -207,7 +207,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest(),
             });
-            const parser = ApiDesignSystemsYamlParser({ sourceMap: false });
+            const parser = new APIDesignSystemsYAMLParser({ sourceMap: false });
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.result?.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/apidom-json/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/apidom-json/index.ts
@@ -4,10 +4,10 @@ import { assert } from 'chai';
 import { isParseResultElement } from '@swagger-api/apidom-core';
 
 import { ParserError, File } from '../../../../src';
-import ApiDOMJsonParser from '../../../../src/parse/parsers/apidom-json';
+import ApiDOMJSONParser from '../../../../src/parse/parsers/apidom-json';
 
 describe('parsers', function () {
-  context('ApiDOMJsonParser', function () {
+  context('ApiDOMJSONParser', function () {
     context('canParse', function () {
       context('given file with .json extension', function () {
         context('and with proper media type', function () {
@@ -20,7 +20,7 @@ describe('parsers', function () {
               uri: '/path/to/apidom.json',
               mediaType: 'application/vnd.apidom+json',
             });
-            const parser = ApiDOMJsonParser();
+            const parser = new ApiDOMJSONParser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -33,7 +33,7 @@ describe('parsers', function () {
               uri: '/path/to/apidom.json',
               mediaType: 'application/vnd.aai.asyncapi+json;version=2.6.0',
             });
-            const parser = ApiDOMJsonParser();
+            const parser = new ApiDOMJSONParser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -46,7 +46,7 @@ describe('parsers', function () {
             uri: '/path/to/apidom.yaml',
             mediaType: 'application/vnd.apidom',
           });
-          const parser = ApiDOMJsonParser();
+          const parser = new ApiDOMJSONParser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -58,7 +58,7 @@ describe('parsers', function () {
             uri: '/path/to/apidom',
             mediaType: 'application/vnd.apidom',
           });
-          const parser = ApiDOMJsonParser();
+          const parser = new ApiDOMJSONParser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -72,7 +72,7 @@ describe('parsers', function () {
               uri: '/path/to/apidom.json',
               data: fs.readFileSync(url),
             });
-            const parser = ApiDOMJsonParser();
+            const parser = new ApiDOMJSONParser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -85,7 +85,7 @@ describe('parsers', function () {
               uri: '/path/to/apidom.json',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = ApiDOMJsonParser();
+            const parser = new ApiDOMJSONParser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -103,7 +103,7 @@ describe('parsers', function () {
             data,
             mediaType: 'application/vnd.apidom+json',
           });
-          const parser = ApiDOMJsonParser();
+          const parser = new ApiDOMJSONParser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -119,7 +119,7 @@ describe('parsers', function () {
             data,
             mediaType: 'application/vnd.apidom+json',
           });
-          const parser = ApiDOMJsonParser();
+          const parser = new ApiDOMJSONParser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -133,7 +133,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: 'application/vnd.apidom+json',
           });
-          const parser = ApiDOMJsonParser();
+          const parser = new ApiDOMJSONParser();
 
           try {
             await parser.parse(file);
@@ -151,7 +151,7 @@ describe('parsers', function () {
             data: '',
             mediaType: 'application/vnd.apidom+json',
           });
-          const parser = ApiDOMJsonParser();
+          const parser = new ApiDOMJSONParser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));

--- a/packages/apidom-reference/test/parse/parsers/asyncapi-json-2/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/asyncapi-json-2/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-asyncapi-json-2';
 
 import File from '../../../../src/File';
-import AsyncApiJson2Parser from '../../../../src/parse/parsers/asyncapi-json-2';
+import AsyncAPIJSON2Parser from '../../../../src/parse/parsers/asyncapi-json-2';
 
 describe('parsers', function () {
-  context('AsyncApiJson2Parser', function () {
+  context('AsyncAPIJSON2Parser', function () {
     context('canParse', function () {
       context('given file with .json extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/asyncapi.json',
               mediaType: mediaTypes.latest(),
             });
-            const parser = AsyncApiJson2Parser();
+            const parser = new AsyncAPIJSON2Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/asyncapi.json',
               mediaType: 'application/vnd.oai.openapi+json;version=3.1.0',
             });
-            const parser = AsyncApiJson2Parser();
+            const parser = new AsyncAPIJSON2Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -47,7 +47,7 @@ describe('parsers', function () {
             uri: '/path/to/asyncapi.yaml',
             mediaType: mediaTypes.latest(),
           });
-          const parser = AsyncApiJson2Parser();
+          const parser = new AsyncAPIJSON2Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -59,7 +59,7 @@ describe('parsers', function () {
             uri: '/path/to/asyncapi',
             mediaType: mediaTypes.latest(),
           });
-          const parser = AsyncApiJson2Parser();
+          const parser = new AsyncAPIJSON2Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -73,7 +73,7 @@ describe('parsers', function () {
               uri: '/path/to/async-api.json',
               data: fs.readFileSync(url),
             });
-            const parser = AsyncApiJson2Parser();
+            const parser = new AsyncAPIJSON2Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -86,7 +86,7 @@ describe('parsers', function () {
               uri: '/path/to/async-api.json',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = AsyncApiJson2Parser();
+            const parser = new AsyncAPIJSON2Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -104,7 +104,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = AsyncApiJson2Parser();
+          const parser = new AsyncAPIJSON2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -120,7 +120,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = AsyncApiJson2Parser();
+          const parser = new AsyncAPIJSON2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -134,7 +134,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest(),
           });
-          const parser = AsyncApiJson2Parser();
+          const parser = new AsyncAPIJSON2Parser();
           const parseResult = await parser.parse(file);
           const numberElement: NumberElement = parseResult.get(0);
 
@@ -150,7 +150,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest(),
           });
-          const parser = AsyncApiJson2Parser();
+          const parser = new AsyncAPIJSON2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -168,7 +168,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest(),
             });
-            const parser = AsyncApiJson2Parser({ sourceMap: true });
+            const parser = new AsyncAPIJSON2Parser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.api?.meta.get('sourceMap')));
@@ -184,7 +184,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest(),
             });
-            const parser = AsyncApiJson2Parser({ sourceMap: false });
+            const parser = new AsyncAPIJSON2Parser({ sourceMap: false });
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/asyncapi-yaml-2/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/asyncapi-yaml-2/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-asyncapi-yaml-2';
 
 import File from '../../../../src/File';
-import AsyncApiYaml2Parser from '../../../../src/parse/parsers/asyncapi-yaml-2';
+import AsyncAPIYAML2Parser from '../../../../src/parse/parsers/asyncapi-yaml-2';
 
 describe('parsers', function () {
-  context('AsyncApiYaml2Parser', function () {
+  context('AsyncAPIYAML2Parser', function () {
     context('canParse', function () {
       context('given file with .yaml extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/asyncapi.yaml',
               mediaType: mediaTypes.latest(),
             });
-            const parser = AsyncApiYaml2Parser();
+            const parser = new AsyncAPIYAML2Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/asyncapi.yaml',
               mediaType: 'application/vnd.oai.openapi+json;version=3.1.0',
             });
-            const parser = AsyncApiYaml2Parser();
+            const parser = new AsyncAPIYAML2Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -52,7 +52,7 @@ describe('parsers', function () {
               uri: '/path/to/asyncapi.yml',
               mediaType: mediaTypes.latest(),
             });
-            const parser = AsyncApiYaml2Parser();
+            const parser = new AsyncAPIYAML2Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -65,7 +65,7 @@ describe('parsers', function () {
               uri: '/path/to/asyncapi.yaml',
               mediaType: 'application/vnd.oai.openapi+json;version=3.1.0',
             });
-            const parser = AsyncApiYaml2Parser();
+            const parser = new AsyncAPIYAML2Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -78,7 +78,7 @@ describe('parsers', function () {
             uri: '/path/to/asyncapi.txt',
             mediaType: mediaTypes.latest(),
           });
-          const parser = AsyncApiYaml2Parser();
+          const parser = new AsyncAPIYAML2Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -90,7 +90,7 @@ describe('parsers', function () {
             uri: '/path/to/asyncapi',
             mediaType: mediaTypes.latest(),
           });
-          const parser = AsyncApiYaml2Parser();
+          const parser = new AsyncAPIYAML2Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -104,7 +104,7 @@ describe('parsers', function () {
               uri: '/path/to/async-api.yaml',
               data: fs.readFileSync(url),
             });
-            const parser = AsyncApiYaml2Parser();
+            const parser = new AsyncAPIYAML2Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -117,7 +117,7 @@ describe('parsers', function () {
               uri: '/path/to/async-api.yaml',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = AsyncApiYaml2Parser();
+            const parser = new AsyncAPIYAML2Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -131,7 +131,7 @@ describe('parsers', function () {
           const uri = path.join(__dirname, 'fixtures', 'sample-api.yaml');
           const data = fs.readFileSync(uri).toString();
           const file = new File({ uri, data, mediaType: mediaTypes.latest() });
-          const parser = AsyncApiYaml2Parser();
+          const parser = new AsyncAPIYAML2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -143,7 +143,7 @@ describe('parsers', function () {
           const uri = path.join(__dirname, 'fixtures', 'sample-api.yaml');
           const data = fs.readFileSync(uri);
           const file = new File({ uri, data, mediaType: mediaTypes.latest() });
-          const parser = AsyncApiYaml2Parser();
+          const parser = new AsyncAPIYAML2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -157,7 +157,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest(),
           });
-          const parser = AsyncApiYaml2Parser();
+          const parser = new AsyncAPIYAML2Parser();
           const parseResult = await parser.parse(file);
           const numberElement: NumberElement = parseResult.get(0);
 
@@ -173,7 +173,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest(),
           });
-          const parser = AsyncApiYaml2Parser();
+          const parser = new AsyncAPIYAML2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -191,7 +191,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest(),
             });
-            const parser = AsyncApiYaml2Parser({ sourceMap: true });
+            const parser = new AsyncAPIYAML2Parser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.api?.meta.get('sourceMap')));
@@ -207,7 +207,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest(),
             });
-            const parser = AsyncApiYaml2Parser({ sourceMap: false });
+            const parser = new AsyncAPIYAML2Parser({ sourceMap: false });
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.api?.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/binary/index-browser.ts
+++ b/packages/apidom-reference/test/parse/parsers/binary/index-browser.ts
@@ -13,7 +13,7 @@ describe('parsers', function () {
       context('given file with .bin extension', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: textEncoder.encode('data') });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -22,7 +22,7 @@ describe('parsers', function () {
       context('given file with unknown extension', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: textEncoder.encode('data') });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -31,7 +31,7 @@ describe('parsers', function () {
       context('given file with no extension', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file', data: textEncoder.encode('data') });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -40,7 +40,7 @@ describe('parsers', function () {
       context('given file with string data', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: 'data' });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -49,7 +49,7 @@ describe('parsers', function () {
       context('given file with no data', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: '' });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -60,7 +60,7 @@ describe('parsers', function () {
       context('given string data', function () {
         specify('should return parse result', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: 'data' });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
           const result = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(result));
@@ -72,7 +72,7 @@ describe('parsers', function () {
       context('given generic JSON data as buffer', function () {
         specify('should return parse result', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: textEncoder.encode('data') });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
           const result = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(result));
@@ -85,7 +85,7 @@ describe('parsers', function () {
       context('given data that is not recognized', function () {
         specify('should coerce to string and parse', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: 1 as any });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
           const result = await parser.parse(file);
           const stringElement: StringElement = result.get(0);
 
@@ -98,7 +98,7 @@ describe('parsers', function () {
         context('given allowEmpty enabled and empty file provided', function () {
           specify('should return empty parse result', async function () {
             const file = new File({ uri: '/path/to/file.json', data: '' });
-            const parser = BinaryParser({ allowEmpty: true });
+            const parser = new BinaryParser({ allowEmpty: true });
             const result = await parser.parse(file);
 
             assert.isTrue(isParseResultElement(result));
@@ -109,7 +109,7 @@ describe('parsers', function () {
         context('given allowEmpty disabled and empty file provided', function () {
           specify('should return empty parse result', async function () {
             const file = new File({ uri: '/path/to/file.json', data: '' });
-            const parser = BinaryParser({ allowEmpty: false });
+            const parser = new BinaryParser({ allowEmpty: false });
             const result = await parser.parse(file);
 
             assert.isTrue(isParseResultElement(result));

--- a/packages/apidom-reference/test/parse/parsers/binary/index-node.ts
+++ b/packages/apidom-reference/test/parse/parsers/binary/index-node.ts
@@ -11,7 +11,7 @@ describe('parsers', function () {
       context('given file with .bin extension', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: Buffer.from('data') });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -20,7 +20,7 @@ describe('parsers', function () {
       context('given file with unknown extension', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: Buffer.from('data') });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -29,7 +29,7 @@ describe('parsers', function () {
       context('given file with no extension', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file', data: Buffer.from('data') });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -38,7 +38,7 @@ describe('parsers', function () {
       context('given file with string data', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: 'data' });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -47,7 +47,7 @@ describe('parsers', function () {
       context('given file with no data', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: '' });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -58,7 +58,7 @@ describe('parsers', function () {
       context('given string data', function () {
         specify('should return parse result', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: 'data' });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
           const result = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(result));
@@ -70,7 +70,7 @@ describe('parsers', function () {
       context('given generic JSON data as buffer', function () {
         specify('should return parse result', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: Buffer.from('data') });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
           const result = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(result));
@@ -82,7 +82,7 @@ describe('parsers', function () {
       context('given data that is not recognized', function () {
         specify('should coerce to string and parse', async function () {
           const file = new File({ uri: '/path/to/file.bin', data: 1 as any });
-          const parser = BinaryParser();
+          const parser = new BinaryParser();
           const result = await parser.parse(file);
           const stringElement: StringElement = result.get(0);
 
@@ -95,7 +95,7 @@ describe('parsers', function () {
         context('given allowEmpty enabled and empty file provided', function () {
           specify('should return empty parse result', async function () {
             const file = new File({ uri: '/path/to/file.json', data: '' });
-            const parser = BinaryParser({ allowEmpty: true });
+            const parser = new BinaryParser({ allowEmpty: true });
             const result = await parser.parse(file);
 
             assert.isTrue(isParseResultElement(result));
@@ -106,7 +106,7 @@ describe('parsers', function () {
         context('given allowEmpty disabled and empty file provided', function () {
           specify('should return empty parse result', async function () {
             const file = new File({ uri: '/path/to/file.json', data: '' });
-            const parser = BinaryParser({ allowEmpty: false });
+            const parser = new BinaryParser({ allowEmpty: false });
             const result = await parser.parse(file);
 
             assert.isTrue(isParseResultElement(result));

--- a/packages/apidom-reference/test/parse/parsers/json/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/json/index.ts
@@ -8,15 +8,15 @@ import {
 } from '@swagger-api/apidom-core';
 
 import File from '../../../../src/File';
-import JsonParser from '../../../../src/parse/parsers/json';
+import JSONParser from '../../../../src/parse/parsers/json';
 
 describe('parsers', function () {
-  context('JsonParser', function () {
+  context('JSONParser', function () {
     context('canParse', function () {
       context('given file with .json extension', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.json', data: '{"a":"b"}' });
-          const parser = JsonParser();
+          const parser = new JSONParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -25,7 +25,7 @@ describe('parsers', function () {
       context('given file with unknown extension', function () {
         specify('should return false', async function () {
           const file = new File({ uri: '/path/to/file.yaml' });
-          const parser = JsonParser();
+          const parser = new JSONParser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -34,7 +34,7 @@ describe('parsers', function () {
       context('given file with no extension', function () {
         specify('should return false', async function () {
           const file = new File({ uri: '/path/to/file' });
-          const parser = JsonParser();
+          const parser = new JSONParser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -47,7 +47,7 @@ describe('parsers', function () {
               uri: '/path/to/json-file.json',
               data: Buffer.from('{"a":"b"}'),
             });
-            const parser = JsonParser();
+            const parser = new JSONParser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -59,7 +59,7 @@ describe('parsers', function () {
               uri: '/path/to/json-file.json',
               data: '{"a":"b"}',
             });
-            const parser = JsonParser();
+            const parser = new JSONParser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -71,7 +71,7 @@ describe('parsers', function () {
       context('given generic JSON data', function () {
         specify('should return parse result', async function () {
           const file = new File({ uri: '/path/to/file.json', data: '{"prop": "val"}' });
-          const parser = JsonParser();
+          const parser = new JSONParser();
           const result = await parser.parse(file);
           const objElement: ObjectElement = result.get(0);
 
@@ -86,7 +86,7 @@ describe('parsers', function () {
             uri: '/path/to/file.json',
             data: Buffer.from('{"prop": "val"}'),
           });
-          const parser = JsonParser();
+          const parser = new JSONParser();
           const result = await parser.parse(file);
           const objElement: ObjectElement = result.get(0);
 
@@ -98,7 +98,7 @@ describe('parsers', function () {
       context('given data that is not a generic JSON data', function () {
         specify('should coerce to string and parse', async function () {
           const file = new File({ uri: '/path/to/file.json', data: 1 as any });
-          const parser = JsonParser();
+          const parser = new JSONParser();
           const result = await parser.parse(file);
           const numberElement: NumberElement = result.get(0);
 
@@ -110,7 +110,7 @@ describe('parsers', function () {
       context('given empty file', function () {
         specify('should return empty parse result', async function () {
           const file = new File({ uri: '/path/to/file.json', data: '' });
-          const parser = JsonParser();
+          const parser = new JSONParser();
           const result = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(result));
@@ -122,7 +122,7 @@ describe('parsers', function () {
         context('given sourceMap enabled', function () {
           specify('should decorate ApiDOM with source maps', async function () {
             const file = new File({ uri: '/path/to/file.json', data: '{"prop": "val"}' });
-            const parser = JsonParser({ sourceMap: true });
+            const parser = new JSONParser({ sourceMap: true });
             const result = await parser.parse(file);
             const objElement: ObjectElement = result.get(0);
 
@@ -133,7 +133,7 @@ describe('parsers', function () {
         context('given sourceMap disabled', function () {
           specify('should not decorate ApiDOM with source maps', async function () {
             const file = new File({ uri: '/path/to/file.json', data: '{"prop": "val"}' });
-            const parser = JsonParser({ sourceMap: false });
+            const parser = new JSONParser({ sourceMap: false });
             const result = await parser.parse(file);
             const objElement: ObjectElement = result.get(0);
 

--- a/packages/apidom-reference/test/parse/parsers/openapi-json-2/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/openapi-json-2/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-openapi-json-2';
 
 import File from '../../../../src/File';
-import OpenApiJson2Parser from '../../../../src/parse/parsers/openapi-json-2';
+import OpenAPIJSON2Parser from '../../../../src/parse/parsers/openapi-json-2';
 
 describe('parsers', function () {
-  context('OpenApiJson2Parser', function () {
+  context('OpenAPIJSON2Parser', function () {
     context('canParse', function () {
       context('given file with .json extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.json',
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = OpenApiJson2Parser();
+            const parser = new OpenAPIJSON2Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.json',
               mediaType: 'application/vnd.aai.asyncapi+json;version=2.6.0',
             });
-            const parser = OpenApiJson2Parser();
+            const parser = new OpenAPIJSON2Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -47,7 +47,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi.yaml',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson2Parser();
+          const parser = new OpenAPIJSON2Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -59,7 +59,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson2Parser();
+          const parser = new OpenAPIJSON2Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -73,7 +73,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.json',
               data: fs.readFileSync(url),
             });
-            const parser = OpenApiJson2Parser();
+            const parser = new OpenAPIJSON2Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -86,7 +86,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.json',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = OpenApiJson2Parser();
+            const parser = new OpenAPIJSON2Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -104,7 +104,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson2Parser();
+          const parser = new OpenAPIJSON2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -120,7 +120,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson2Parser();
+          const parser = new OpenAPIJSON2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -134,7 +134,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson2Parser();
+          const parser = new OpenAPIJSON2Parser();
           const parseResult = await parser.parse(file);
           const numberElement: NumberElement = parseResult.get(0);
 
@@ -150,7 +150,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson2Parser();
+          const parser = new OpenAPIJSON2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -168,7 +168,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = OpenApiJson2Parser({ sourceMap: true });
+            const parser = new OpenAPIJSON2Parser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.api?.meta.get('sourceMap')));
@@ -184,7 +184,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = OpenApiJson2Parser();
+            const parser = new OpenAPIJSON2Parser();
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.api?.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/openapi-json-3-0/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/openapi-json-3-0/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-openapi-json-3-0';
 
 import File from '../../../../src/File';
-import OpenApiJson3_0Parser from '../../../../src/parse/parsers/openapi-json-3-0';
+import OpenAPIJSON3_0Parser from '../../../../src/parse/parsers/openapi-json-3-0';
 
 describe('parsers', function () {
-  context('OpenApiJson3_0Parser', function () {
+  context('OpenAPIJSON3_0Parser', function () {
     context('canParse', function () {
       context('given file with .json extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.json',
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = OpenApiJson3_0Parser();
+            const parser = new OpenAPIJSON3_0Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.json',
               mediaType: 'application/vnd.aai.asyncapi+json;version=2.6.0',
             });
-            const parser = OpenApiJson3_0Parser();
+            const parser = new OpenAPIJSON3_0Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -47,7 +47,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi.yaml',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_0Parser();
+          const parser = new OpenAPIJSON3_0Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -59,7 +59,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_0Parser();
+          const parser = new OpenAPIJSON3_0Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -73,7 +73,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.json',
               data: fs.readFileSync(url),
             });
-            const parser = OpenApiJson3_0Parser();
+            const parser = new OpenAPIJSON3_0Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -86,7 +86,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.json',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = OpenApiJson3_0Parser();
+            const parser = new OpenAPIJSON3_0Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -104,7 +104,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_0Parser();
+          const parser = new OpenAPIJSON3_0Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -120,7 +120,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_0Parser();
+          const parser = new OpenAPIJSON3_0Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -134,7 +134,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_0Parser();
+          const parser = new OpenAPIJSON3_0Parser();
           const parseResult = await parser.parse(file);
           const numberElement: NumberElement = parseResult.get(0);
 
@@ -150,7 +150,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_0Parser();
+          const parser = new OpenAPIJSON3_0Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -168,7 +168,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = OpenApiJson3_0Parser({ sourceMap: true });
+            const parser = new OpenAPIJSON3_0Parser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.api?.meta.get('sourceMap')));
@@ -184,7 +184,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = OpenApiJson3_0Parser();
+            const parser = new OpenAPIJSON3_0Parser();
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.api?.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/openapi-json-3-1/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/openapi-json-3-1/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-openapi-json-3-1';
 
 import File from '../../../../src/File';
-import OpenApiJson3_1Parser from '../../../../src/parse/parsers/openapi-json-3-1';
+import OpenAPIJSON3_1Parser from '../../../../src/parse/parsers/openapi-json-3-1';
 
 describe('parsers', function () {
-  context('OpenApiJson3_1Parser', function () {
+  context('OpenAPIJSON3_1Parser', function () {
     context('canParse', function () {
       context('given file with .json extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.json',
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = OpenApiJson3_1Parser();
+            const parser = new OpenAPIJSON3_1Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.json',
               mediaType: 'application/vnd.aai.asyncapi+json;version=2.6.0',
             });
-            const parser = OpenApiJson3_1Parser();
+            const parser = new OpenAPIJSON3_1Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -47,7 +47,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi.yaml',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_1Parser();
+          const parser = new OpenAPIJSON3_1Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -59,7 +59,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_1Parser();
+          const parser = new OpenAPIJSON3_1Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -73,7 +73,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.json',
               data: fs.readFileSync(url),
             });
-            const parser = OpenApiJson3_1Parser();
+            const parser = new OpenAPIJSON3_1Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -86,7 +86,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.json',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = OpenApiJson3_1Parser();
+            const parser = new OpenAPIJSON3_1Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -104,7 +104,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_1Parser();
+          const parser = new OpenAPIJSON3_1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -120,7 +120,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_1Parser();
+          const parser = new OpenAPIJSON3_1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -134,7 +134,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_1Parser();
+          const parser = new OpenAPIJSON3_1Parser();
           const parseResult = await parser.parse(file);
           const numberElement: NumberElement = parseResult.get(0);
 
@@ -150,7 +150,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = OpenApiJson3_1Parser();
+          const parser = new OpenAPIJSON3_1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -168,7 +168,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = OpenApiJson3_1Parser({ sourceMap: true });
+            const parser = new OpenAPIJSON3_1Parser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.api?.meta.get('sourceMap')));
@@ -184,7 +184,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = OpenApiJson3_1Parser();
+            const parser = new OpenAPIJSON3_1Parser();
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.api?.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/openapi-yaml-2/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/openapi-yaml-2/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-openapi-yaml-2';
 
 import File from '../../../../src/File';
-import OpenApiYaml2Parser from '../../../../src/parse/parsers/openapi-yaml-2';
+import OpenAPIYAML2Parser from '../../../../src/parse/parsers/openapi-yaml-2';
 
 describe('parsers', function () {
-  context('OpenApiYaml2Parser', function () {
+  context('OpenAPIYAML2Parser', function () {
     context('canParse', function () {
       context('given file with .yaml extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yaml',
               mediaType: mediaTypes.latest('generic'),
             });
-            const parser = OpenApiYaml2Parser();
+            const parser = new OpenAPIYAML2Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yaml',
               mediaType: 'application/vnd.aai.asyncapi;version=2.6.0',
             });
-            const parser = OpenApiYaml2Parser();
+            const parser = new OpenAPIYAML2Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -52,7 +52,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yml',
               mediaType: mediaTypes.latest('generic'),
             });
-            const parser = OpenApiYaml2Parser();
+            const parser = new OpenAPIYAML2Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -65,7 +65,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yaml',
               mediaType: 'application/vnd.aai.asyncapi;version=2.6.0',
             });
-            const parser = OpenApiYaml2Parser();
+            const parser = new OpenAPIYAML2Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -78,7 +78,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi.txt',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml2Parser();
+          const parser = new OpenAPIYAML2Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -90,7 +90,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml2Parser();
+          const parser = new OpenAPIYAML2Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -104,7 +104,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.yaml',
               data: fs.readFileSync(url),
             });
-            const parser = OpenApiYaml2Parser();
+            const parser = new OpenAPIYAML2Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -117,7 +117,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.yaml',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = OpenApiYaml2Parser();
+            const parser = new OpenAPIYAML2Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -135,7 +135,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml2Parser();
+          const parser = new OpenAPIYAML2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -151,7 +151,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml2Parser();
+          const parser = new OpenAPIYAML2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -165,7 +165,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml2Parser();
+          const parser = new OpenAPIYAML2Parser();
           const result = await parser.parse(file);
           const numberElement: NumberElement = result.get(0);
 
@@ -181,7 +181,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml2Parser();
+          const parser = new OpenAPIYAML2Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -199,7 +199,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('yaml'),
             });
-            const parser = OpenApiYaml2Parser({ sourceMap: true });
+            const parser = new OpenAPIYAML2Parser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.api?.meta.get('sourceMap')));
@@ -211,7 +211,7 @@ describe('parsers', function () {
             const uri = path.join(__dirname, 'fixtures', 'sample-api.yaml');
             const data = fs.readFileSync(uri).toString();
             const file = new File({ uri, data });
-            const parser = OpenApiYaml2Parser({ sourceMap: false });
+            const parser = new OpenAPIYAML2Parser({ sourceMap: false });
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.api?.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/openapi-yaml-3-0/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/openapi-yaml-3-0/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-openapi-yaml-3-0';
 
 import File from '../../../../src/File';
-import OpenApiYaml3_0Parser from '../../../../src/parse/parsers/openapi-yaml-3-0';
+import OpenAPIYAML3_0Parser from '../../../../src/parse/parsers/openapi-yaml-3-0';
 
 describe('parsers', function () {
-  context('OpenApiYaml3_0Parser', function () {
+  context('OpenAPIYAML3_0Parser', function () {
     context('canParse', function () {
       context('given file with .yaml extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yaml',
               mediaType: mediaTypes.latest('generic'),
             });
-            const parser = OpenApiYaml3_0Parser();
+            const parser = new OpenAPIYAML3_0Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yaml',
               mediaType: 'application/vnd.aai.asyncapi;version=2.6.0',
             });
-            const parser = OpenApiYaml3_0Parser();
+            const parser = new OpenAPIYAML3_0Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -52,7 +52,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yml',
               mediaType: mediaTypes.latest('generic'),
             });
-            const parser = OpenApiYaml3_0Parser();
+            const parser = new OpenAPIYAML3_0Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -65,7 +65,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yaml',
               mediaType: 'application/vnd.aai.asyncapi;version=2.6.0',
             });
-            const parser = OpenApiYaml3_0Parser();
+            const parser = new OpenAPIYAML3_0Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -78,7 +78,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi.txt',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_0Parser();
+          const parser = new OpenAPIYAML3_0Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -90,7 +90,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_0Parser();
+          const parser = new OpenAPIYAML3_0Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -104,7 +104,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.yaml',
               data: fs.readFileSync(url),
             });
-            const parser = OpenApiYaml3_0Parser();
+            const parser = new OpenAPIYAML3_0Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -117,7 +117,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.yaml',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = OpenApiYaml3_0Parser();
+            const parser = new OpenAPIYAML3_0Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -135,7 +135,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_0Parser();
+          const parser = new OpenAPIYAML3_0Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -151,7 +151,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_0Parser();
+          const parser = new OpenAPIYAML3_0Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -165,7 +165,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_0Parser();
+          const parser = new OpenAPIYAML3_0Parser();
           const result = await parser.parse(file);
           const numberElement: NumberElement = result.get(0);
 
@@ -181,7 +181,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_0Parser();
+          const parser = new OpenAPIYAML3_0Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -199,7 +199,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('yaml'),
             });
-            const parser = OpenApiYaml3_0Parser({ sourceMap: true });
+            const parser = new OpenAPIYAML3_0Parser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.api?.meta.get('sourceMap')));
@@ -211,7 +211,7 @@ describe('parsers', function () {
             const uri = path.join(__dirname, 'fixtures', 'sample-api.yaml');
             const data = fs.readFileSync(uri).toString();
             const file = new File({ uri, data });
-            const parser = OpenApiYaml3_0Parser({ sourceMap: false });
+            const parser = new OpenAPIYAML3_0Parser({ sourceMap: false });
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.api?.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/openapi-yaml-3-1/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/openapi-yaml-3-1/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-openapi-yaml-3-1';
 
 import File from '../../../../src/File';
-import OpenApiYaml3_1Parser from '../../../../src/parse/parsers/openapi-yaml-3-1';
+import OpenAPIYAML3_1Parser from '../../../../src/parse/parsers/openapi-yaml-3-1';
 
 describe('parsers', function () {
-  context('OpenApiYaml3_1Parser', function () {
+  context('OpenAPIYAML3_1Parser', function () {
     context('canParse', function () {
       context('given file with .yaml extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yaml',
               mediaType: mediaTypes.latest('generic'),
             });
-            const parser = OpenApiYaml3_1Parser();
+            const parser = new OpenAPIYAML3_1Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yaml',
               mediaType: 'application/vnd.aai.asyncapi;version=2.6.0',
             });
-            const parser = OpenApiYaml3_1Parser();
+            const parser = new OpenAPIYAML3_1Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -52,7 +52,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yml',
               mediaType: mediaTypes.latest('generic'),
             });
-            const parser = OpenApiYaml3_1Parser();
+            const parser = new OpenAPIYAML3_1Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -65,7 +65,7 @@ describe('parsers', function () {
               uri: '/path/to/openapi.yaml',
               mediaType: 'application/vnd.aai.asyncapi;version=2.6.0',
             });
-            const parser = OpenApiYaml3_1Parser();
+            const parser = new OpenAPIYAML3_1Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -78,7 +78,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi.txt',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_1Parser();
+          const parser = new OpenAPIYAML3_1Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -90,7 +90,7 @@ describe('parsers', function () {
             uri: '/path/to/openapi',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_1Parser();
+          const parser = new OpenAPIYAML3_1Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -104,7 +104,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.yaml',
               data: fs.readFileSync(url),
             });
-            const parser = OpenApiYaml3_1Parser();
+            const parser = new OpenAPIYAML3_1Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -117,7 +117,7 @@ describe('parsers', function () {
               uri: '/path/to/open-api.yaml',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = OpenApiYaml3_1Parser();
+            const parser = new OpenAPIYAML3_1Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -135,7 +135,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_1Parser();
+          const parser = new OpenAPIYAML3_1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -151,7 +151,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_1Parser();
+          const parser = new OpenAPIYAML3_1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -165,7 +165,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_1Parser();
+          const parser = new OpenAPIYAML3_1Parser();
           const result = await parser.parse(file);
           const numberElement: NumberElement = result.get(0);
 
@@ -181,7 +181,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = OpenApiYaml3_1Parser();
+          const parser = new OpenAPIYAML3_1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -199,7 +199,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('yaml'),
             });
-            const parser = OpenApiYaml3_1Parser({ sourceMap: true });
+            const parser = new OpenAPIYAML3_1Parser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.api?.meta.get('sourceMap')));
@@ -211,7 +211,7 @@ describe('parsers', function () {
             const uri = path.join(__dirname, 'fixtures', 'sample-api.yaml');
             const data = fs.readFileSync(uri).toString();
             const file = new File({ uri, data });
-            const parser = OpenApiYaml3_1Parser({ sourceMap: false });
+            const parser = new OpenAPIYAML3_1Parser({ sourceMap: false });
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.api?.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/workflows-json-1/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/workflows-json-1/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-workflows-json-1';
 
 import File from '../../../../src/File';
-import WorkflowsJson1Parser from '../../../../src/parse/parsers/workflows-json-1';
+import WorkflowsJSON1Parser from '../../../../src/parse/parsers/workflows-json-1';
 
 describe('parsers', function () {
-  context('WorkflowsJson1Parser', function () {
+  context('WorkflowsJSON1Parser', function () {
     context('canParse', function () {
       context('given file with .json extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/workflows.json',
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = WorkflowsJson1Parser();
+            const parser = new WorkflowsJSON1Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/workflows.json',
               mediaType: 'application/vnd.aai.asyncapi+json;version=2.6.0',
             });
-            const parser = WorkflowsJson1Parser();
+            const parser = new WorkflowsJSON1Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -47,7 +47,7 @@ describe('parsers', function () {
             uri: '/path/to/workflows.yaml',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = WorkflowsJson1Parser();
+          const parser = new WorkflowsJSON1Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -59,7 +59,7 @@ describe('parsers', function () {
             uri: '/path/to/workflows',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = WorkflowsJson1Parser();
+          const parser = new WorkflowsJSON1Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -73,7 +73,7 @@ describe('parsers', function () {
               uri: '/path/to/workflows.json',
               data: fs.readFileSync(uri),
             });
-            const parser = WorkflowsJson1Parser();
+            const parser = new WorkflowsJSON1Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -86,7 +86,7 @@ describe('parsers', function () {
               uri: '/path/to/workflows.json',
               data: fs.readFileSync(uri).toString(),
             });
-            const parser = WorkflowsJson1Parser();
+            const parser = new WorkflowsJSON1Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -104,7 +104,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = WorkflowsJson1Parser();
+          const parser = new WorkflowsJSON1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -120,7 +120,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = WorkflowsJson1Parser();
+          const parser = new WorkflowsJSON1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -134,7 +134,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = WorkflowsJson1Parser();
+          const parser = new WorkflowsJSON1Parser();
           const parseResult = await parser.parse(file);
           const numberElement: NumberElement = parseResult.get(0);
 
@@ -150,7 +150,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest('json'),
           });
-          const parser = WorkflowsJson1Parser();
+          const parser = new WorkflowsJSON1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -168,7 +168,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = WorkflowsJson1Parser({ sourceMap: true });
+            const parser = new WorkflowsJSON1Parser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.api?.meta.get('sourceMap')));
@@ -184,7 +184,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('json'),
             });
-            const parser = WorkflowsJson1Parser();
+            const parser = new WorkflowsJSON1Parser();
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.api?.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/workflows-yaml-1/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/workflows-yaml-1/index.ts
@@ -5,10 +5,10 @@ import { NumberElement, isParseResultElement, isSourceMapElement } from '@swagge
 import { mediaTypes } from '@swagger-api/apidom-parser-adapter-workflows-yaml-1';
 
 import File from '../../../../src/File';
-import WorkflowsYaml1Parser from '../../../../src/parse/parsers/workflows-yaml-1';
+import WorkflowsYAML1Parser from '../../../../src/parse/parsers/workflows-yaml-1';
 
 describe('parsers', function () {
-  context('WorkflowsYaml1Parser', function () {
+  context('new WorkflowsYAML1Parser', function () {
     context('canParse', function () {
       context('given file with .yaml extension', function () {
         context('and with proper media type', function () {
@@ -21,7 +21,7 @@ describe('parsers', function () {
               uri: '/path/to/worklfows.yaml',
               mediaType: mediaTypes.latest('generic'),
             });
-            const parser = WorkflowsYaml1Parser();
+            const parser = new WorkflowsYAML1Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -34,7 +34,7 @@ describe('parsers', function () {
               uri: '/path/to/workflows.yaml',
               mediaType: 'application/vnd.aai.asyncapi;version=2.6.0',
             });
-            const parser = WorkflowsYaml1Parser();
+            const parser = new WorkflowsYAML1Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -52,7 +52,7 @@ describe('parsers', function () {
               uri: '/path/to/workflows.yml',
               mediaType: mediaTypes.latest('generic'),
             });
-            const parser = WorkflowsYaml1Parser();
+            const parser = new WorkflowsYAML1Parser();
 
             assert.isTrue(await parser.canParse(file1));
             assert.isTrue(await parser.canParse(file2));
@@ -65,7 +65,7 @@ describe('parsers', function () {
               uri: '/path/to/workflows.yaml',
               mediaType: 'application/vnd.aai.asyncapi;version=2.6.0',
             });
-            const parser = WorkflowsYaml1Parser();
+            const parser = new WorkflowsYAML1Parser();
 
             assert.isFalse(await parser.canParse(file));
           });
@@ -78,7 +78,7 @@ describe('parsers', function () {
             uri: '/path/to/workflows.txt',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = WorkflowsYaml1Parser();
+          const parser = new WorkflowsYAML1Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -90,7 +90,7 @@ describe('parsers', function () {
             uri: '/path/to/worklfows',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = WorkflowsYaml1Parser();
+          const parser = new WorkflowsYAML1Parser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -104,7 +104,7 @@ describe('parsers', function () {
               uri: '/path/to/workflows.yaml',
               data: fs.readFileSync(url),
             });
-            const parser = WorkflowsYaml1Parser();
+            const parser = new WorkflowsYAML1Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -117,7 +117,7 @@ describe('parsers', function () {
               uri: '/path/to/workflows.yaml',
               data: fs.readFileSync(url).toString(),
             });
-            const parser = WorkflowsYaml1Parser();
+            const parser = new WorkflowsYAML1Parser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -135,7 +135,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = WorkflowsYaml1Parser();
+          const parser = new WorkflowsYAML1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -151,7 +151,7 @@ describe('parsers', function () {
             data,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = WorkflowsYaml1Parser();
+          const parser = new WorkflowsYAML1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -165,7 +165,7 @@ describe('parsers', function () {
             data: 1 as any,
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = WorkflowsYaml1Parser();
+          const parser = new WorkflowsYAML1Parser();
           const result = await parser.parse(file);
           const numberElement: NumberElement = result.get(0);
 
@@ -181,7 +181,7 @@ describe('parsers', function () {
             data: '',
             mediaType: mediaTypes.latest('yaml'),
           });
-          const parser = WorkflowsYaml1Parser();
+          const parser = new WorkflowsYAML1Parser();
           const parseResult = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(parseResult));
@@ -199,7 +199,7 @@ describe('parsers', function () {
               data,
               mediaType: mediaTypes.latest('yaml'),
             });
-            const parser = WorkflowsYaml1Parser({ sourceMap: true });
+            const parser = new WorkflowsYAML1Parser({ sourceMap: true });
             const parseResult = await parser.parse(file);
 
             assert.isTrue(isSourceMapElement(parseResult.api?.meta.get('sourceMap')));
@@ -211,7 +211,7 @@ describe('parsers', function () {
             const uri = path.join(__dirname, 'fixtures', 'sample-workflow.yaml');
             const data = fs.readFileSync(uri).toString();
             const file = new File({ uri, data });
-            const parser = WorkflowsYaml1Parser({ sourceMap: false });
+            const parser = new WorkflowsYAML1Parser({ sourceMap: false });
             const parseResult = await parser.parse(file);
 
             assert.isUndefined(parseResult.api?.meta.get('sourceMap'));

--- a/packages/apidom-reference/test/parse/parsers/yaml/index.ts
+++ b/packages/apidom-reference/test/parse/parsers/yaml/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@swagger-api/apidom-core';
 
 import File from '../../../../src/File';
-import YamlParser from '../../../../src/parse/parsers/yaml-1-2';
+import YAMLParser from '../../../../src/parse/parsers/yaml-1-2';
 
 describe('parsers', function () {
   context('YamlParser', function () {
@@ -16,7 +16,7 @@ describe('parsers', function () {
       context('given file with .yaml extension', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.yaml', data: 'key: value' });
-          const parser = YamlParser();
+          const parser = new YAMLParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -25,7 +25,7 @@ describe('parsers', function () {
       context('given file with .yml extension', function () {
         specify('should return true', async function () {
           const file = new File({ uri: '/path/to/file.yml', data: 'key: value' });
-          const parser = YamlParser();
+          const parser = new YAMLParser();
 
           assert.isTrue(await parser.canParse(file));
         });
@@ -34,7 +34,7 @@ describe('parsers', function () {
       context('given file with unknown extension', function () {
         specify('should return false', async function () {
           const file = new File({ uri: '/path/to/file.txt' });
-          const parser = YamlParser();
+          const parser = new YAMLParser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -43,7 +43,7 @@ describe('parsers', function () {
       context('given file with no extension', function () {
         specify('should return false', async function () {
           const file = new File({ uri: '/path/to/file' });
-          const parser = YamlParser();
+          const parser = new YAMLParser();
 
           assert.isFalse(await parser.canParse(file));
         });
@@ -56,7 +56,7 @@ describe('parsers', function () {
               uri: '/path/to/yaml.yaml',
               data: Buffer.from('key: value'),
             });
-            const parser = YamlParser();
+            const parser = new YAMLParser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -68,7 +68,7 @@ describe('parsers', function () {
               uri: '/path/to/yaml.yaml',
               data: 'key: value',
             });
-            const parser = YamlParser();
+            const parser = new YAMLParser();
 
             assert.isTrue(await parser.canParse(file));
           });
@@ -80,7 +80,7 @@ describe('parsers', function () {
       context('given generic YAML data', function () {
         specify('should return parse result', async function () {
           const file = new File({ uri: '/path/to/file.yaml', data: 'prop: val' });
-          const parser = YamlParser();
+          const parser = new YAMLParser();
           const result = await parser.parse(file);
           const objElement: ObjectElement = result.get(0);
 
@@ -92,7 +92,7 @@ describe('parsers', function () {
       context('given generic YAML data as buffer', function () {
         specify('should return parse result', async function () {
           const file = new File({ uri: '/path/to/file.yaml', data: Buffer.from('prop: val') });
-          const parser = YamlParser();
+          const parser = new YAMLParser();
           const result = await parser.parse(file);
           const objElement: ObjectElement = result.get(0);
 
@@ -104,7 +104,7 @@ describe('parsers', function () {
       context('given data that is not a generic YAML data', function () {
         specify('should coerce to string and parse', async function () {
           const file = new File({ uri: '/path/to/file.yaml', data: 1 as any });
-          const parser = YamlParser();
+          const parser = new YAMLParser();
           const result = await parser.parse(file);
           const numberElement: NumberElement = result.get(0);
 
@@ -116,7 +116,7 @@ describe('parsers', function () {
       context('given empty file', function () {
         specify('should return empty parse result', async function () {
           const file = new File({ uri: '/path/to/file.yaml', data: '' });
-          const parser = YamlParser();
+          const parser = new YAMLParser();
           const result = await parser.parse(file);
 
           assert.isTrue(isParseResultElement(result));
@@ -128,7 +128,7 @@ describe('parsers', function () {
         context('given sourceMap enabled', function () {
           specify('should decorate ApiDOM with source maps', async function () {
             const file = new File({ uri: '/path/to/file.yaml', data: 'prop: val' });
-            const parser = YamlParser({ sourceMap: true });
+            const parser = new YAMLParser({ sourceMap: true });
             const result = await parser.parse(file);
             const objElement: ObjectElement = result.get(0);
 
@@ -139,7 +139,7 @@ describe('parsers', function () {
         context('given sourceMap disabled', function () {
           specify('should not decorate ApiDOM with source maps', async function () {
             const file = new File({ uri: '/path/to/file.yaml', data: 'prop: val' });
-            const parser = YamlParser({ sourceMap: false });
+            const parser = new YAMLParser({ sourceMap: false });
             const result = await parser.parse(file);
             const objElement: ObjectElement = result.get(0);
 

--- a/packages/apidom-reference/test/resolve/index.ts
+++ b/packages/apidom-reference/test/resolve/index.ts
@@ -7,7 +7,7 @@ import FileResolver from '../../src/resolve/resolvers/file/index-node';
 import UnmatchedResolveStrategyError from '../../src/errors/UnmatchedResolveStrategyError';
 import ResolveError from '../../src/errors/ResolveError';
 import ParseError from '../../src/errors/ParseError';
-import OpenApiJson3_1Parser from '../../src/parse/parsers/openapi-json-3-1';
+import OpenAPIJSON3_1Parser from '../../src/parse/parsers/openapi-json-3-1';
 
 const fixturePath = path.join(
   __dirname,
@@ -171,7 +171,7 @@ describe('resolve', function () {
       const options = {
         parse: {
           mediaType: mediaTypes.latest('json'),
-          parsers: [OpenApiJson3_1Parser({ allowEmpty: false })],
+          parsers: [new OpenAPIJSON3_1Parser({ allowEmpty: false })],
         },
       };
 


### PR DESCRIPTION
Refs #3481

BREAKING CHANGE: parsers from apidom-reference package became a class and requires to be instantiated with new operator.

