### PR TITLE
feat(reference): change dereference visitors from stamps to TypeScript classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34998,11 +34998,6 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true
     },
-    "node_modules/stampit": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/stampit/-/stampit-4.3.2.tgz",
-      "integrity": "sha512-pE2org1+ZWQBnIxRPrBM2gVupkuDD0TTNIo1H6GdT/vO82NXli2z8lRE8cu/nBIHrcOCXFBAHpb9ZldrB2/qOA=="
-    },
     "node_modules/static-eval": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
@@ -40519,8 +40514,7 @@
         "minimatch": "^7.4.3",
         "process": "^0.11.10",
         "ramda": "~0.30.0",
-        "ramda-adjunct": "^5.0.0",
-        "stampit": "^4.3.2"
+        "ramda-adjunct": "^5.0.0"
       },
       "devDependencies": {
         "@swagger-api/apidom-error": "*",

--- a/packages/apidom-reference/package.json
+++ b/packages/apidom-reference/package.json
@@ -264,8 +264,7 @@
     "minimatch": "^7.4.3",
     "process": "^0.11.10",
     "ramda": "~0.30.0",
-    "ramda-adjunct": "^5.0.0",
-    "stampit": "^4.3.2"
+    "ramda-adjunct": "^5.0.0"
   },
   "optionalDependencies": {
     "@swagger-api/apidom-error": "^0.99.0",

--- a/packages/apidom-reference/src/ReferenceSet.ts
+++ b/packages/apidom-reference/src/ReferenceSet.ts
@@ -12,7 +12,7 @@ class ReferenceSet {
 
   public readonly refs: Reference[];
 
-  public readonly circular: boolean;
+  public circular: boolean;
 
   constructor({ refs = [], circular = false }: ReferenceSetOptions = {}) {
     this.refs = [];

--- a/packages/apidom-reference/src/dereference/strategies/apidom/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/apidom/index.ts
@@ -57,7 +57,7 @@ class ApiDOMDereferenceStrategy extends DereferenceStrategy {
       refSet = mutableRefSet;
     }
 
-    const visitor = ApiDOMDereferenceVisitor({ reference, options });
+    const visitor = new ApiDOMDereferenceVisitor({ reference: reference!, options });
     const dereferencedElement = await visitAsync(refSet.rootRef!.value, visitor);
 
     /**
@@ -74,8 +74,6 @@ class ApiDOMDereferenceStrategy extends DereferenceStrategy {
             }),
         )
         .forEach((ref) => immutableRefSet.add(ref));
-      reference = immutableRefSet.find((ref) => ref.uri === file.uri);
-      refSet = immutableRefSet;
     }
 
     /**
@@ -92,4 +90,5 @@ class ApiDOMDereferenceStrategy extends DereferenceStrategy {
   }
 }
 
+export { ApiDOMDereferenceVisitor };
 export default ApiDOMDereferenceStrategy;

--- a/packages/apidom-reference/src/dereference/strategies/apidom/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/apidom/visitor.ts
@@ -1,4 +1,3 @@
-import stampit from 'stampit';
 import { propEq } from 'ramda';
 import { ApiDOMError } from '@swagger-api/apidom-error';
 import {
@@ -20,7 +19,9 @@ import MaximumResolveDepthError from '../../../errors/MaximumResolveDepthError';
 import * as url from '../../../util/url';
 import parse from '../../../parse';
 import Reference from '../../../Reference';
+import ReferenceSet from '../../../ReferenceSet';
 import { evaluate } from './selectors/element-id';
+import type { ReferenceOptions } from '../../../options';
 
 // @ts-ignore
 const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
@@ -38,159 +39,163 @@ const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
  * WARNING: this implementation only supports referencing elements in the local document. Points 2-4 are not supported.
  */
 
-const ApiDOMDereferenceVisitor = stampit({
-  props: {
-    reference: null,
-    options: null,
-  },
-  init({ reference, options }) {
+export interface ApiDOMDereferenceVisitorOptions {
+  readonly reference: Reference;
+  readonly options: ReferenceOptions;
+}
+
+class ApiDOMDereferenceVisitor {
+  protected readonly reference: Reference;
+
+  protected readonly options: ReferenceOptions;
+
+  constructor({ reference, options }: ApiDOMDereferenceVisitorOptions) {
     this.reference = reference;
     this.options = options;
-  },
-  methods: {
-    toBaseURI(uri: string): string {
-      return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
-    },
+  }
 
-    async toReference(uri: string): Promise<Reference> {
-      // detect maximum depth of resolution
-      if (this.reference.depth >= this.options.resolve.maxDepth) {
-        throw new MaximumResolveDepthError(
-          `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
-        );
-      }
+  protected toBaseURI(uri: string): string {
+    return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
+  }
 
-      const baseURI = this.toBaseURI(uri);
-      const { refSet } = this.reference;
+  protected async toReference(uri: string): Promise<Reference> {
+    // detect maximum depth of resolution
+    if (this.reference.depth >= this.options.resolve.maxDepth) {
+      throw new MaximumResolveDepthError(
+        `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
+      );
+    }
 
-      // we've already processed this Reference in past
-      if (refSet.has(baseURI)) {
-        return refSet.find(propEq(baseURI, 'uri'));
-      }
+    const baseURI = this.toBaseURI(uri);
+    const { refSet } = this.reference as { refSet: ReferenceSet };
 
-      const parseResult = await parse(url.unsanitize(baseURI), {
-        ...this.options,
-        parse: { ...this.options.parse, mediaType: 'text/plain' },
-      });
+    // we've already processed this Reference in past
+    if (refSet.has(baseURI)) {
+      return refSet.find(propEq(baseURI, 'uri'))!;
+    }
 
-      // register new mutable reference with a refSet
-      const mutableReference = new Reference({
-        uri: baseURI,
-        value: cloneDeep(parseResult),
+    const parseResult = await parse(url.unsanitize(baseURI), {
+      ...this.options,
+      parse: { ...this.options.parse, mediaType: 'text/plain' },
+    });
+
+    // register new mutable reference with a refSet
+    const mutableReference = new Reference({
+      uri: baseURI,
+      value: cloneDeep(parseResult),
+      depth: this.reference.depth + 1,
+    });
+    refSet.add(mutableReference);
+
+    if (this.options.dereference.immutable) {
+      // register new immutable reference with a refSet
+      const immutableReference = new Reference({
+        uri: `immutable://${baseURI}`,
+        value: parseResult,
         depth: this.reference.depth + 1,
       });
-      refSet.add(mutableReference);
+      refSet.add(immutableReference);
+    }
 
-      if (this.options.dereference.immutable) {
-        // register new immutable reference with a refSet
-        const immutableReference = new Reference({
-          uri: `immutable://${baseURI}`,
-          value: parseResult,
-          depth: this.reference.depth + 1,
-        });
-        refSet.add(immutableReference);
-      }
+    return mutableReference;
+  }
 
-      return mutableReference;
-    },
+  public async RefElement(
+    refElement: RefElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    const refURI = toValue(refElement);
+    const refNormalizedURI = refURI.includes('#') ? refURI : `#${refURI}`;
+    const retrievalURI = this.toBaseURI(refNormalizedURI);
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
 
-    async RefElement(
-      refElement: RefElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
+    // ignore resolving internal RefElements
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this ref element
+      return false;
+    }
+    // ignore resolving external RefElements
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this ref element
+      return false;
+    }
+
+    const reference = await this.toReference(refNormalizedURI);
+    const refBaseURI = url.resolve(retrievalURI, refNormalizedURI);
+    const elementID = uriToElementID(refBaseURI);
+    let referencedElement: unknown | Element | undefined = evaluate(
+      elementID,
+      reference.value.result as Element,
+    );
+
+    if (!isElement(referencedElement)) {
+      throw new ApiDOMError(`Referenced element with id="${elementID}" was not found`);
+    }
+
+    if (refElement === referencedElement) {
+      throw new ApiDOMError('RefElement cannot reference itself');
+    }
+
+    if (isRefElement(referencedElement)) {
+      throw new ApiDOMError('RefElement cannot reference another RefElement');
+    }
+
+    if (isExternalReference) {
+      // dive deep into the fragment
+      const visitor = new ApiDOMDereferenceVisitor({ reference, options: this.options });
+      referencedElement = await visitAsync(referencedElement, visitor);
+    }
+
+    /**
+     * When path is used, it references the given property of the referenced element
+     */
+    const referencedElementPath: string = toValue(refElement.path);
+    if (referencedElementPath !== 'element' && isElement(referencedElement)) {
+      referencedElement = refract(referencedElement[referencedElementPath]);
+    }
+
+    /**
+     * Transclusion of a Ref Element SHALL be defined in the if/else block below.
+     */
+    if (
+      isObjectElement(referencedElement) &&
+      isObjectElement(ancestors[ancestors.length - 1]) &&
+      Array.isArray(parent) &&
+      typeof key === 'number'
     ) {
-      const refURI = toValue(refElement);
-      const refNormalizedURI = refURI.includes('#') ? refURI : `#${refURI}`;
-      const retrievalURI = this.toBaseURI(refNormalizedURI);
-      const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-      const isExternalReference = !isInternalReference;
-
-      // ignore resolving internal RefElements
-      if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this ref element
-        return false;
-      }
-      // ignore resolving external RefElements
-      if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this ref element
-        return false;
-      }
-
-      const reference = await this.toReference(refNormalizedURI);
-      const refBaseURI = url.resolve(retrievalURI, refNormalizedURI);
-      const elementID = uriToElementID(refBaseURI);
-      let referencedElement: unknown | Element | undefined = evaluate(
-        elementID,
-        reference.value.result,
-      );
-
-      if (!isElement(referencedElement)) {
-        throw new ApiDOMError(`Referenced element with id="${elementID}" was not found`);
-      }
-
-      if (refElement === referencedElement) {
-        throw new ApiDOMError('RefElement cannot reference itself');
-      }
-
-      if (isRefElement(referencedElement)) {
-        throw new ApiDOMError('RefElement cannot reference another RefElement');
-      }
-
-      if (isExternalReference) {
-        // dive deep into the fragment
-        const visitor = ApiDOMDereferenceVisitor({ reference, options: this.options });
-        referencedElement = await visitAsync(referencedElement, visitor);
-      }
-
       /**
-       * When path is used, it references the given property of the referenced element
+       * If the Ref Element is held by an Object Element and references an Object Element,
+       * its content entries SHALL be inserted in place of the Ref Element.
        */
-      const referencedElementPath: string = toValue(refElement.path);
-      if (referencedElementPath !== 'element' && isElement(referencedElement)) {
-        referencedElement = refract(referencedElement[referencedElementPath]);
-      }
-
+      parent.splice(key, 1, ...referencedElement.content);
+    } else if (
+      isArrayElement(referencedElement) &&
+      Array.isArray(parent) &&
+      typeof key === 'number'
+    ) {
       /**
-       * Transclusion of a Ref Element SHALL be defined in the if/else block below.
+       * If the Ref Element is held by an Array Element and references an Array Element,
+       * its content entries SHALL be inserted in place of the Ref Element.
        */
-      if (
-        isObjectElement(referencedElement) &&
-        isObjectElement(ancestors[ancestors.length - 1]) &&
-        Array.isArray(parent) &&
-        typeof key === 'number'
-      ) {
-        /**
-         * If the Ref Element is held by an Object Element and references an Object Element,
-         * its content entries SHALL be inserted in place of the Ref Element.
-         */
-        parent.splice(key, 1, ...referencedElement.content);
-      } else if (
-        isArrayElement(referencedElement) &&
-        Array.isArray(parent) &&
-        typeof key === 'number'
-      ) {
-        /**
-         * If the Ref Element is held by an Array Element and references an Array Element,
-         * its content entries SHALL be inserted in place of the Ref Element.
-         */
-        parent.splice(key, 1, ...referencedElement.content);
-      } else if (isMemberElement(parent)) {
-        /**
-         * The Ref Element is substituted by the Element it references.
-         */
-        parent.value = referencedElement; // eslint-disable-line no-param-reassign
-      } else if (Array.isArray(parent)) {
-        /**
-         * The Ref Element is substituted by the Element it references.
-         */
-        parent[key] = referencedElement; // eslint-disable-line no-param-reassign
-      }
+      parent.splice(key, 1, ...referencedElement.content);
+    } else if (isMemberElement(parent)) {
+      /**
+       * The Ref Element is substituted by the Element it references.
+       */
+      parent.value = referencedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      /**
+       * The Ref Element is substituted by the Element it references.
+       */
+      parent[key] = referencedElement; // eslint-disable-line no-param-reassign
+    }
 
-      return !parent ? referencedElement : false;
-    },
-  },
-});
+    return !parent ? referencedElement : false;
+  }
+}
 
 export default ApiDOMDereferenceVisitor;

--- a/packages/apidom-reference/src/dereference/strategies/asyncapi-2/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/asyncapi-2/index.ts
@@ -10,7 +10,7 @@ import DereferenceStrategy, { DereferenceStrategyOptions } from '../DereferenceS
 import File from '../../../File';
 import Reference from '../../../Reference';
 import ReferenceSet from '../../../ReferenceSet';
-import AsyncApi2DereferenceVisitor from './visitor';
+import AsyncAPI2DereferenceVisitor from './visitor';
 import type { ReferenceOptions } from '../../../options';
 
 // @ts-ignore
@@ -39,14 +39,14 @@ class AsyncAPI2DereferenceStrategy extends DereferenceStrategy {
     const immutableRefSet = options.dereference.refSet ?? new ReferenceSet();
     const mutableRefSet = new ReferenceSet();
     let refSet = immutableRefSet;
-    let reference;
+    let reference: Reference;
 
     if (!immutableRefSet.has(file.uri)) {
       reference = new Reference({ uri: file.uri, value: file.parseResult! });
       immutableRefSet.add(reference);
     } else {
       // pre-computed refSet was provided as configuration option
-      reference = immutableRefSet.find((ref) => ref.uri === file.uri);
+      reference = immutableRefSet.find((ref) => ref.uri === file.uri)!;
     }
 
     /**
@@ -63,11 +63,11 @@ class AsyncAPI2DereferenceStrategy extends DereferenceStrategy {
             }),
         )
         .forEach((ref) => mutableRefSet.add(ref));
-      reference = mutableRefSet.find((ref) => ref.uri === file.uri);
+      reference = mutableRefSet.find((ref) => ref.uri === file.uri)!;
       refSet = mutableRefSet;
     }
 
-    const visitor = AsyncApi2DereferenceVisitor({ reference, namespace, options });
+    const visitor = new AsyncAPI2DereferenceVisitor({ reference, namespace, options });
     const dereferencedElement = await visitAsync(refSet.rootRef!.value, visitor, {
       keyMap,
       nodeTypeGetter: getNodeType,
@@ -87,8 +87,6 @@ class AsyncAPI2DereferenceStrategy extends DereferenceStrategy {
             }),
         )
         .forEach((ref) => immutableRefSet.add(ref));
-      reference = immutableRefSet.find((ref) => ref.uri === file.uri);
-      refSet = immutableRefSet;
     }
 
     /**
@@ -105,4 +103,5 @@ class AsyncAPI2DereferenceStrategy extends DereferenceStrategy {
   }
 }
 
+export { AsyncAPI2DereferenceVisitor };
 export default AsyncAPI2DereferenceStrategy;

--- a/packages/apidom-reference/src/dereference/strategies/asyncapi-2/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/asyncapi-2/visitor.ts
@@ -1,4 +1,3 @@
-import stampit from 'stampit';
 import { propEq } from 'ramda';
 import {
   isElement,
@@ -10,6 +9,7 @@ import {
   cloneShallow,
   visit,
   toValue,
+  Namespace,
   Element,
   BooleanElement,
   RefElement,
@@ -33,6 +33,8 @@ import { AncestorLineage } from '../../util';
 import * as url from '../../../util/url';
 import parse from '../../../parse';
 import Reference from '../../../Reference';
+import ReferenceSet from '../../../ReferenceSet';
+import type { ReferenceOptions } from '../../../options';
 
 // @ts-ignore
 const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
@@ -40,266 +42,464 @@ const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
 // initialize element identity manager
 const identityManager = new IdentityManager();
 
-const AsyncApi2DereferenceVisitor = stampit({
-  props: {
-    indirections: [],
-    namespace: null,
-    reference: null,
-    options: null,
-    ancestors: null,
-    refractCache: null,
-  },
-  init({
-    indirections = [],
+export interface AsyncAPI2DereferenceVisitorOptions {
+  readonly namespace: Namespace;
+  readonly reference: Reference;
+  readonly options: ReferenceOptions;
+  readonly indirections?: Element[];
+  readonly ancestors?: AncestorLineage<Element>;
+  readonly refractCache?: Map<string, Element>;
+}
+
+class AsyncAPI2DereferenceVisitor {
+  protected readonly indirections: Element[];
+
+  protected readonly namespace: Namespace;
+
+  protected readonly reference: Reference;
+
+  protected readonly options: ReferenceOptions;
+
+  protected readonly ancestors: AncestorLineage<Element>;
+
+  protected readonly refractCache: Map<string, Element>;
+
+  constructor({
     reference,
     namespace,
     options,
+    indirections = [],
     ancestors = new AncestorLineage(),
     refractCache = new Map(),
-  }) {
+  }: AsyncAPI2DereferenceVisitorOptions) {
     this.indirections = indirections;
     this.namespace = namespace;
     this.reference = reference;
     this.options = options;
     this.ancestors = new AncestorLineage(...ancestors);
     this.refractCache = refractCache;
-  },
-  methods: {
-    toBaseURI(uri: string): string {
-      return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
-    },
+  }
 
-    async toReference(uri: string): Promise<Reference> {
-      // detect maximum depth of resolution
-      if (this.reference.depth >= this.options.resolve.maxDepth) {
-        throw new MaximumResolveDepthError(
-          `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
-        );
-      }
+  protected toBaseURI(uri: string): string {
+    return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
+  }
 
-      const baseURI = this.toBaseURI(uri);
-      const { refSet } = this.reference;
+  protected async toReference(uri: string): Promise<Reference> {
+    // detect maximum depth of resolution
+    if (this.reference.depth >= this.options.resolve.maxDepth) {
+      throw new MaximumResolveDepthError(
+        `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
+      );
+    }
 
-      // we've already processed this Reference in past
-      if (refSet.has(baseURI)) {
-        return refSet.find(propEq(baseURI, 'uri'));
-      }
+    const baseURI = this.toBaseURI(uri);
+    const { refSet } = this.reference as { refSet: ReferenceSet };
 
-      const parseResult = await parse(url.unsanitize(baseURI), {
-        ...this.options,
-        parse: { ...this.options.parse, mediaType: 'text/plain' },
-      });
+    // we've already processed this Reference in past
+    if (refSet.has(baseURI)) {
+      return refSet.find(propEq(baseURI, 'uri'))!;
+    }
 
-      // register new mutable reference with a refSet
-      const mutableReference = new Reference({
-        uri: baseURI,
-        value: cloneDeep(parseResult),
+    const parseResult = await parse(url.unsanitize(baseURI), {
+      ...this.options,
+      parse: { ...this.options.parse, mediaType: 'text/plain' },
+    });
+
+    // register new mutable reference with a refSet
+    const mutableReference = new Reference({
+      uri: baseURI,
+      value: cloneDeep(parseResult),
+      depth: this.reference.depth + 1,
+    });
+    refSet.add(mutableReference);
+
+    if (this.options.dereference.immutable) {
+      // register new immutable reference with a refSet
+      const immutableReference = new Reference({
+        uri: `immutable://${baseURI}`,
+        value: parseResult,
         depth: this.reference.depth + 1,
       });
-      refSet.add(mutableReference);
+      refSet.add(immutableReference);
+    }
 
-      if (this.options.dereference.immutable) {
-        // register new immutable reference with a refSet
-        const immutableReference = new Reference({
-          uri: `immutable://${baseURI}`,
-          value: parseResult,
-          depth: this.reference.depth + 1,
-        });
-        refSet.add(immutableReference);
+    return mutableReference;
+  }
+
+  protected toAncestorLineage(
+    ancestors: (Element | Element[] | undefined)[],
+  ): [AncestorLineage<Element>, Set<Element>] {
+    /**
+     * Compute full ancestors lineage.
+     * Ancestors are flatten to unwrap all Element instances.
+     */
+    const directAncestors = new Set<Element>(ancestors.filter(isElement));
+    const ancestorsLineage = new AncestorLineage(...this.ancestors, directAncestors);
+
+    return [ancestorsLineage, directAncestors];
+  }
+
+  public async ReferenceElement(
+    referencingElement: ReferenceElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    // skip current referencing element as it's already been access
+    if (this.indirections.includes(referencingElement)) {
+      return false;
+    }
+
+    const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+
+    const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving internal Reference Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this reference and all it's child elements
+      return false;
+    }
+    // ignore resolving external Reference Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this reference and all it's child elements
+      return false;
+    }
+
+    const reference = await this.toReference(toValue(referencingElement.$ref));
+    const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+
+    this.indirections.push(referencingElement);
+
+    const jsonPointer = uriToPointer($refBaseURI);
+
+    // possibly non-semantic fragment
+    let referencedElement = evaluate(jsonPointer, reference.value.result as Element);
+    referencedElement.id = identityManager.identify(referencedElement);
+
+    /**
+     * Applying semantics to a referenced element if semantics are missing.
+     */
+    if (isPrimitiveElement(referencedElement)) {
+      const referencedElementType = toValue(referencingElement.meta.get('referenced-element'));
+      const cacheKey = `${referencedElementType}-${toValue(identityManager.identify(referencedElement))}`;
+
+      if (this.refractCache.has(cacheKey)) {
+        referencedElement = this.refractCache.get(cacheKey)!;
+      } else if (isReferenceLikeElement(referencedElement)) {
+        // handling indirect references
+        referencedElement = ReferenceElement.refract(referencedElement);
+        referencedElement.setMetaProperty('referenced-element', referencedElementType);
+        this.refractCache.set(cacheKey, referencedElement);
+      } else {
+        // handling direct references
+        const ElementClass = this.namespace.getElementClass(referencedElementType);
+        referencedElement = ElementClass.refract(referencedElement);
+        this.refractCache.set(cacheKey, referencedElement);
       }
+    }
 
-      return mutableReference;
-    },
+    // detect direct or circular reference
+    if (referencingElement === referencedElement) {
+      throw new ApiDOMError('Recursive Reference Object detected');
+    }
 
-    toAncestorLineage(ancestors) {
-      /**
-       * Compute full ancestors lineage.
-       * Ancestors are flatten to unwrap all Element instances.
-       */
-      const directAncestors = new Set<Element>(ancestors.filter(isElement));
-      const ancestorsLineage = new AncestorLineage(...this.ancestors, directAncestors);
+    // detect maximum depth of dereferencing
+    if (this.indirections.length > this.options.dereference.maxDepth) {
+      throw new MaximumDereferenceDepthError(
+        `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
+      );
+    }
 
-      return [ancestorsLineage, directAncestors];
-    },
+    // detect second deep dive into the same fragment and avoid it
+    if (ancestorsLineage.includes(referencedElement)) {
+      reference.refSet!.circular = true;
 
-    async ReferenceElement(
-      referencingElement: ReferenceElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
-    ) {
-      // skip current referencing element as it's already been access
-      if (this.indirections.includes(referencingElement)) {
-        return false;
-      }
-
-      const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
-
-      const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
-      const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-      const isExternalReference = !isInternalReference;
-
-      // ignore resolving internal Reference Objects
-      if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this reference and all it's child elements
-        return false;
-      }
-      // ignore resolving external Reference Objects
-      if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this reference and all it's child elements
-        return false;
-      }
-
-      const reference = await this.toReference(toValue(referencingElement.$ref));
-      const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
-
-      this.indirections.push(referencingElement);
-
-      const jsonPointer = uriToPointer($refBaseURI);
-
-      // possibly non-semantic fragment
-      let referencedElement = evaluate(jsonPointer, reference.value.result);
-      referencedElement.id = identityManager.identify(referencedElement);
-
-      /**
-       * Applying semantics to a referenced element if semantics are missing.
-       */
-      if (isPrimitiveElement(referencedElement)) {
-        const referencedElementType = toValue(referencingElement.meta.get('referenced-element'));
-        const cacheKey = `${referencedElementType}-${toValue(identityManager.identify(referencedElement))}`;
-
-        if (this.refractCache.has(cacheKey)) {
-          referencedElement = this.refractCache.get(cacheKey);
-        } else if (isReferenceLikeElement(referencedElement)) {
-          // handling indirect references
-          referencedElement = ReferenceElement.refract(referencedElement);
-          referencedElement.setMetaProperty('referenced-element', referencedElementType);
-          this.refractCache.set(cacheKey, referencedElement);
-        } else {
-          // handling direct references
-          const ElementClass = this.namespace.getElementClass(referencedElementType);
-          referencedElement = ElementClass.refract(referencedElement);
-          this.refractCache.set(cacheKey, referencedElement);
-        }
-      }
-
-      // detect direct or circular reference
-      if (referencingElement === referencedElement) {
-        throw new ApiDOMError('Recursive Reference Object detected');
-      }
-
-      // detect maximum depth of dereferencing
-      if (this.indirections.length > this.options.dereference.maxDepth) {
-        throw new MaximumDereferenceDepthError(
-          `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
-        );
-      }
-
-      // detect second deep dive into the same fragment and avoid it
-      if (ancestorsLineage.includes(referencedElement)) {
-        reference.refSet.circular = true;
-
-        if (this.options.dereference.circular === 'error') {
-          throw new ApiDOMError('Circular reference detected');
-        } else if (this.options.dereference.circular === 'replace') {
-          const refElement = new RefElement(referencedElement.id, {
-            type: 'reference',
-            uri: reference.uri,
-            $ref: toValue(referencingElement.$ref),
-          });
-          const replacer =
-            this.options.dereference.strategyOpts['asyncapi-2']?.circularReplacer ??
-            this.options.dereference.circularReplacer;
-          const replacement = replacer(refElement);
-
-          if (isMemberElement(parent)) {
-            parent.value = replacement; // eslint-disable-line no-param-reassign
-          } else if (Array.isArray(parent)) {
-            parent[key] = replacement; // eslint-disable-line no-param-reassign
-          }
-
-          return !parent ? replacement : false;
-        }
-      }
-
-      /**
-       * Dive deep into the fragment.
-       *
-       * Cases to consider:
-       *  1. We're crossing document boundary
-       *  2. Fragment is from non-root document
-       *  3. Fragment is a Reference Object. We need to follow it to get the eventual value
-       *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
-       */
-      const isNonRootDocument = url.stripHash(reference.refSet.rootRef.uri) !== reference.uri;
-      const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
-      if (
-        (isExternalReference ||
-          isNonRootDocument ||
-          isReferenceElement(referencedElement) ||
-          shouldDetectCircular) &&
-        !ancestorsLineage.includesCycle(referencedElement)
-      ) {
-        // append referencing reference to ancestors lineage
-        directAncestors.add(referencingElement);
-
-        const visitor = AsyncApi2DereferenceVisitor({
-          reference,
-          namespace: this.namespace,
-          indirections: [...this.indirections],
-          options: this.options,
-          refractCache: this.refractCache,
-          ancestors: ancestorsLineage,
-        });
-        referencedElement = await visitAsync(referencedElement, visitor, {
-          keyMap,
-          nodeTypeGetter: getNodeType,
-        });
-
-        // remove referencing reference from ancestors lineage
-        directAncestors.delete(referencingElement);
-      }
-
-      this.indirections.pop();
-
-      // Boolean JSON Schemas
-      if (isBooleanJsonSchemaElement(referencedElement as unknown)) {
-        const booleanJsonSchemaElement: BooleanElement = cloneDeep(referencedElement);
-        // assign unique id to merged element
-        booleanJsonSchemaElement.setMetaProperty('id', identityManager.generateId());
-        // annotate referenced element with info about original referencing element
-        booleanJsonSchemaElement.setMetaProperty('ref-fields', {
+      if (this.options.dereference.circular === 'error') {
+        throw new ApiDOMError('Circular reference detected');
+      } else if (this.options.dereference.circular === 'replace') {
+        const refElement = new RefElement(referencedElement.id, {
+          type: 'reference',
+          uri: reference.uri,
           $ref: toValue(referencingElement.$ref),
         });
-        // annotate referenced element with info about origin
-        booleanJsonSchemaElement.setMetaProperty('ref-origin', reference.uri);
-        // annotate fragment with info about referencing element
-        booleanJsonSchemaElement.setMetaProperty(
-          'ref-referencing-element-id',
-          cloneDeep(identityManager.identify(referencingElement)),
-        );
+        const replacer =
+          this.options.dereference.strategyOpts['asyncapi-2']?.circularReplacer ??
+          this.options.dereference.circularReplacer;
+        const replacement = replacer(refElement);
 
         if (isMemberElement(parent)) {
-          parent.value = booleanJsonSchemaElement; // eslint-disable-line no-param-reassign
+          parent.value = replacement; // eslint-disable-line no-param-reassign
         } else if (Array.isArray(parent)) {
-          parent[key] = booleanJsonSchemaElement; // eslint-disable-line no-param-reassign
+          parent[key] = replacement; // eslint-disable-line no-param-reassign
         }
 
-        return !parent ? booleanJsonSchemaElement : false;
+        return !parent ? replacement : false;
+      }
+    }
+
+    /**
+     * Dive deep into the fragment.
+     *
+     * Cases to consider:
+     *  1. We're crossing document boundary
+     *  2. Fragment is from non-root document
+     *  3. Fragment is a Reference Object. We need to follow it to get the eventual value
+     *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
+     */
+    const isNonRootDocument = url.stripHash(reference.refSet!.rootRef!.uri) !== reference.uri;
+    const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
+    if (
+      (isExternalReference ||
+        isNonRootDocument ||
+        isReferenceElement(referencedElement) ||
+        shouldDetectCircular) &&
+      !ancestorsLineage.includesCycle(referencedElement)
+    ) {
+      // append referencing reference to ancestors lineage
+      directAncestors.add(referencingElement);
+
+      const visitor = new AsyncAPI2DereferenceVisitor({
+        reference,
+        namespace: this.namespace,
+        indirections: [...this.indirections],
+        options: this.options,
+        refractCache: this.refractCache,
+        ancestors: ancestorsLineage,
+      });
+      referencedElement = await visitAsync(referencedElement, visitor, {
+        keyMap,
+        nodeTypeGetter: getNodeType,
+      });
+
+      // remove referencing reference from ancestors lineage
+      directAncestors.delete(referencingElement);
+    }
+
+    this.indirections.pop();
+
+    // Boolean JSON Schemas
+    if (isBooleanJsonSchemaElement(referencedElement as unknown)) {
+      const booleanJsonSchemaElement: BooleanElement = cloneDeep(referencedElement);
+      // assign unique id to merged element
+      booleanJsonSchemaElement.setMetaProperty('id', identityManager.generateId());
+      // annotate referenced element with info about original referencing element
+      booleanJsonSchemaElement.setMetaProperty('ref-fields', {
+        $ref: toValue(referencingElement.$ref),
+      });
+      // annotate referenced element with info about origin
+      booleanJsonSchemaElement.setMetaProperty('ref-origin', reference.uri);
+      // annotate fragment with info about referencing element
+      booleanJsonSchemaElement.setMetaProperty(
+        'ref-referencing-element-id',
+        cloneDeep(identityManager.identify(referencingElement)),
+      );
+
+      if (isMemberElement(parent)) {
+        parent.value = booleanJsonSchemaElement; // eslint-disable-line no-param-reassign
+      } else if (Array.isArray(parent)) {
+        parent[key] = booleanJsonSchemaElement; // eslint-disable-line no-param-reassign
       }
 
-      /**
-       * Creating a new version of referenced element to avoid modifying the original one.
-       */
-      const mergedElement = cloneShallow(referencedElement);
+      return !parent ? booleanJsonSchemaElement : false;
+    }
+
+    /**
+     * Creating a new version of referenced element to avoid modifying the original one.
+     */
+    const mergedElement = cloneShallow(referencedElement);
+    // assign unique id to merged element
+    mergedElement.setMetaProperty('id', identityManager.generateId());
+    // annotate referenced element with info about original referencing element
+    mergedElement.setMetaProperty('ref-fields', {
+      $ref: toValue(referencingElement.$ref),
+    });
+    // annotate fragment with info about origin
+    mergedElement.setMetaProperty('ref-origin', reference.uri);
+    // annotate fragment with info about referencing element
+    mergedElement.setMetaProperty(
+      'ref-referencing-element-id',
+      cloneDeep(identityManager.identify(referencingElement)),
+    );
+
+    /**
+     * Transclude referencing element with merged referenced element.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = mergedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = mergedElement; // eslint-disable-line no-param-reassign
+    }
+
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? mergedElement : false;
+  }
+
+  public async ChannelItemElement(
+    referencingElement: ChannelItemElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    // ignore ChannelItemElement without $ref field
+    if (!isStringElement(referencingElement.$ref)) {
+      return undefined;
+    }
+
+    // skip current referencing element as it's already been access
+    if (this.indirections.includes(referencingElement)) {
+      return false;
+    }
+
+    const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+
+    const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving internal Channel Item Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this channel item but traverse all it's child elements
+      return undefined;
+    }
+    // ignore resolving external Channel Item Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this channel item but traverse all it's child elements
+      return undefined;
+    }
+
+    const reference = await this.toReference(toValue(referencingElement.$ref));
+    const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+
+    this.indirections.push(referencingElement);
+
+    const jsonPointer = uriToPointer($refBaseURI);
+
+    // possibly non-semantic referenced element
+    let referencedElement = evaluate(jsonPointer, reference.value.result as Element);
+    referencedElement.id = identityManager.identify(referencedElement);
+
+    /**
+     * Applying semantics to a referenced element if semantics are missing.
+     */
+    if (isPrimitiveElement(referencedElement)) {
+      const cacheKey = `channel-item-${toValue(identityManager.identify(referencedElement))}`;
+
+      if (this.refractCache.has(cacheKey)) {
+        referencedElement = this.refractCache.get(cacheKey)!;
+      } else {
+        referencedElement = ChannelItemElement.refract(referencedElement);
+        this.refractCache.set(cacheKey, referencedElement);
+      }
+    }
+
+    // detect direct or indirect reference
+    if (referencingElement === referencedElement) {
+      throw new ApiDOMError('Recursive Channel Item Object reference detected');
+    }
+
+    // detect maximum depth of dereferencing
+    if (this.indirections.length > this.options.dereference.maxDepth) {
+      throw new MaximumDereferenceDepthError(
+        `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
+      );
+    }
+
+    // detect second deep dive into the same fragment and avoid it
+    if (ancestorsLineage.includes(referencedElement)) {
+      reference.refSet!.circular = true;
+
+      if (this.options.dereference.circular === 'error') {
+        throw new ApiDOMError('Circular reference detected');
+      } else if (this.options.dereference.circular === 'replace') {
+        const refElement = new RefElement(referencedElement.id, {
+          type: 'channel-item',
+          uri: reference.uri,
+          $ref: toValue(referencingElement.$ref),
+        });
+        const replacer =
+          this.options.dereference.strategyOpts['asyncapi-2']?.circularReplacer ??
+          this.options.dereference.circularReplacer;
+        const replacement = replacer(refElement);
+
+        if (isMemberElement(parent)) {
+          parent.value = replacement; // eslint-disable-line no-param-reassign
+        } else if (Array.isArray(parent)) {
+          parent[key] = replacement; // eslint-disable-line no-param-reassign
+        }
+
+        return !parent ? replacement : undefined;
+      }
+    }
+
+    /**
+     * Dive deep into the fragment.
+     *
+     * Cases to consider:
+     *  1. We're crossing document boundary
+     *  2. Fragment is from non-root document
+     *  3. Fragment is a Channel Item Object with $ref field. We need to follow it to get the eventual value
+     *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
+     */
+    const isNonRootDocument = url.stripHash(reference.refSet!.rootRef!.uri) !== reference.uri;
+    const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
+    if (
+      (isExternalReference ||
+        isNonRootDocument ||
+        (isChannelItemElement(referencedElement) && isStringElement(referencedElement.$ref)) ||
+        shouldDetectCircular) &&
+      !ancestorsLineage.includesCycle(referencedElement)
+    ) {
+      // append referencing reference to ancestors lineage
+      directAncestors.add(referencingElement);
+
+      const visitor = new AsyncAPI2DereferenceVisitor({
+        reference,
+        namespace: this.namespace,
+        indirections: [...this.indirections],
+        options: this.options,
+        refractCache: this.refractCache,
+        ancestors: ancestorsLineage,
+      });
+      referencedElement = await visitAsync(referencedElement, visitor, {
+        keyMap,
+        nodeTypeGetter: getNodeType,
+      });
+
+      // remove referencing reference from ancestors lineage
+      directAncestors.delete(referencingElement);
+    }
+
+    this.indirections.pop();
+
+    /**
+     * Creating a new version of Channel Item by merging fields from referenced Channel Item with referencing one.
+     */
+    if (isChannelItemElement(referencedElement)) {
+      const mergedElement = new ChannelItemElement(
+        [...referencedElement.content] as any,
+        cloneDeep(referencedElement.meta),
+        cloneDeep(referencedElement.attributes),
+      );
       // assign unique id to merged element
       mergedElement.setMetaProperty('id', identityManager.generateId());
+      // existing keywords from referencing ChannelItemElement overrides ones from referenced ChannelItemElement
+      referencingElement.forEach((value: Element, keyElement: Element, item: Element) => {
+        mergedElement.remove(toValue(keyElement));
+        mergedElement.content.push(item);
+      });
+      mergedElement.remove('$ref');
+
       // annotate referenced element with info about original referencing element
       mergedElement.setMetaProperty('ref-fields', {
         $ref: toValue(referencingElement.$ref),
       });
-      // annotate fragment with info about origin
+      // annotate referenced with info about origin
       mergedElement.setMetaProperty('ref-origin', reference.uri);
       // annotate fragment with info about referencing element
       mergedElement.setMetaProperty(
@@ -307,207 +507,23 @@ const AsyncApi2DereferenceVisitor = stampit({
         cloneDeep(identityManager.identify(referencingElement)),
       );
 
-      /**
-       * Transclude referencing element with merged referenced element.
-       */
-      if (isMemberElement(parent)) {
-        parent.value = mergedElement; // eslint-disable-line no-param-reassign
-      } else if (Array.isArray(parent)) {
-        parent[key] = mergedElement; // eslint-disable-line no-param-reassign
-      }
+      referencedElement = mergedElement;
+    }
 
-      /**
-       * We're at the root of the tree, so we're just replacing the entire tree.
-       */
-      return !parent ? mergedElement : false;
-    },
+    /**
+     * Transclude referencing element with merged referenced element.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = referencedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = referencedElement; // eslint-disable-line no-param-reassign
+    }
 
-    async ChannelItemElement(
-      referencingElement: ChannelItemElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
-    ) {
-      // ignore ChannelItemElement without $ref field
-      if (!isStringElement(referencingElement.$ref)) {
-        return undefined;
-      }
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? referencedElement : undefined;
+  }
+}
 
-      // skip current referencing element as it's already been access
-      if (this.indirections.includes(referencingElement)) {
-        return false;
-      }
-
-      const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
-
-      const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
-      const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-      const isExternalReference = !isInternalReference;
-
-      // ignore resolving internal Channel Item Objects
-      if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this channel item but traverse all it's child elements
-        return undefined;
-      }
-      // ignore resolving external Channel Item Objects
-      if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this channel item but traverse all it's child elements
-        return undefined;
-      }
-
-      const reference = await this.toReference(toValue(referencingElement.$ref));
-      const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
-
-      this.indirections.push(referencingElement);
-
-      const jsonPointer = uriToPointer($refBaseURI);
-
-      // possibly non-semantic referenced element
-      let referencedElement = evaluate(jsonPointer, reference.value.result);
-      referencedElement.id = identityManager.identify(referencedElement);
-
-      /**
-       * Applying semantics to a referenced element if semantics are missing.
-       */
-      if (isPrimitiveElement(referencedElement)) {
-        const cacheKey = `channel-item-${toValue(identityManager.identify(referencedElement))}`;
-
-        if (this.refractCache.has(cacheKey)) {
-          referencedElement = this.refractCache.get(cacheKey);
-        } else {
-          referencedElement = ChannelItemElement.refract(referencedElement);
-          this.refractCache.set(cacheKey, referencedElement);
-        }
-      }
-
-      // detect direct or indirect reference
-      if (referencingElement === referencedElement) {
-        throw new ApiDOMError('Recursive Channel Item Object reference detected');
-      }
-
-      // detect maximum depth of dereferencing
-      if (this.indirections.length > this.options.dereference.maxDepth) {
-        throw new MaximumDereferenceDepthError(
-          `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
-        );
-      }
-
-      // detect second deep dive into the same fragment and avoid it
-      if (ancestorsLineage.includes(referencedElement)) {
-        reference.refSet.circular = true;
-
-        if (this.options.dereference.circular === 'error') {
-          throw new ApiDOMError('Circular reference detected');
-        } else if (this.options.dereference.circular === 'replace') {
-          const refElement = new RefElement(referencedElement.id, {
-            type: 'channel-item',
-            uri: reference.uri,
-            $ref: toValue(referencingElement.$ref),
-          });
-          const replacer =
-            this.options.dereference.strategyOpts['asyncapi-2']?.circularReplacer ??
-            this.options.dereference.circularReplacer;
-          const replacement = replacer(refElement);
-
-          if (isMemberElement(parent)) {
-            parent.value = replacement; // eslint-disable-line no-param-reassign
-          } else if (Array.isArray(parent)) {
-            parent[key] = replacement; // eslint-disable-line no-param-reassign
-          }
-
-          return !parent ? replacement : undefined;
-        }
-      }
-
-      /**
-       * Dive deep into the fragment.
-       *
-       * Cases to consider:
-       *  1. We're crossing document boundary
-       *  2. Fragment is from non-root document
-       *  3. Fragment is a Channel Item Object with $ref field. We need to follow it to get the eventual value
-       *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
-       */
-      const isNonRootDocument = url.stripHash(reference.refSet.rootRef.uri) !== reference.uri;
-      const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
-      if (
-        (isExternalReference ||
-          isNonRootDocument ||
-          (isChannelItemElement(referencedElement) && isStringElement(referencedElement.$ref)) ||
-          shouldDetectCircular) &&
-        !ancestorsLineage.includesCycle(referencedElement)
-      ) {
-        // append referencing reference to ancestors lineage
-        directAncestors.add(referencingElement);
-
-        const visitor = AsyncApi2DereferenceVisitor({
-          reference,
-          namespace: this.namespace,
-          indirections: [...this.indirections],
-          options: this.options,
-          refractCache: this.refractCache,
-          ancestors: ancestorsLineage,
-        });
-        referencedElement = await visitAsync(referencedElement, visitor, {
-          keyMap,
-          nodeTypeGetter: getNodeType,
-        });
-
-        // remove referencing reference from ancestors lineage
-        directAncestors.delete(referencingElement);
-      }
-
-      this.indirections.pop();
-
-      /**
-       * Creating a new version of Channel Item by merging fields from referenced Channel Item with referencing one.
-       */
-      if (isChannelItemElement(referencedElement)) {
-        const mergedElement = new ChannelItemElement(
-          [...referencedElement.content] as any,
-          cloneDeep(referencedElement.meta),
-          cloneDeep(referencedElement.attributes),
-        );
-        // assign unique id to merged element
-        mergedElement.setMetaProperty('id', identityManager.generateId());
-        // existing keywords from referencing ChannelItemElement overrides ones from referenced ChannelItemElement
-        referencingElement.forEach((value: Element, keyElement: Element, item: Element) => {
-          mergedElement.remove(toValue(keyElement));
-          mergedElement.content.push(item);
-        });
-        mergedElement.remove('$ref');
-
-        // annotate referenced element with info about original referencing element
-        mergedElement.setMetaProperty('ref-fields', {
-          $ref: toValue(referencingElement.$ref),
-        });
-        // annotate referenced with info about origin
-        mergedElement.setMetaProperty('ref-origin', reference.uri);
-        // annotate fragment with info about referencing element
-        mergedElement.setMetaProperty(
-          'ref-referencing-element-id',
-          cloneDeep(identityManager.identify(referencingElement)),
-        );
-
-        referencedElement = mergedElement;
-      }
-
-      /**
-       * Transclude referencing element with merged referenced element.
-       */
-      if (isMemberElement(parent)) {
-        parent.value = referencedElement; // eslint-disable-line no-param-reassign
-      } else if (Array.isArray(parent)) {
-        parent[key] = referencedElement; // eslint-disable-line no-param-reassign
-      }
-
-      /**
-       * We're at the root of the tree, so we're just replacing the entire tree.
-       */
-      return !parent ? referencedElement : undefined;
-    },
-  },
-});
-
-export default AsyncApi2DereferenceVisitor;
+export default AsyncAPI2DereferenceVisitor;

--- a/packages/apidom-reference/src/dereference/strategies/openapi-2/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-2/index.ts
@@ -10,7 +10,7 @@ import DereferenceStrategy, { DereferenceStrategyOptions } from '../DereferenceS
 import File from '../../../File';
 import Reference from '../../../Reference';
 import ReferenceSet from '../../../ReferenceSet';
-import OpenApi2DereferenceVisitor from './visitor';
+import OpenAPI2DereferenceVisitor from './visitor';
 import type { ReferenceOptions } from '../../../options';
 
 // @ts-ignore
@@ -67,7 +67,7 @@ class OpenAPI2DereferenceStrategy extends DereferenceStrategy {
       refSet = mutableRefSet;
     }
 
-    const visitor = OpenApi2DereferenceVisitor({ reference, namespace, options });
+    const visitor = new OpenAPI2DereferenceVisitor({ reference: reference!, namespace, options });
     const dereferencedElement = await visitAsync(refSet.rootRef!.value, visitor, {
       keyMap,
       nodeTypeGetter: getNodeType,
@@ -105,4 +105,5 @@ class OpenAPI2DereferenceStrategy extends DereferenceStrategy {
   }
 }
 
+export { OpenAPI2DereferenceVisitor };
 export default OpenAPI2DereferenceStrategy;

--- a/packages/apidom-reference/src/dereference/strategies/openapi-2/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-2/visitor.ts
@@ -1,4 +1,3 @@
-import stampit from 'stampit';
 import { propEq } from 'ramda';
 import {
   Element,
@@ -12,6 +11,7 @@ import {
   cloneShallow,
   cloneDeep,
   toValue,
+  Namespace,
 } from '@swagger-api/apidom-core';
 import { ApiDOMError } from '@swagger-api/apidom-error';
 import { evaluate, uriToPointer } from '@swagger-api/apidom-json-pointer';
@@ -34,6 +34,9 @@ import { AncestorLineage } from '../../util';
 import * as url from '../../../util/url';
 import parse from '../../../parse';
 import Reference from '../../../Reference';
+import ReferenceSet from '../../../ReferenceSet';
+import type { ReferenceOptions } from '../../../options';
+import { AsyncAPI2DereferenceVisitorOptions } from '../asyncapi-2/visitor';
 
 // @ts-ignore
 const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
@@ -41,600 +44,437 @@ const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
 // initialize element identity manager
 const identityManager = new IdentityManager();
 
-const OpenApi2DereferenceVisitor = stampit({
-  props: {
-    indirections: [],
-    namespace: null,
-    reference: null,
-    options: null,
-    refractCache: null,
-    ancestors: null,
-  },
-  init({
-    indirections = [],
+export interface OpenAPI2DereferenceVisitorOptions {
+  readonly namespace: Namespace;
+  readonly reference: Reference;
+  readonly options: ReferenceOptions;
+  readonly indirections?: Element[];
+  readonly ancestors?: AncestorLineage<Element>;
+  readonly refractCache?: Map<string, Element>;
+}
+
+class OpenAPI2DereferenceVisitor {
+  protected readonly indirections: Element[];
+
+  protected readonly namespace: Namespace;
+
+  protected readonly reference: Reference;
+
+  protected readonly options: ReferenceOptions;
+
+  protected readonly ancestors: AncestorLineage<Element>;
+
+  protected readonly refractCache: Map<string, Element>;
+
+  constructor({
     reference,
     namespace,
     options,
-    refractCache = new Map(),
+    indirections = [],
     ancestors = new AncestorLineage(),
-  }) {
+    refractCache = new Map(),
+  }: AsyncAPI2DereferenceVisitorOptions) {
     this.indirections = indirections;
     this.namespace = namespace;
     this.reference = reference;
     this.options = options;
     this.ancestors = new AncestorLineage(...ancestors);
     this.refractCache = refractCache;
-  },
-  methods: {
-    toBaseURI(uri: string): string {
-      return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
-    },
+  }
 
-    async toReference(uri: string): Promise<Reference> {
-      // detect maximum depth of resolution
-      if (this.reference.depth >= this.options.resolve.maxDepth) {
-        throw new MaximumResolveDepthError(
-          `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
-        );
-      }
+  protected toBaseURI(uri: string): string {
+    return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
+  }
 
-      const baseURI = this.toBaseURI(uri);
-      const { refSet } = this.reference;
+  protected async toReference(uri: string): Promise<Reference> {
+    // detect maximum depth of resolution
+    if (this.reference.depth >= this.options.resolve.maxDepth) {
+      throw new MaximumResolveDepthError(
+        `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
+      );
+    }
 
-      // we've already processed this Reference in past
-      if (refSet.has(baseURI)) {
-        return refSet.find(propEq(baseURI, 'uri'));
-      }
+    const baseURI = this.toBaseURI(uri);
+    const { refSet } = this.reference as { refSet: ReferenceSet };
 
-      const parseResult = await parse(url.unsanitize(baseURI), {
-        ...this.options,
-        parse: { ...this.options.parse, mediaType: 'text/plain' },
-      });
+    // we've already processed this Reference in past
+    if (refSet.has(baseURI)) {
+      return refSet.find(propEq(baseURI, 'uri'))!;
+    }
 
-      // register new mutable reference with a refSet
-      const mutableReference = new Reference({
-        uri: baseURI,
-        value: cloneDeep(parseResult),
+    const parseResult = await parse(url.unsanitize(baseURI), {
+      ...this.options,
+      parse: { ...this.options.parse, mediaType: 'text/plain' },
+    });
+
+    // register new mutable reference with a refSet
+    const mutableReference = new Reference({
+      uri: baseURI,
+      value: cloneDeep(parseResult),
+      depth: this.reference.depth + 1,
+    });
+    refSet.add(mutableReference);
+
+    if (this.options.dereference.immutable) {
+      // register new immutable reference with a refSet
+      const immutableReference = new Reference({
+        uri: `immutable://${baseURI}`,
+        value: parseResult,
         depth: this.reference.depth + 1,
       });
-      refSet.add(mutableReference);
+      refSet.add(immutableReference);
+    }
 
-      if (this.options.dereference.immutable) {
-        // register new immutable reference with a refSet
-        const immutableReference = new Reference({
-          uri: `immutable://${baseURI}`,
-          value: parseResult,
-          depth: this.reference.depth + 1,
-        });
-        refSet.add(immutableReference);
+    return mutableReference;
+  }
+
+  protected toAncestorLineage(
+    ancestors: (Element | Element[] | undefined)[],
+  ): [AncestorLineage<Element>, Set<Element>] {
+    /**
+     * Compute full ancestors lineage.
+     * Ancestors are flatten to unwrap all Element instances.
+     */
+    const directAncestors = new Set<Element>(ancestors.filter(isElement));
+    const ancestorsLineage = new AncestorLineage(...this.ancestors, directAncestors);
+
+    return [ancestorsLineage, directAncestors];
+  }
+
+  public async ReferenceElement(
+    referencingElement: ReferenceElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    // skip current referencing element as it's already been access
+    if (this.indirections.includes(referencingElement)) {
+      return false;
+    }
+
+    const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+
+    const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving internal Reference Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this reference element and all it's child elements
+      return false;
+    }
+    // ignore resolving external Reference Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this reference element and all it's child elements
+      return false;
+    }
+
+    const reference = await this.toReference(toValue(referencingElement.$ref));
+    const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+
+    this.indirections.push(referencingElement);
+
+    const jsonPointer = uriToPointer($refBaseURI);
+
+    // possibly non-semantic fragment
+    let referencedElement = evaluate(jsonPointer, reference.value.result as Element);
+    referencedElement.id = identityManager.identify(referencedElement);
+
+    /**
+     * Applying semantics to a referenced element if semantics are missing.
+     */
+    if (isPrimitiveElement(referencedElement)) {
+      const referencedElementType = toValue(referencingElement.meta.get('referenced-element'));
+      const cacheKey = `${referencedElementType}-${toValue(identityManager.identify(referencedElement))}`;
+
+      if (this.refractCache.has(cacheKey)) {
+        referencedElement = this.refractCache.get(cacheKey)!;
+      } else if (isReferenceLikeElement(referencedElement)) {
+        // handling indirect references
+        referencedElement = ReferenceElement.refract(referencedElement);
+        referencedElement.setMetaProperty('referenced-element', referencedElementType);
+        this.refractCache.set(cacheKey, referencedElement);
+      } else {
+        // handling direct references
+        const ElementClass = this.namespace.getElementClass(referencedElementType);
+        referencedElement = ElementClass.refract(referencedElement);
+        this.refractCache.set(cacheKey, referencedElement);
       }
+    }
 
-      return mutableReference;
-    },
+    // detect direct or circular reference
+    if (referencingElement === referencedElement) {
+      throw new ApiDOMError('Recursive Reference Object detected');
+    }
 
-    toAncestorLineage(ancestors) {
-      /**
-       * Compute full ancestors lineage.
-       * Ancestors are flatten to unwrap all Element instances.
-       */
-      const directAncestors = new Set<Element>(ancestors.filter(isElement));
-      const ancestorsLineage = new AncestorLineage(...this.ancestors, directAncestors);
-
-      return [ancestorsLineage, directAncestors];
-    },
-
-    async ReferenceElement(
-      referencingElement: ReferenceElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
-    ) {
-      // skip current referencing element as it's already been access
-      if (this.indirections.includes(referencingElement)) {
-        return false;
-      }
-
-      const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
-
-      const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
-      const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-      const isExternalReference = !isInternalReference;
-
-      // ignore resolving internal Reference Objects
-      if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this reference element and all it's child elements
-        return false;
-      }
-      // ignore resolving external Reference Objects
-      if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this reference element and all it's child elements
-        return false;
-      }
-
-      const reference = await this.toReference(toValue(referencingElement.$ref));
-      const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
-
-      this.indirections.push(referencingElement);
-
-      const jsonPointer = uriToPointer($refBaseURI);
-
-      // possibly non-semantic fragment
-      let referencedElement = evaluate(jsonPointer, reference.value.result);
-      referencedElement.id = identityManager.identify(referencedElement);
-
-      /**
-       * Applying semantics to a referenced element if semantics are missing.
-       */
-      if (isPrimitiveElement(referencedElement)) {
-        const referencedElementType = toValue(referencingElement.meta.get('referenced-element'));
-        const cacheKey = `${referencedElementType}-${toValue(identityManager.identify(referencedElement))}`;
-
-        if (this.refractCache.has(cacheKey)) {
-          referencedElement = this.refractCache.get(cacheKey);
-        } else if (isReferenceLikeElement(referencedElement)) {
-          // handling indirect references
-          referencedElement = ReferenceElement.refract(referencedElement);
-          referencedElement.setMetaProperty('referenced-element', referencedElementType);
-          this.refractCache.set(cacheKey, referencedElement);
-        } else {
-          // handling direct references
-          const ElementClass = this.namespace.getElementClass(referencedElementType);
-          referencedElement = ElementClass.refract(referencedElement);
-          this.refractCache.set(cacheKey, referencedElement);
-        }
-      }
-
-      // detect direct or circular reference
-      if (referencingElement === referencedElement) {
-        throw new ApiDOMError('Recursive Reference Object detected');
-      }
-
-      // detect maximum depth of dereferencing
-      if (this.indirections.length > this.options.dereference.maxDepth) {
-        throw new MaximumDereferenceDepthError(
-          `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
-        );
-      }
-
-      // detect second deep dive into the same fragment and avoid it
-      if (ancestorsLineage.includes(referencedElement)) {
-        reference.refSet.circular = true;
-
-        if (this.options.dereference.circular === 'error') {
-          throw new ApiDOMError('Circular reference detected');
-        } else if (this.options.dereference.circular === 'replace') {
-          const refElement = new RefElement(referencedElement.id, {
-            type: 'reference',
-            uri: reference.uri,
-            $ref: toValue(referencingElement.$ref),
-          });
-          const replacer =
-            this.options.dereference.strategyOpts['openapi-2']?.circularReplacer ??
-            this.options.dereference.circularReplacer;
-          const replacement = replacer(refElement);
-
-          if (isMemberElement(parent)) {
-            parent.value = replacement; // eslint-disable-line no-param-reassign
-          } else if (Array.isArray(parent)) {
-            parent[key] = replacement; // eslint-disable-line no-param-reassign
-          }
-
-          return !parent ? replacement : false;
-        }
-      }
-
-      /**
-       * Dive deep into the fragment.
-       *
-       * Cases to consider:
-       *  1. We're crossing document boundary
-       *  2. Fragment is from non-root document
-       *  3. Fragment is a Reference Object. We need to follow it to get the eventual value
-       *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
-       */
-      const isNonRootDocument = url.stripHash(reference.refSet.rootRef.uri) !== reference.uri;
-      const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
-      if (
-        (isExternalReference ||
-          isNonRootDocument ||
-          isReferenceElement(referencedElement) ||
-          shouldDetectCircular) &&
-        !ancestorsLineage.includesCycle(referencedElement)
-      ) {
-        // append referencing reference to ancestors lineage
-        directAncestors.add(referencingElement);
-
-        const visitor = OpenApi2DereferenceVisitor({
-          reference,
-          namespace: this.namespace,
-          indirections: [...this.indirections],
-          options: this.options,
-          refractCache: this.refractCache,
-          ancestors: ancestorsLineage,
-        });
-        referencedElement = await visitAsync(referencedElement, visitor, {
-          keyMap,
-          nodeTypeGetter: getNodeType,
-        });
-
-        // remove referencing reference from ancestors lineage
-        directAncestors.delete(referencingElement);
-      }
-
-      this.indirections.pop();
-
-      /**
-       * Creating a new version of referenced element to avoid modifying the original one.
-       */
-      const mergedElement = cloneShallow(referencedElement);
-      // assign unique id to merged element
-      mergedElement.setMetaProperty('id', identityManager.generateId());
-      // annotate referenced element with info about original referencing element
-      mergedElement.setMetaProperty('ref-fields', {
-        // @ts-ignore
-        $ref: toValue(referencingElement.$ref),
-      });
-      // annotate fragment with info about origin
-      mergedElement.setMetaProperty('ref-origin', reference.uri);
-      // annotate fragment with info about referencing element
-      mergedElement.setMetaProperty(
-        'ref-referencing-element-id',
-        cloneDeep(identityManager.identify(referencingElement)),
+    // detect maximum depth of dereferencing
+    if (this.indirections.length > this.options.dereference.maxDepth) {
+      throw new MaximumDereferenceDepthError(
+        `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
       );
+    }
 
-      /**
-       * Transclude referencing element with merged referenced element.
-       */
-      if (isMemberElement(parent)) {
-        parent.value = mergedElement; // eslint-disable-line no-param-reassign
-      } else if (Array.isArray(parent)) {
-        parent[key] = mergedElement; // eslint-disable-line no-param-reassign
-      }
+    // detect second deep dive into the same fragment and avoid it
+    if (ancestorsLineage.includes(referencedElement)) {
+      reference.refSet!.circular = true;
 
-      /**
-       * We're at the root of the tree, so we're just replacing the entire tree.
-       */
-      return !parent ? mergedElement : false;
-    },
-
-    async PathItemElement(
-      referencingElement: PathItemElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
-    ) {
-      // ignore PathItemElement without $ref field
-      if (!isStringElement(referencingElement.$ref)) {
-        return undefined;
-      }
-
-      // skip current referencing element as it's already been access
-      if (this.indirections.includes(referencingElement)) {
-        return false;
-      }
-
-      const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
-
-      const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
-      const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-      const isExternalReference = !isInternalReference;
-
-      // ignore resolving internal Path Item Objects
-      if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this Path Item element but traverse all it's child elements
-        return undefined;
-      }
-      // ignore resolving external Path Item Objects
-      if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this Path Item element but traverse all it's child elements
-        return undefined;
-      }
-
-      const reference = await this.toReference(toValue(referencingElement.$ref));
-      const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
-
-      this.indirections.push(referencingElement);
-
-      const jsonPointer = uriToPointer($refBaseURI);
-
-      // possibly non-semantic referenced element
-      let referencedElement = evaluate(jsonPointer, reference.value.result);
-      referencedElement.id = identityManager.identify(referencedElement);
-
-      /**
-       * Applying semantics to a referenced element if semantics are missing.
-       */
-      if (isPrimitiveElement(referencedElement)) {
-        const cacheKey = `pathItem-${toValue(identityManager.identify(referencedElement))}`;
-
-        if (this.refractCache.has(cacheKey)) {
-          referencedElement = this.refractCache.get(cacheKey);
-        } else {
-          referencedElement = PathItemElement.refract(referencedElement);
-          this.refractCache.set(cacheKey, referencedElement);
-        }
-      }
-
-      // detect direct or indirect reference
-      if (referencingElement === referencedElement) {
-        throw new ApiDOMError('Recursive Path Item Object reference detected');
-      }
-
-      // detect maximum depth of dereferencing
-      if (this.indirections.length > this.options.dereference.maxDepth) {
-        throw new MaximumDereferenceDepthError(
-          `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
-        );
-      }
-
-      // detect second deep dive into the same fragment and avoid it
-      if (ancestorsLineage.includes(referencedElement)) {
-        reference.refSet.circular = true;
-
-        if (this.options.dereference.circular === 'error') {
-          throw new ApiDOMError('Circular reference detected');
-        } else if (this.options.dereference.circular === 'replace') {
-          const refElement = new RefElement(referencedElement.id, {
-            type: 'path-item',
-            uri: reference.uri,
-            $ref: toValue(referencingElement.$ref),
-          });
-          const replacer =
-            this.options.dereference.strategyOpts['openapi-2']?.circularReplacer ??
-            this.options.dereference.circularReplacer;
-          const replacement = replacer(refElement);
-
-          if (isMemberElement(parent)) {
-            parent.value = replacement; // eslint-disable-line no-param-reassign
-          } else if (Array.isArray(parent)) {
-            parent[key] = replacement; // eslint-disable-line no-param-reassign
-          }
-
-          return !parent ? replacement : false;
-        }
-      }
-
-      /**
-       * Dive deep into the fragment.
-       *
-       * Cases to consider:
-       *  1. We're crossing document boundary
-       *  2. Fragment is from non-root document
-       *  3. Fragment is a Paht Item Object with $ref field. We need to follow it to get the eventual value
-       *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
-       */
-      const isNonRootDocument = url.stripHash(reference.refSet.rootRef.uri) !== reference.uri;
-      const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
-      if (
-        (isExternalReference ||
-          isNonRootDocument ||
-          (isPathItemElement(referencedElement) && isStringElement(referencedElement.$ref)) ||
-          shouldDetectCircular) &&
-        !ancestorsLineage.includesCycle(referencedElement)
-      ) {
-        // append referencing reference to ancestors lineage
-        directAncestors.add(referencingElement);
-
-        const visitor = OpenApi2DereferenceVisitor({
-          reference,
-          namespace: this.namespace,
-          indirections: [...this.indirections],
-          options: this.options,
-          refractCache: this.refractCache,
-          ancestors: ancestorsLineage,
-        });
-        referencedElement = await visitAsync(referencedElement, visitor, {
-          keyMap,
-          nodeTypeGetter: getNodeType,
-        });
-
-        // remove referencing reference from ancestors lineage
-        directAncestors.delete(referencingElement);
-      }
-
-      this.indirections.pop();
-
-      // merge fields from referenced Path Item with referencing one
-      if (isPathItemElement(referencedElement)) {
-        const mergedElement = new PathItemElement(
-          [...referencedElement.content] as any,
-          cloneDeep(referencedElement.meta),
-          cloneDeep(referencedElement.attributes),
-        );
-        // assign unique id to merged element
-        mergedElement.setMetaProperty('id', identityManager.generateId());
-        // existing keywords from referencing PathItemElement overrides ones from referenced element
-        referencingElement.forEach((value: Element, keyElement: Element, item: Element) => {
-          mergedElement.remove(toValue(keyElement));
-          mergedElement.content.push(item);
-        });
-        mergedElement.remove('$ref');
-
-        // annotate referenced element with info about original referencing element
-        mergedElement.setMetaProperty('ref-fields', {
+      if (this.options.dereference.circular === 'error') {
+        throw new ApiDOMError('Circular reference detected');
+      } else if (this.options.dereference.circular === 'replace') {
+        const refElement = new RefElement(referencedElement.id, {
+          type: 'reference',
+          uri: reference.uri,
           $ref: toValue(referencingElement.$ref),
         });
-        // annotate referenced element with info about origin
-        mergedElement.setMetaProperty('ref-origin', reference.uri);
-        // annotate fragment with info about referencing element
-        mergedElement.setMetaProperty(
-          'ref-referencing-element-id',
-          cloneDeep(identityManager.identify(referencingElement)),
-        );
+        const replacer =
+          this.options.dereference.strategyOpts['openapi-2']?.circularReplacer ??
+          this.options.dereference.circularReplacer;
+        const replacement = replacer(refElement);
 
-        referencedElement = mergedElement;
+        if (isMemberElement(parent)) {
+          parent.value = replacement; // eslint-disable-line no-param-reassign
+        } else if (Array.isArray(parent)) {
+          parent[key] = replacement; // eslint-disable-line no-param-reassign
+        }
+
+        return !parent ? replacement : false;
       }
+    }
 
-      /**
-       * Transclude referencing element with merged referenced element.
-       */
-      if (isMemberElement(parent)) {
-        parent.value = referencedElement; // eslint-disable-line no-param-reassign
-      } else if (Array.isArray(parent)) {
-        parent[key] = referencedElement; // eslint-disable-line no-param-reassign
-      }
-
-      /**
-       * We're at the root of the tree, so we're just replacing the entire tree.
-       */
-      return !parent ? referencedElement : undefined;
-    },
-
-    async JSONReferenceElement(
-      referencingElement: JSONReferenceElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
+    /**
+     * Dive deep into the fragment.
+     *
+     * Cases to consider:
+     *  1. We're crossing document boundary
+     *  2. Fragment is from non-root document
+     *  3. Fragment is a Reference Object. We need to follow it to get the eventual value
+     *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
+     */
+    const isNonRootDocument = url.stripHash(reference.refSet!.rootRef!.uri) !== reference.uri;
+    const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
+    if (
+      (isExternalReference ||
+        isNonRootDocument ||
+        isReferenceElement(referencedElement) ||
+        shouldDetectCircular) &&
+      !ancestorsLineage.includesCycle(referencedElement)
     ) {
-      // skip current referencing element as it's already been access
-      if (this.indirections.includes(referencingElement)) {
-        return false;
+      // append referencing reference to ancestors lineage
+      directAncestors.add(referencingElement);
+
+      const visitor = new OpenAPI2DereferenceVisitor({
+        reference,
+        namespace: this.namespace,
+        indirections: [...this.indirections],
+        options: this.options,
+        refractCache: this.refractCache,
+        ancestors: ancestorsLineage,
+      });
+      referencedElement = await visitAsync(referencedElement, visitor, {
+        keyMap,
+        nodeTypeGetter: getNodeType,
+      });
+
+      // remove referencing reference from ancestors lineage
+      directAncestors.delete(referencingElement);
+    }
+
+    this.indirections.pop();
+
+    /**
+     * Creating a new version of referenced element to avoid modifying the original one.
+     */
+    const mergedElement = cloneShallow(referencedElement);
+    // assign unique id to merged element
+    mergedElement.setMetaProperty('id', identityManager.generateId());
+    // annotate referenced element with info about original referencing element
+    mergedElement.setMetaProperty('ref-fields', {
+      // @ts-ignore
+      $ref: toValue(referencingElement.$ref),
+    });
+    // annotate fragment with info about origin
+    mergedElement.setMetaProperty('ref-origin', reference.uri);
+    // annotate fragment with info about referencing element
+    mergedElement.setMetaProperty(
+      'ref-referencing-element-id',
+      cloneDeep(identityManager.identify(referencingElement)),
+    );
+
+    /**
+     * Transclude referencing element with merged referenced element.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = mergedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = mergedElement; // eslint-disable-line no-param-reassign
+    }
+
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? mergedElement : false;
+  }
+
+  public async PathItemElement(
+    referencingElement: PathItemElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    // ignore PathItemElement without $ref field
+    if (!isStringElement(referencingElement.$ref)) {
+      return undefined;
+    }
+
+    // skip current referencing element as it's already been access
+    if (this.indirections.includes(referencingElement)) {
+      return false;
+    }
+
+    const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+
+    const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving internal Path Item Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this Path Item element but traverse all it's child elements
+      return undefined;
+    }
+    // ignore resolving external Path Item Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this Path Item element but traverse all it's child elements
+      return undefined;
+    }
+
+    const reference = await this.toReference(toValue(referencingElement.$ref));
+    const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+
+    this.indirections.push(referencingElement);
+
+    const jsonPointer = uriToPointer($refBaseURI);
+
+    // possibly non-semantic referenced element
+    let referencedElement = evaluate(jsonPointer, reference.value.result as Element);
+    referencedElement.id = identityManager.identify(referencedElement);
+
+    /**
+     * Applying semantics to a referenced element if semantics are missing.
+     */
+    if (isPrimitiveElement(referencedElement)) {
+      const cacheKey = `pathItem-${toValue(identityManager.identify(referencedElement))}`;
+
+      if (this.refractCache.has(cacheKey)) {
+        referencedElement = this.refractCache.get(cacheKey)!;
+      } else {
+        referencedElement = PathItemElement.refract(referencedElement);
+        this.refractCache.set(cacheKey, referencedElement);
       }
+    }
 
-      const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+    // detect direct or indirect reference
+    if (referencingElement === referencedElement) {
+      throw new ApiDOMError('Recursive Path Item Object reference detected');
+    }
 
-      const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
-      const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-      const isExternalReference = !isInternalReference;
+    // detect maximum depth of dereferencing
+    if (this.indirections.length > this.options.dereference.maxDepth) {
+      throw new MaximumDereferenceDepthError(
+        `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
+      );
+    }
 
-      // ignore resolving internal JSONReference Objects
-      if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this JSONReference element and all it's child elements
-        return false;
-      }
-      // ignore resolving external JSONReference Objects
-      if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this JSONReference element and all it's child elements
-        return false;
-      }
+    // detect second deep dive into the same fragment and avoid it
+    if (ancestorsLineage.includes(referencedElement)) {
+      reference.refSet!.circular = true;
 
-      const reference = await this.toReference(toValue(referencingElement.$ref));
-      const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
-
-      this.indirections.push(referencingElement);
-
-      const jsonPointer = uriToPointer($refBaseURI);
-
-      // possibly non-semantic fragment
-      let referencedElement = evaluate(jsonPointer, reference.value.result);
-      referencedElement.id = identityManager.identify(referencedElement);
-
-      /**
-       * Applying semantics to a referenced element if semantics are missing.
-       */
-      if (isPrimitiveElement(referencedElement)) {
-        const referencedElementType = toValue(referencingElement.meta.get('referenced-element'));
-        const cacheKey = `path-item-${toValue(identityManager.identify(referencedElement))}`;
-
-        if (this.refractCache.has(cacheKey)) {
-          referencedElement = this.refractCache.get(cacheKey);
-        } else if (isJSONReferenceLikeElement(referencedElement)) {
-          // handling indirect references
-          referencedElement = ReferenceElement.refract(referencedElement);
-          referencedElement.setMetaProperty('referenced-element', referencedElementType);
-          this.refractCache.set(cacheKey, referencedElement);
-        } else {
-          // handling direct references
-          const ElementClass = this.namespace.getElementClass(referencedElementType);
-          referencedElement = ElementClass.refract(referencedElement);
-          this.refractCache.set(cacheKey, referencedElement);
-        }
-      }
-
-      // detect direct or circular reference
-      if (referencingElement === referencedElement) {
-        throw new ApiDOMError('Recursive Reference Object detected');
-      }
-
-      // detect maximum depth of dereferencing
-      if (this.indirections.length > this.options.dereference.maxDepth) {
-        throw new MaximumDereferenceDepthError(
-          `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
-        );
-      }
-
-      // detect second deep dive into the same fragment and avoid it
-      if (ancestorsLineage.includes(referencedElement)) {
-        if (this.options.dereference.circular === 'error') {
-          throw new ApiDOMError('Circular reference detected');
-        } else if (this.options.dereference.circular === 'replace') {
-          const refElement = new RefElement(referencedElement.id, {
-            type: 'json-reference',
-            uri: reference.uri,
-            $ref: toValue(referencingElement.$ref),
-          });
-          const replacer =
-            this.options.dereference.strategyOpts['openapi-2']?.circularReplacer ??
-            this.options.dereference.circularReplacer;
-          const replacement = replacer(refElement);
-
-          if (isMemberElement(parent)) {
-            parent.value = replacement; // eslint-disable-line no-param-reassign
-          } else if (Array.isArray(parent)) {
-            parent[key] = replacement; // eslint-disable-line no-param-reassign
-          }
-
-          reference.refSet.circular = true;
-
-          return !parent ? replacement : false;
-        }
-      }
-
-      /**
-       * Dive deep into the fragment.
-       *
-       * Cases to consider:
-       *  1. We're crossing document boundary
-          2. Fragment is from non-root document
-       *  3. Fragment is a JSON Reference Object. We need to follow it to get the eventual value
-       *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
-       */
-      const isNonRootDocument = url.stripHash(reference.refSet.rootRef.uri) !== reference.uri;
-      const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
-      if (
-        (isExternalReference ||
-          isNonRootDocument ||
-          isJSONReferenceElement(referencedElement) ||
-          shouldDetectCircular) &&
-        !ancestorsLineage.includesCycle(referencedElement)
-      ) {
-        // append referencing reference to ancestors lineage
-        directAncestors.add(referencingElement);
-
-        const visitor = OpenApi2DereferenceVisitor({
-          reference,
-          namespace: this.namespace,
-          indirections: [...this.indirections],
-          options: this.options,
-          refractCache: this.refractCache,
-          ancestors: ancestorsLineage,
+      if (this.options.dereference.circular === 'error') {
+        throw new ApiDOMError('Circular reference detected');
+      } else if (this.options.dereference.circular === 'replace') {
+        const refElement = new RefElement(referencedElement.id, {
+          type: 'path-item',
+          uri: reference.uri,
+          $ref: toValue(referencingElement.$ref),
         });
-        referencedElement = await visitAsync(referencedElement, visitor, {
-          keyMap,
-          nodeTypeGetter: getNodeType,
-        });
+        const replacer =
+          this.options.dereference.strategyOpts['openapi-2']?.circularReplacer ??
+          this.options.dereference.circularReplacer;
+        const replacement = replacer(refElement);
 
-        // remove referencing reference from ancestors lineage
-        directAncestors.delete(referencingElement);
+        if (isMemberElement(parent)) {
+          parent.value = replacement; // eslint-disable-line no-param-reassign
+        } else if (Array.isArray(parent)) {
+          parent[key] = replacement; // eslint-disable-line no-param-reassign
+        }
+
+        return !parent ? replacement : false;
       }
+    }
 
-      this.indirections.pop();
+    /**
+     * Dive deep into the fragment.
+     *
+     * Cases to consider:
+     *  1. We're crossing document boundary
+     *  2. Fragment is from non-root document
+     *  3. Fragment is a Paht Item Object with $ref field. We need to follow it to get the eventual value
+     *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
+     */
+    const isNonRootDocument = url.stripHash(reference.refSet!.rootRef!.uri) !== reference.uri;
+    const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
+    if (
+      (isExternalReference ||
+        isNonRootDocument ||
+        (isPathItemElement(referencedElement) && isStringElement(referencedElement.$ref)) ||
+        shouldDetectCircular) &&
+      !ancestorsLineage.includesCycle(referencedElement)
+    ) {
+      // append referencing reference to ancestors lineage
+      directAncestors.add(referencingElement);
 
-      /**
-       * Creating a new version of referenced element to avoid modifying the original one.
-       */
-      const mergedElement = cloneShallow(referencedElement);
+      const visitor = new OpenAPI2DereferenceVisitor({
+        reference,
+        namespace: this.namespace,
+        indirections: [...this.indirections],
+        options: this.options,
+        refractCache: this.refractCache,
+        ancestors: ancestorsLineage,
+      });
+      referencedElement = await visitAsync(referencedElement, visitor, {
+        keyMap,
+        nodeTypeGetter: getNodeType,
+      });
+
+      // remove referencing reference from ancestors lineage
+      directAncestors.delete(referencingElement);
+    }
+
+    this.indirections.pop();
+
+    // merge fields from referenced Path Item with referencing one
+    if (isPathItemElement(referencedElement)) {
+      const mergedElement = new PathItemElement(
+        [...referencedElement.content] as any,
+        cloneDeep(referencedElement.meta),
+        cloneDeep(referencedElement.attributes),
+      );
       // assign unique id to merged element
       mergedElement.setMetaProperty('id', identityManager.generateId());
+      // existing keywords from referencing PathItemElement overrides ones from referenced element
+      referencingElement.forEach((value: Element, keyElement: Element, item: Element) => {
+        mergedElement.remove(toValue(keyElement));
+        mergedElement.content.push(item);
+      });
+      mergedElement.remove('$ref');
+
       // annotate referenced element with info about original referencing element
       mergedElement.setMetaProperty('ref-fields', {
-        // @ts-ignore
         $ref: toValue(referencingElement.$ref),
       });
-      // annotate fragment with info about origin
+      // annotate referenced element with info about origin
       mergedElement.setMetaProperty('ref-origin', reference.uri);
       // annotate fragment with info about referencing element
       mergedElement.setMetaProperty(
@@ -642,21 +482,198 @@ const OpenApi2DereferenceVisitor = stampit({
         cloneDeep(identityManager.identify(referencingElement)),
       );
 
-      /**
-       * Transclude referencing element with merged referenced element.
-       */
-      if (isMemberElement(parent)) {
-        parent.value = mergedElement; // eslint-disable-line no-param-reassign
-      } else if (Array.isArray(parent)) {
-        parent[key] = mergedElement; // eslint-disable-line no-param-reassign
+      referencedElement = mergedElement;
+    }
+
+    /**
+     * Transclude referencing element with merged referenced element.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = referencedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = referencedElement; // eslint-disable-line no-param-reassign
+    }
+
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? referencedElement : undefined;
+  }
+
+  public async JSONReferenceElement(
+    referencingElement: JSONReferenceElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    // skip current referencing element as it's already been access
+    if (this.indirections.includes(referencingElement)) {
+      return false;
+    }
+
+    const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+
+    const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving internal JSONReference Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this JSONReference element and all it's child elements
+      return false;
+    }
+    // ignore resolving external JSONReference Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this JSONReference element and all it's child elements
+      return false;
+    }
+
+    const reference = await this.toReference(toValue(referencingElement.$ref));
+    const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+
+    this.indirections.push(referencingElement);
+
+    const jsonPointer = uriToPointer($refBaseURI);
+
+    // possibly non-semantic fragment
+    let referencedElement = evaluate(jsonPointer, reference.value.result as Element);
+    referencedElement.id = identityManager.identify(referencedElement);
+
+    /**
+     * Applying semantics to a referenced element if semantics are missing.
+     */
+    if (isPrimitiveElement(referencedElement)) {
+      const referencedElementType = toValue(referencingElement.meta.get('referenced-element'));
+      const cacheKey = `path-item-${toValue(identityManager.identify(referencedElement))}`;
+
+      if (this.refractCache.has(cacheKey)) {
+        referencedElement = this.refractCache.get(cacheKey)!;
+      } else if (isJSONReferenceLikeElement(referencedElement)) {
+        // handling indirect references
+        referencedElement = ReferenceElement.refract(referencedElement);
+        referencedElement.setMetaProperty('referenced-element', referencedElementType);
+        this.refractCache.set(cacheKey, referencedElement);
+      } else {
+        // handling direct references
+        const ElementClass = this.namespace.getElementClass(referencedElementType);
+        referencedElement = ElementClass.refract(referencedElement);
+        this.refractCache.set(cacheKey, referencedElement);
       }
+    }
 
-      /**
-       * We're at the root of the tree, so we're just replacing the entire tree.
-       */
-      return !parent ? mergedElement : false;
-    },
-  },
-});
+    // detect direct or circular reference
+    if (referencingElement === referencedElement) {
+      throw new ApiDOMError('Recursive Reference Object detected');
+    }
 
-export default OpenApi2DereferenceVisitor;
+    // detect maximum depth of dereferencing
+    if (this.indirections.length > this.options.dereference.maxDepth) {
+      throw new MaximumDereferenceDepthError(
+        `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
+      );
+    }
+
+    // detect second deep dive into the same fragment and avoid it
+    if (ancestorsLineage.includes(referencedElement)) {
+      if (this.options.dereference.circular === 'error') {
+        throw new ApiDOMError('Circular reference detected');
+      } else if (this.options.dereference.circular === 'replace') {
+        const refElement = new RefElement(referencedElement.id, {
+          type: 'json-reference',
+          uri: reference.uri,
+          $ref: toValue(referencingElement.$ref),
+        });
+        const replacer =
+          this.options.dereference.strategyOpts['openapi-2']?.circularReplacer ??
+          this.options.dereference.circularReplacer;
+        const replacement = replacer(refElement);
+
+        if (isMemberElement(parent)) {
+          parent.value = replacement; // eslint-disable-line no-param-reassign
+        } else if (Array.isArray(parent)) {
+          parent[key] = replacement; // eslint-disable-line no-param-reassign
+        }
+
+        reference.refSet!.circular = true;
+
+        return !parent ? replacement : false;
+      }
+    }
+
+    /**
+     * Dive deep into the fragment.
+     *
+     * Cases to consider:
+     *  1. We're crossing document boundary
+     2. Fragment is from non-root document
+     *  3. Fragment is a JSON Reference Object. We need to follow it to get the eventual value
+     *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
+     */
+    const isNonRootDocument = url.stripHash(reference.refSet!.rootRef!.uri) !== reference.uri;
+    const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
+    if (
+      (isExternalReference ||
+        isNonRootDocument ||
+        isJSONReferenceElement(referencedElement) ||
+        shouldDetectCircular) &&
+      !ancestorsLineage.includesCycle(referencedElement)
+    ) {
+      // append referencing reference to ancestors lineage
+      directAncestors.add(referencingElement);
+
+      const visitor = new OpenAPI2DereferenceVisitor({
+        reference,
+        namespace: this.namespace,
+        indirections: [...this.indirections],
+        options: this.options,
+        refractCache: this.refractCache,
+        ancestors: ancestorsLineage,
+      });
+      referencedElement = await visitAsync(referencedElement, visitor, {
+        keyMap,
+        nodeTypeGetter: getNodeType,
+      });
+
+      // remove referencing reference from ancestors lineage
+      directAncestors.delete(referencingElement);
+    }
+
+    this.indirections.pop();
+
+    /**
+     * Creating a new version of referenced element to avoid modifying the original one.
+     */
+    const mergedElement = cloneShallow(referencedElement);
+    // assign unique id to merged element
+    mergedElement.setMetaProperty('id', identityManager.generateId());
+    // annotate referenced element with info about original referencing element
+    mergedElement.setMetaProperty('ref-fields', {
+      // @ts-ignore
+      $ref: toValue(referencingElement.$ref),
+    });
+    // annotate fragment with info about origin
+    mergedElement.setMetaProperty('ref-origin', reference.uri);
+    // annotate fragment with info about referencing element
+    mergedElement.setMetaProperty(
+      'ref-referencing-element-id',
+      cloneDeep(identityManager.identify(referencingElement)),
+    );
+
+    /**
+     * Transclude referencing element with merged referenced element.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = mergedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = mergedElement; // eslint-disable-line no-param-reassign
+    }
+
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? mergedElement : false;
+  }
+}
+
+export default OpenAPI2DereferenceVisitor;

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/index.ts
@@ -10,7 +10,7 @@ import DereferenceStrategy, { DereferenceStrategyOptions } from '../DereferenceS
 import File from '../../../File';
 import Reference from '../../../Reference';
 import ReferenceSet from '../../../ReferenceSet';
-import OpenApi3_0DereferenceVisitor from './visitor';
+import OpenAPI3_0DereferenceVisitor from './visitor';
 import type { ReferenceOptions } from '../../../options';
 
 // @ts-ignore
@@ -68,7 +68,7 @@ class OpenAPI3_0DereferenceStrategy extends DereferenceStrategy {
       refSet = mutableRefSet;
     }
 
-    const visitor = OpenApi3_0DereferenceVisitor({ reference, namespace, options });
+    const visitor = new OpenAPI3_0DereferenceVisitor({ reference: reference!, namespace, options });
     const dereferencedElement = await visitAsync(refSet.rootRef!.value, visitor, {
       keyMap,
       nodeTypeGetter: getNodeType,
@@ -88,8 +88,6 @@ class OpenAPI3_0DereferenceStrategy extends DereferenceStrategy {
             }),
         )
         .forEach((ref) => immutableRefSet.add(ref));
-      reference = immutableRefSet.find((ref) => ref.uri === file.uri);
-      refSet = immutableRefSet;
     }
 
     /**
@@ -106,4 +104,5 @@ class OpenAPI3_0DereferenceStrategy extends DereferenceStrategy {
   }
 }
 
+export { OpenAPI3_0DereferenceVisitor };
 export default OpenAPI3_0DereferenceStrategy;

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
@@ -1,4 +1,3 @@
-import stampit from 'stampit';
 import { propEq } from 'ramda';
 import { isUndefined } from 'ramda-adjunct';
 import {
@@ -14,6 +13,7 @@ import {
   toValue,
   Element,
   RefElement,
+  Namespace,
 } from '@swagger-api/apidom-core';
 import { ApiDOMError } from '@swagger-api/apidom-error';
 import { evaluate, uriToPointer } from '@swagger-api/apidom-json-pointer';
@@ -36,7 +36,9 @@ import MaximumResolveDepthError from '../../../errors/MaximumResolveDepthError';
 import * as url from '../../../util/url';
 import parse from '../../../parse';
 import Reference from '../../../Reference';
+import ReferenceSet from '../../../ReferenceSet';
 import { AncestorLineage } from '../../util';
+import type { ReferenceOptions } from '../../../options';
 
 // @ts-ignore
 const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
@@ -44,240 +46,438 @@ const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
 // initialize element identity manager
 const identityManager = new IdentityManager();
 
-const OpenApi3_0DereferenceVisitor = stampit({
-  props: {
-    indirections: [],
-    namespace: null,
-    reference: null,
-    options: null,
-    refractCache: null,
-    ancestors: null,
-  },
-  init({
-    indirections = [],
+export interface OpenAPI3_0DereferenceVisitorOptions {
+  readonly namespace: Namespace;
+  readonly reference: Reference;
+  readonly options: ReferenceOptions;
+  readonly indirections?: Element[];
+  readonly ancestors?: AncestorLineage<Element>;
+  readonly refractCache?: Map<string, Element>;
+}
+
+class OpenAPI3_0DereferenceVisitor {
+  protected readonly indirections: Element[];
+
+  protected readonly namespace: Namespace;
+
+  protected readonly reference: Reference;
+
+  protected readonly options: ReferenceOptions;
+
+  protected readonly ancestors: AncestorLineage<Element>;
+
+  protected readonly refractCache: Map<string, Element>;
+
+  constructor({
     reference,
     namespace,
     options,
-    refractCache = new Map(),
+    indirections = [],
     ancestors = new AncestorLineage(),
-  }) {
+    refractCache = new Map(),
+  }: OpenAPI3_0DereferenceVisitorOptions) {
     this.indirections = indirections;
     this.namespace = namespace;
     this.reference = reference;
     this.options = options;
+    this.ancestors = new AncestorLineage(...ancestors);
     this.refractCache = refractCache;
-    this.ancestors = ancestors;
-  },
-  methods: {
-    toBaseURI(uri: string): string {
-      return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
-    },
+  }
 
-    async toReference(uri: string): Promise<Reference> {
-      // detect maximum depth of resolution
-      if (this.reference.depth >= this.options.resolve.maxDepth) {
-        throw new MaximumResolveDepthError(
-          `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
-        );
-      }
+  protected toBaseURI(uri: string): string {
+    return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
+  }
 
-      const baseURI = this.toBaseURI(uri);
-      const { refSet } = this.reference;
+  protected async toReference(uri: string): Promise<Reference> {
+    // detect maximum depth of resolution
+    if (this.reference.depth >= this.options.resolve.maxDepth) {
+      throw new MaximumResolveDepthError(
+        `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
+      );
+    }
 
-      // we've already processed this Reference in past
-      if (refSet.has(baseURI)) {
-        return refSet.find(propEq(baseURI, 'uri'));
-      }
+    const baseURI = this.toBaseURI(uri);
+    const { refSet } = this.reference as { refSet: ReferenceSet };
 
-      const parseResult = await parse(url.unsanitize(baseURI), {
-        ...this.options,
-        parse: { ...this.options.parse, mediaType: 'text/plain' },
-      });
+    // we've already processed this Reference in past
+    if (refSet.has(baseURI)) {
+      return refSet.find(propEq(baseURI, 'uri'))!;
+    }
 
-      // register new mutable reference with a refSet
-      const mutableReference = new Reference({
-        uri: baseURI,
-        value: cloneDeep(parseResult),
+    const parseResult = await parse(url.unsanitize(baseURI), {
+      ...this.options,
+      parse: { ...this.options.parse, mediaType: 'text/plain' },
+    });
+
+    // register new mutable reference with a refSet
+    const mutableReference = new Reference({
+      uri: baseURI,
+      value: cloneDeep(parseResult),
+      depth: this.reference.depth + 1,
+    });
+    refSet.add(mutableReference);
+
+    if (this.options.dereference.immutable) {
+      // register new immutable reference with a refSet
+      const immutableReference = new Reference({
+        uri: `immutable://${baseURI}`,
+        value: parseResult,
         depth: this.reference.depth + 1,
       });
-      refSet.add(mutableReference);
+      refSet.add(immutableReference);
+    }
 
-      if (this.options.dereference.immutable) {
-        // register new immutable reference with a refSet
-        const immutableReference = new Reference({
-          uri: `immutable://${baseURI}`,
-          value: parseResult,
-          depth: this.reference.depth + 1,
-        });
-        refSet.add(immutableReference);
+    return mutableReference;
+  }
+
+  protected toAncestorLineage(
+    ancestors: (Element | Element[] | undefined)[],
+  ): [AncestorLineage<Element>, Set<Element>] {
+    /**
+     * Compute full ancestors lineage.
+     * Ancestors are flatten to unwrap all Element instances.
+     */
+    const directAncestors = new Set<Element>(ancestors.filter(isElement));
+    const ancestorsLineage = new AncestorLineage(...this.ancestors, directAncestors);
+
+    return [ancestorsLineage, directAncestors];
+  }
+
+  public async ReferenceElement(
+    referencingElement: ReferenceElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    // skip current referencing element as it's already been access
+    if (this.indirections.includes(referencingElement)) {
+      return false;
+    }
+
+    const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+
+    const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving internal Reference Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this reference element
+      return false;
+    }
+    // ignore resolving external Reference Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this reference element
+      return false;
+    }
+
+    const reference = await this.toReference(toValue(referencingElement.$ref));
+    const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+
+    this.indirections.push(referencingElement);
+
+    const jsonPointer = uriToPointer($refBaseURI);
+
+    // possibly non-semantic fragment
+    let referencedElement = evaluate(jsonPointer, reference.value.result as Element);
+    referencedElement.id = identityManager.identify(referencedElement);
+
+    /**
+     * Applying semantics to a referenced element if semantics are missing.
+     */
+    if (isPrimitiveElement(referencedElement)) {
+      const referencedElementType = toValue(referencingElement.meta.get('referenced-element'));
+      const cacheKey = `${referencedElementType}-${toValue(identityManager.identify(referencedElement))}`;
+
+      if (this.refractCache.has(cacheKey)) {
+        referencedElement = this.refractCache.get(cacheKey)!;
+      } else if (isReferenceLikeElement(referencedElement)) {
+        // handling indirect references
+        referencedElement = ReferenceElement.refract(referencedElement);
+        referencedElement.setMetaProperty('referenced-element', referencedElementType);
+        this.refractCache.set(cacheKey, referencedElement);
+      } else {
+        // handling direct references
+        const ElementClass = this.namespace.getElementClass(referencedElementType);
+        referencedElement = ElementClass.refract(referencedElement);
+        this.refractCache.set(cacheKey, referencedElement);
       }
+    }
 
-      return mutableReference;
-    },
+    // detect direct or circular reference
+    if (referencingElement === referencedElement) {
+      throw new ApiDOMError('Recursive Reference Object detected');
+    }
 
-    toAncestorLineage(ancestors: [Element | Element[]]) {
-      /**
-       * Compute full ancestors lineage.
-       * Ancestors are flatten to unwrap all Element instances.
-       */
-      const directAncestors = new Set<Element>(ancestors.filter(isElement));
-      const ancestorsLineage = new AncestorLineage(...this.ancestors, directAncestors);
+    // detect maximum depth of dereferencing
+    if (this.indirections.length > this.options.dereference.maxDepth) {
+      throw new MaximumDereferenceDepthError(
+        `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
+      );
+    }
 
-      return [ancestorsLineage, directAncestors];
-    },
+    // detect second deep dive into the same fragment and avoid it
+    if (ancestorsLineage.includes(referencedElement)) {
+      reference.refSet!.circular = true;
 
-    async ReferenceElement(
-      referencingElement: ReferenceElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
+      if (this.options.dereference.circular === 'error') {
+        throw new ApiDOMError('Circular reference detected');
+      } else if (this.options.dereference.circular === 'replace') {
+        const refElement = new RefElement(referencedElement.id, {
+          type: 'reference',
+          uri: reference.uri,
+          $ref: toValue(referencingElement.$ref),
+        });
+        const replacer =
+          this.options.dereference.strategyOpts['openapi-3-0']?.circularReplacer ??
+          this.options.dereference.circularReplacer;
+        const replacement = replacer(refElement);
+
+        if (isMemberElement(parent)) {
+          parent.value = replacement; // eslint-disable-line no-param-reassign
+        } else if (Array.isArray(parent)) {
+          parent[key] = replacement; // eslint-disable-line no-param-reassign
+        }
+
+        return !parent ? replacement : false;
+      }
+    }
+
+    /**
+     * Dive deep into the fragment.
+     *
+     * Cases to consider:
+     *  1. We're crossing document boundary
+     *  2. Fragment is from non-root document
+     *  3. Fragment is a Reference Object. We need to follow it to get the eventual value
+     *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
+     */
+    const isNonRootDocument = url.stripHash(reference.refSet!.rootRef!.uri) !== reference.uri;
+    const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
+    if (
+      (isExternalReference ||
+        isNonRootDocument ||
+        isReferenceElement(referencedElement) ||
+        shouldDetectCircular) &&
+      !ancestorsLineage.includesCycle(referencedElement)
     ) {
-      // skip current referencing element as it's already been access
-      if (this.indirections.includes(referencingElement)) {
-        return false;
+      // append referencing reference to ancestors lineage
+      directAncestors.add(referencingElement);
+
+      const visitor = new OpenAPI3_0DereferenceVisitor({
+        reference,
+        namespace: this.namespace,
+        indirections: [...this.indirections],
+        options: this.options,
+        refractCache: this.refractCache,
+        ancestors: ancestorsLineage,
+      });
+      referencedElement = await visitAsync(referencedElement, visitor, {
+        keyMap,
+        nodeTypeGetter: getNodeType,
+      });
+
+      // remove referencing reference from ancestors lineage
+      directAncestors.delete(referencingElement);
+    }
+
+    this.indirections.pop();
+
+    /**
+     * Creating a new version of referenced element to avoid modifying the original one.
+     */
+    const mergedElement = cloneShallow(referencedElement);
+    // assign unique id to merged element
+    mergedElement.setMetaProperty('id', identityManager.generateId());
+    // annotate referenced element with info about original referencing element
+    mergedElement.setMetaProperty('ref-fields', {
+      $ref: toValue(referencingElement.$ref),
+    });
+    // annotate fragment with info about origin
+    mergedElement.setMetaProperty('ref-origin', reference.uri);
+    // annotate fragment with info about referencing element
+    mergedElement.setMetaProperty(
+      'ref-referencing-element-id',
+      cloneDeep(identityManager.identify(referencingElement)),
+    );
+
+    /**
+     * Transclude referencing element with merged referenced element.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = mergedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = mergedElement; // eslint-disable-line no-param-reassign
+    }
+
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? mergedElement : false;
+  }
+
+  public async PathItemElement(
+    referencingElement: PathItemElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    // ignore PathItemElement without $ref field
+    if (!isStringElement(referencingElement.$ref)) {
+      return undefined;
+    }
+
+    // skip current referencing element as it's already been access
+    if (this.indirections.includes(referencingElement)) {
+      return false;
+    }
+
+    const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+
+    const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving internal Path Item Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this Path Item element but traverse all it's child elements
+      return undefined;
+    }
+    // ignore resolving external Path Item Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this Path Item element but traverse all it's child elements
+      return undefined;
+    }
+
+    const reference = await this.toReference(toValue(referencingElement.$ref));
+    const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+
+    this.indirections.push(referencingElement);
+
+    const jsonPointer = uriToPointer($refBaseURI);
+
+    // possibly non-semantic referenced element
+    let referencedElement = evaluate(jsonPointer, reference.value.result as Element);
+    referencedElement.id = identityManager.identify(referencedElement);
+
+    /**
+     * Applying semantics to a referenced element if semantics are missing.
+     */
+    if (!isPathItemElement(referencedElement)) {
+      const cacheKey = `path-item-${toValue(identityManager.identify(referencedElement))}`;
+
+      if (this.refractCache.has(cacheKey)) {
+        referencedElement = this.refractCache.get(cacheKey)!;
+      } else {
+        referencedElement = PathItemElement.refract(referencedElement);
+        this.refractCache.set(cacheKey, referencedElement);
       }
+    }
 
-      const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+    // detect direct or circular reference
+    if (referencingElement === referencedElement) {
+      throw new ApiDOMError('Recursive Path Item Object reference detected');
+    }
 
-      const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
-      const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-      const isExternalReference = !isInternalReference;
+    // detect maximum depth of dereferencing
+    if (this.indirections.length > this.options.dereference.maxDepth) {
+      throw new MaximumDereferenceDepthError(
+        `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
+      );
+    }
 
-      // ignore resolving internal Reference Objects
-      if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this reference element
-        return false;
-      }
-      // ignore resolving external Reference Objects
-      if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this reference element
-        return false;
-      }
+    // detect second deep dive into the same fragment and avoid it
+    if (ancestorsLineage.includes(referencedElement)) {
+      reference.refSet!.circular = true;
 
-      const reference = await this.toReference(toValue(referencingElement.$ref));
-      const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
-
-      this.indirections.push(referencingElement);
-
-      const jsonPointer = uriToPointer($refBaseURI);
-
-      // possibly non-semantic fragment
-      let referencedElement = evaluate(jsonPointer, reference.value.result);
-      referencedElement.id = identityManager.identify(referencedElement);
-
-      /**
-       * Applying semantics to a referenced element if semantics are missing.
-       */
-      if (isPrimitiveElement(referencedElement)) {
-        const referencedElementType = toValue(referencingElement.meta.get('referenced-element'));
-        const cacheKey = `${referencedElementType}-${toValue(identityManager.identify(referencedElement))}`;
-
-        if (this.refractCache.has(cacheKey)) {
-          referencedElement = this.refractCache.get(cacheKey);
-        } else if (isReferenceLikeElement(referencedElement)) {
-          // handling indirect references
-          referencedElement = ReferenceElement.refract(referencedElement);
-          referencedElement.setMetaProperty('referenced-element', referencedElementType);
-          this.refractCache.set(cacheKey, referencedElement);
-        } else {
-          // handling direct references
-          const ElementClass = this.namespace.getElementClass(referencedElementType);
-          referencedElement = ElementClass.refract(referencedElement);
-          this.refractCache.set(cacheKey, referencedElement);
-        }
-      }
-
-      // detect direct or circular reference
-      if (referencingElement === referencedElement) {
-        throw new ApiDOMError('Recursive Reference Object detected');
-      }
-
-      // detect maximum depth of dereferencing
-      if (this.indirections.length > this.options.dereference.maxDepth) {
-        throw new MaximumDereferenceDepthError(
-          `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
-        );
-      }
-
-      // detect second deep dive into the same fragment and avoid it
-      if (ancestorsLineage.includes(referencedElement)) {
-        reference.refSet.circular = true;
-
-        if (this.options.dereference.circular === 'error') {
-          throw new ApiDOMError('Circular reference detected');
-        } else if (this.options.dereference.circular === 'replace') {
-          const refElement = new RefElement(referencedElement.id, {
-            type: 'reference',
-            uri: reference.uri,
-            $ref: toValue(referencingElement.$ref),
-          });
-          const replacer =
-            this.options.dereference.strategyOpts['openapi-3-0']?.circularReplacer ??
-            this.options.dereference.circularReplacer;
-          const replacement = replacer(refElement);
-
-          if (isMemberElement(parent)) {
-            parent.value = replacement; // eslint-disable-line no-param-reassign
-          } else if (Array.isArray(parent)) {
-            parent[key] = replacement; // eslint-disable-line no-param-reassign
-          }
-
-          return !parent ? replacement : false;
-        }
-      }
-
-      /**
-       * Dive deep into the fragment.
-       *
-       * Cases to consider:
-       *  1. We're crossing document boundary
-       *  2. Fragment is from non-root document
-       *  3. Fragment is a Reference Object. We need to follow it to get the eventual value
-       *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
-       */
-      const isNonRootDocument = url.stripHash(reference.refSet.rootRef.uri) !== reference.uri;
-      const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
-      if (
-        (isExternalReference ||
-          isNonRootDocument ||
-          isReferenceElement(referencedElement) ||
-          shouldDetectCircular) &&
-        !ancestorsLineage.includesCycle(referencedElement)
-      ) {
-        // append referencing reference to ancestors lineage
-        directAncestors.add(referencingElement);
-
-        const visitor = OpenApi3_0DereferenceVisitor({
-          reference,
-          namespace: this.namespace,
-          indirections: [...this.indirections],
-          options: this.options,
-          refractCache: this.refractCache,
-          ancestors: ancestorsLineage,
+      if (this.options.dereference.circular === 'error') {
+        throw new ApiDOMError('Circular reference detected');
+      } else if (this.options.dereference.circular === 'replace') {
+        const refElement = new RefElement(referencedElement.id, {
+          type: 'path-item',
+          uri: reference.uri,
+          $ref: toValue(referencingElement.$ref),
         });
-        referencedElement = await visitAsync(referencedElement, visitor, {
-          keyMap,
-          nodeTypeGetter: getNodeType,
-        });
+        const replacer =
+          this.options.dereference.strategyOpts['openapi-3-0']?.circularReplacer ??
+          this.options.dereference.circularReplacer;
+        const replacement = replacer(refElement);
 
-        // remove referencing reference from ancestors lineage
-        directAncestors.delete(referencingElement);
+        if (isMemberElement(parent)) {
+          parent.value = replacement; // eslint-disable-line no-param-reassign
+        } else if (Array.isArray(parent)) {
+          parent[key] = replacement; // eslint-disable-line no-param-reassign
+        }
+
+        return !parent ? replacement : undefined;
       }
+    }
 
-      this.indirections.pop();
+    /**
+     * Dive deep into the fragment.
+     *
+     * Cases to consider:
+     *  1. We're crossing document boundary
+     *  2. Fragment is from non-root document
+     *  3. Fragment is a Path Item Object with $ref field. We need to follow it to get the eventual value
+     *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
+     */
+    const isNonRootDocument = url.stripHash(reference.refSet!.rootRef!.uri) !== reference.uri;
+    const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
+    if (
+      (isExternalReference ||
+        isNonRootDocument ||
+        (isPathItemElement(referencedElement) && isStringElement(referencedElement.$ref)) ||
+        shouldDetectCircular) &&
+      !ancestorsLineage.includesCycle(referencedElement)
+    ) {
+      // append referencing reference to ancestors lineage
+      directAncestors.add(referencingElement);
 
-      /**
-       * Creating a new version of referenced element to avoid modifying the original one.
-       */
-      const mergedElement = cloneShallow(referencedElement);
+      const visitor = new OpenAPI3_0DereferenceVisitor({
+        reference,
+        namespace: this.namespace,
+        indirections: [...this.indirections],
+        options: this.options,
+        refractCache: this.refractCache,
+        ancestors: ancestorsLineage,
+      });
+      referencedElement = await visitAsync(referencedElement, visitor, {
+        keyMap,
+        nodeTypeGetter: getNodeType,
+      });
+
+      // remove referencing reference from ancestors lineage
+      directAncestors.delete(referencingElement);
+    }
+
+    this.indirections.pop();
+
+    /**
+     * Creating a new version of Path Item by merging fields from referenced Path Item with referencing one.
+     */
+    if (isPathItemElement(referencedElement)) {
+      const mergedElement = new PathItemElement(
+        [...referencedElement.content] as any,
+        cloneDeep(referencedElement.meta),
+        cloneDeep(referencedElement.attributes),
+      );
       // assign unique id to merged element
       mergedElement.setMetaProperty('id', identityManager.generateId());
+      // existing keywords from referencing PathItemElement overrides ones from referenced element
+      referencingElement.forEach((value: Element, keyElement: Element, item: Element) => {
+        mergedElement.remove(toValue(keyElement));
+        mergedElement.content.push(item);
+      });
+      mergedElement.remove('$ref');
+
       // annotate referenced element with info about original referencing element
       mergedElement.setMetaProperty('ref-fields', {
         $ref: toValue(referencingElement.$ref),
       });
-      // annotate fragment with info about origin
+      // annotate referenced element with info about origin
       mergedElement.setMetaProperty('ref-origin', reference.uri);
       // annotate fragment with info about referencing element
       mergedElement.setMetaProperty(
@@ -285,368 +485,188 @@ const OpenApi3_0DereferenceVisitor = stampit({
         cloneDeep(identityManager.identify(referencingElement)),
       );
 
-      /**
-       * Transclude referencing element with merged referenced element.
-       */
-      if (isMemberElement(parent)) {
-        parent.value = mergedElement; // eslint-disable-line no-param-reassign
-      } else if (Array.isArray(parent)) {
-        parent[key] = mergedElement; // eslint-disable-line no-param-reassign
-      }
+      referencedElement = mergedElement;
+    }
 
-      /**
-       * We're at the root of the tree, so we're just replacing the entire tree.
-       */
-      return !parent ? mergedElement : false;
-    },
+    /**
+     * Transclude referencing element with merged referenced element.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = referencedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = referencedElement; // eslint-disable-line no-param-reassign
+    }
 
-    async PathItemElement(
-      referencingElement: PathItemElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
-    ) {
-      // ignore PathItemElement without $ref field
-      if (!isStringElement(referencingElement.$ref)) {
-        return undefined;
-      }
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? referencedElement : undefined;
+  }
 
-      // skip current referencing element as it's already been access
-      if (this.indirections.includes(referencingElement)) {
-        return false;
-      }
+  public async LinkElement(
+    linkElement: LinkElement,
+    key: string | number,
+    parent: Element | undefined,
+  ) {
+    // ignore LinkElement without operationRef or operationId field
+    if (!isStringElement(linkElement.operationRef) && !isStringElement(linkElement.operationId)) {
+      return undefined;
+    }
 
-      const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+    // operationRef and operationId fields are mutually exclusive
+    if (isStringElement(linkElement.operationRef) && isStringElement(linkElement.operationId)) {
+      throw new ApiDOMError(
+        'LinkElement operationRef and operationId fields are mutually exclusive.',
+      );
+    }
 
-      const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    let operationElement: Element | undefined;
+
+    if (isStringElement(linkElement.operationRef)) {
+      // possibly non-semantic referenced element
+      const jsonPointer = uriToPointer(toValue(linkElement.operationRef));
+      const retrievalURI = this.toBaseURI(toValue(linkElement.operationRef));
       const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
       const isExternalReference = !isInternalReference;
 
-      // ignore resolving internal Path Item Objects
+      // ignore resolving internal Operation Object reference
       if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this Path Item element but traverse all it's child elements
+        // skip traversing this Link element but traverse all it's child elements
         return undefined;
       }
-      // ignore resolving external Path Item Objects
+      // ignore resolving external Operation Object reference
       if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this Path Item element but traverse all it's child elements
+        // skip traversing this Link element but traverse all it's child elements
         return undefined;
       }
 
-      const reference = await this.toReference(toValue(referencingElement.$ref));
-      const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+      const reference = await this.toReference(toValue(linkElement.operationRef));
 
-      this.indirections.push(referencingElement);
-
-      const jsonPointer = uriToPointer($refBaseURI);
-
-      // possibly non-semantic referenced element
-      let referencedElement = evaluate(jsonPointer, reference.value.result);
-      referencedElement.id = identityManager.identify(referencedElement);
-
-      /**
-       * Applying semantics to a referenced element if semantics are missing.
-       */
-      if (!isPathItemElement(referencedElement)) {
-        const cacheKey = `path-item-${toValue(identityManager.identify(referencedElement))}`;
+      operationElement = evaluate(jsonPointer, reference.value.result as Element);
+      // applying semantics to a referenced element
+      if (isPrimitiveElement(operationElement)) {
+        const cacheKey = `operation-${toValue(identityManager.identify(operationElement))}`;
 
         if (this.refractCache.has(cacheKey)) {
-          referencedElement = this.refractCache.get(cacheKey);
+          operationElement = this.refractCache.get(cacheKey)!;
         } else {
-          referencedElement = PathItemElement.refract(referencedElement);
-          this.refractCache.set(cacheKey, referencedElement);
+          operationElement = OperationElement.refract(operationElement);
+          this.refractCache.set(cacheKey, operationElement);
         }
       }
-
-      // detect direct or circular reference
-      if (referencingElement === referencedElement) {
-        throw new ApiDOMError('Recursive Path Item Object reference detected');
-      }
-
-      // detect maximum depth of dereferencing
-      if (this.indirections.length > this.options.dereference.maxDepth) {
-        throw new MaximumDereferenceDepthError(
-          `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
-        );
-      }
-
-      // detect second deep dive into the same fragment and avoid it
-      if (ancestorsLineage.includes(referencedElement)) {
-        reference.refSet.circular = true;
-
-        if (this.options.dereference.circular === 'error') {
-          throw new ApiDOMError('Circular reference detected');
-        } else if (this.options.dereference.circular === 'replace') {
-          const refElement = new RefElement(referencedElement.id, {
-            type: 'path-item',
-            uri: reference.uri,
-            $ref: toValue(referencingElement.$ref),
-          });
-          const replacer =
-            this.options.dereference.strategyOpts['openapi-3-0']?.circularReplacer ??
-            this.options.dereference.circularReplacer;
-          const replacement = replacer(refElement);
-
-          if (isMemberElement(parent)) {
-            parent.value = replacement; // eslint-disable-line no-param-reassign
-          } else if (Array.isArray(parent)) {
-            parent[key] = replacement; // eslint-disable-line no-param-reassign
-          }
-
-          return !parent ? replacement : undefined;
-        }
-      }
-
-      /**
-       * Dive deep into the fragment.
-       *
-       * Cases to consider:
-       *  1. We're crossing document boundary
-       *  2. Fragment is from non-root document
-       *  3. Fragment is a Path Item Object with $ref field. We need to follow it to get the eventual value
-       *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
-       */
-      const isNonRootDocument = url.stripHash(reference.refSet.rootRef.uri) !== reference.uri;
-      const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
-      if (
-        (isExternalReference ||
-          isNonRootDocument ||
-          (isPathItemElement(referencedElement) && isStringElement(referencedElement.$ref)) ||
-          shouldDetectCircular) &&
-        !ancestorsLineage.includesCycle(referencedElement)
-      ) {
-        // append referencing reference to ancestors lineage
-        directAncestors.add(referencingElement);
-
-        const visitor = OpenApi3_0DereferenceVisitor({
-          reference,
-          namespace: this.namespace,
-          indirections: [...this.indirections],
-          options: this.options,
-          refractCache: this.refractCache,
-          ancestors: ancestorsLineage,
-        });
-        referencedElement = await visitAsync(referencedElement, visitor, {
-          keyMap,
-          nodeTypeGetter: getNodeType,
-        });
-
-        // remove referencing reference from ancestors lineage
-        directAncestors.delete(referencingElement);
-      }
-
-      this.indirections.pop();
-
-      /**
-       * Creating a new version of Path Item by merging fields from referenced Path Item with referencing one.
-       */
-      if (isPathItemElement(referencedElement)) {
-        const mergedElement = new PathItemElement(
-          [...referencedElement.content] as any,
-          cloneDeep(referencedElement.meta),
-          cloneDeep(referencedElement.attributes),
-        );
-        // assign unique id to merged element
-        mergedElement.setMetaProperty('id', identityManager.generateId());
-        // existing keywords from referencing PathItemElement overrides ones from referenced element
-        referencingElement.forEach((value: Element, keyElement: Element, item: Element) => {
-          mergedElement.remove(toValue(keyElement));
-          mergedElement.content.push(item);
-        });
-        mergedElement.remove('$ref');
-
-        // annotate referenced element with info about original referencing element
-        mergedElement.setMetaProperty('ref-fields', {
-          $ref: toValue(referencingElement.$ref),
-        });
-        // annotate referenced element with info about origin
-        mergedElement.setMetaProperty('ref-origin', reference.uri);
-        // annotate fragment with info about referencing element
-        mergedElement.setMetaProperty(
-          'ref-referencing-element-id',
-          cloneDeep(identityManager.identify(referencingElement)),
-        );
-
-        referencedElement = mergedElement;
-      }
-
-      /**
-       * Transclude referencing element with merged referenced element.
-       */
-      if (isMemberElement(parent)) {
-        parent.value = referencedElement; // eslint-disable-line no-param-reassign
-      } else if (Array.isArray(parent)) {
-        parent[key] = referencedElement; // eslint-disable-line no-param-reassign
-      }
-
-      /**
-       * We're at the root of the tree, so we're just replacing the entire tree.
-       */
-      return !parent ? referencedElement : undefined;
-    },
-
-    async LinkElement(linkElement: LinkElement, key: string | number, parent: Element | undefined) {
-      // ignore LinkElement without operationRef or operationId field
-      if (!isStringElement(linkElement.operationRef) && !isStringElement(linkElement.operationId)) {
-        return undefined;
-      }
-
-      // operationRef and operationId fields are mutually exclusive
-      if (isStringElement(linkElement.operationRef) && isStringElement(linkElement.operationId)) {
-        throw new ApiDOMError(
-          'LinkElement operationRef and operationId fields are mutually exclusive.',
-        );
-      }
-
-      let operationElement: any;
-
-      if (isStringElement(linkElement.operationRef)) {
-        // possibly non-semantic referenced element
-        const jsonPointer = uriToPointer(toValue(linkElement.operationRef));
-        const retrievalURI = this.toBaseURI(toValue(linkElement.operationRef));
-        const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-        const isExternalReference = !isInternalReference;
-
-        // ignore resolving internal Operation Object reference
-        if (!this.options.resolve.internal && isInternalReference) {
-          // skip traversing this Link element but traverse all it's child elements
-          return undefined;
-        }
-        // ignore resolving external Operation Object reference
-        if (!this.options.resolve.external && isExternalReference) {
-          // skip traversing this Link element but traverse all it's child elements
-          return undefined;
-        }
-
-        const reference = await this.toReference(toValue(linkElement.operationRef));
-
-        operationElement = evaluate(jsonPointer, reference.value.result);
-        // applying semantics to a referenced element
-        if (isPrimitiveElement(operationElement)) {
-          const cacheKey = `operation-${toValue(identityManager.identify(operationElement))}`;
-
-          if (this.refractCache.has(cacheKey)) {
-            operationElement = this.refractCache.get(cacheKey);
-          } else {
-            operationElement = OperationElement.refract(operationElement);
-            this.refractCache.set(cacheKey, operationElement);
-          }
-        }
-        // create shallow clone to be able to annotate with metadata
-        operationElement = cloneShallow(operationElement);
-        // annotate operation element with info about origin
-        operationElement.setMetaProperty('ref-origin', reference.uri);
-
-        const linkElementCopy = cloneShallow(linkElement);
-        linkElementCopy.operationRef?.meta.set('operation', operationElement);
-
-        /**
-         * Transclude Link Object containing Operation Object in its meta.
-         */
-        if (isMemberElement(parent)) {
-          parent.value = linkElementCopy; // eslint-disable-line no-param-reassign
-        } else if (Array.isArray(parent)) {
-          parent[key] = linkElementCopy; // eslint-disable-line no-param-reassign
-        }
-
-        /**
-         * We're at the root of the tree, so we're just replacing the entire tree.
-         */
-        return !parent ? linkElementCopy : undefined;
-      }
-
-      if (isStringElement(linkElement.operationId)) {
-        const operationId = toValue(linkElement.operationId);
-        const reference = await this.toReference(url.unsanitize(this.reference.uri));
-        operationElement = find(
-          (e) =>
-            isOperationElement(e) && isElement(e.operationId) && e.operationId.equals(operationId),
-          reference.value.result,
-        );
-        // OperationElement not found by its operationId
-        if (isUndefined(operationElement)) {
-          throw new ApiDOMError(`OperationElement(operationId=${operationId}) not found.`);
-        }
-
-        const linkElementCopy = cloneShallow(linkElement);
-        linkElementCopy.operationId?.meta.set('operation', operationElement);
-
-        /**
-         * Transclude Link Object containing Operation Object in its meta.
-         */
-        if (isMemberElement(parent)) {
-          parent.value = linkElementCopy; // eslint-disable-line no-param-reassign
-        } else if (Array.isArray(parent)) {
-          parent[key] = linkElementCopy; // eslint-disable-line no-param-reassign
-        }
-
-        /**
-         * We're at the root of the tree, so we're just replacing the entire tree.
-         */
-        return !parent ? linkElementCopy : undefined;
-      }
-
-      return undefined;
-    },
-
-    async ExampleElement(
-      exampleElement: ExampleElement,
-      key: string | number,
-      parent: Element | undefined,
-    ) {
-      // ignore ExampleElement without externalValue field
-      if (!isStringElement(exampleElement.externalValue)) {
-        return undefined;
-      }
-
-      // value and externalValue fields are mutually exclusive
-      if (exampleElement.hasKey('value') && isStringElement(exampleElement.externalValue)) {
-        throw new ApiDOMError(
-          'ExampleElement value and externalValue fields are mutually exclusive.',
-        );
-      }
-
-      const retrievalURI = this.toBaseURI(toValue(exampleElement.externalValue));
-      const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-      const isExternalReference = !isInternalReference;
-
-      // ignore resolving external Example Objects
-      if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this Example element but traverse all it's child elements
-        return undefined;
-      }
-      // ignore resolving external Example Objects
-      if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this Example element but traverse all it's child elements
-        return undefined;
-      }
-
-      const reference = await this.toReference(toValue(exampleElement.externalValue));
-
-      // shallow clone of the referenced element
-      const valueElement = cloneShallow(reference.value.result);
+      // create shallow clone to be able to annotate with metadata
+      operationElement = cloneShallow(operationElement);
       // annotate operation element with info about origin
-      valueElement.setMetaProperty('ref-origin', reference.uri);
+      operationElement.setMetaProperty('ref-origin', reference.uri);
 
-      const exampleElementCopy = cloneShallow(exampleElement);
-      exampleElementCopy.value = valueElement;
+      const linkElementCopy = cloneShallow(linkElement);
+      linkElementCopy.operationRef?.meta.set('operation', operationElement);
 
       /**
-       * Transclude Example Object containing external value.
+       * Transclude Link Object containing Operation Object in its meta.
        */
       if (isMemberElement(parent)) {
-        parent.value = exampleElementCopy; // eslint-disable-line no-param-reassign
+        parent.value = linkElementCopy; // eslint-disable-line no-param-reassign
       } else if (Array.isArray(parent)) {
-        parent[key] = exampleElementCopy; // eslint-disable-line no-param-reassign
+        parent[key] = linkElementCopy; // eslint-disable-line no-param-reassign
       }
 
       /**
        * We're at the root of the tree, so we're just replacing the entire tree.
        */
-      return !parent ? exampleElementCopy : undefined;
-    },
-  },
-});
+      return !parent ? linkElementCopy : undefined;
+    }
 
-export default OpenApi3_0DereferenceVisitor;
+    if (isStringElement(linkElement.operationId)) {
+      const operationId = toValue(linkElement.operationId);
+      const reference = await this.toReference(url.unsanitize(this.reference.uri));
+      operationElement = find(
+        (e) =>
+          isOperationElement(e) && isElement(e.operationId) && e.operationId.equals(operationId),
+        reference.value.result as Element,
+      );
+      // OperationElement not found by its operationId
+      if (isUndefined(operationElement)) {
+        throw new ApiDOMError(`OperationElement(operationId=${operationId}) not found.`);
+      }
+
+      const linkElementCopy = cloneShallow(linkElement);
+      linkElementCopy.operationId?.meta.set('operation', operationElement);
+
+      /**
+       * Transclude Link Object containing Operation Object in its meta.
+       */
+      if (isMemberElement(parent)) {
+        parent.value = linkElementCopy; // eslint-disable-line no-param-reassign
+      } else if (Array.isArray(parent)) {
+        parent[key] = linkElementCopy; // eslint-disable-line no-param-reassign
+      }
+
+      /**
+       * We're at the root of the tree, so we're just replacing the entire tree.
+       */
+      return !parent ? linkElementCopy : undefined;
+    }
+
+    return undefined;
+  }
+
+  public async ExampleElement(
+    exampleElement: ExampleElement,
+    key: string | number,
+    parent: Element | undefined,
+  ) {
+    // ignore ExampleElement without externalValue field
+    if (!isStringElement(exampleElement.externalValue)) {
+      return undefined;
+    }
+
+    // value and externalValue fields are mutually exclusive
+    if (exampleElement.hasKey('value') && isStringElement(exampleElement.externalValue)) {
+      throw new ApiDOMError(
+        'ExampleElement value and externalValue fields are mutually exclusive.',
+      );
+    }
+
+    const retrievalURI = this.toBaseURI(toValue(exampleElement.externalValue));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving external Example Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this Example element but traverse all it's child elements
+      return undefined;
+    }
+    // ignore resolving external Example Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this Example element but traverse all it's child elements
+      return undefined;
+    }
+
+    const reference = await this.toReference(toValue(exampleElement.externalValue));
+
+    // shallow clone of the referenced element
+    const valueElement = cloneShallow(reference.value.result as Element);
+    // annotate operation element with info about origin
+    valueElement.setMetaProperty('ref-origin', reference.uri);
+
+    const exampleElementCopy = cloneShallow(exampleElement);
+    exampleElementCopy.value = valueElement;
+
+    /**
+     * Transclude Example Object containing external value.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = exampleElementCopy; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = exampleElementCopy; // eslint-disable-line no-param-reassign
+    }
+
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? exampleElementCopy : undefined;
+  }
+}
+
+export default OpenAPI3_0DereferenceVisitor;

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/index.ts
@@ -11,7 +11,7 @@ import DereferenceStrategy, { DereferenceStrategyOptions } from '../DereferenceS
 import File from '../../../File';
 import Reference from '../../../Reference';
 import ReferenceSet from '../../../ReferenceSet';
-import OpenApi3_1DereferenceVisitor from './visitor';
+import OpenAPI3_1DereferenceVisitor from './visitor';
 import type { ReferenceOptions } from '../../../options';
 
 // @ts-ignore
@@ -68,7 +68,7 @@ class OpenAPI3_1DereferenceStrategy extends DereferenceStrategy {
       refSet = mutableRefSet;
     }
 
-    const visitor = OpenApi3_1DereferenceVisitor({ reference, namespace, options });
+    const visitor = new OpenAPI3_1DereferenceVisitor({ reference: reference!, namespace, options });
     const dereferencedElement = await visitAsync(refSet.rootRef!.value, visitor, {
       keyMap,
       nodeTypeGetter: getNodeType,
@@ -88,8 +88,6 @@ class OpenAPI3_1DereferenceStrategy extends DereferenceStrategy {
             }),
         )
         .forEach((ref) => immutableRefSet.add(ref));
-      reference = immutableRefSet.find((ref) => ref.uri === file.uri);
-      refSet = immutableRefSet;
     }
 
     /**
@@ -106,7 +104,7 @@ class OpenAPI3_1DereferenceStrategy extends DereferenceStrategy {
   }
 }
 
-export { OpenApi3_1DereferenceVisitor };
+export { OpenAPI3_1DereferenceVisitor };
 export { resolveSchema$refField, resolveSchema$idField, maybeRefractToSchemaElement } from './util';
 
 export default OpenAPI3_1DereferenceStrategy;

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
@@ -1,4 +1,3 @@
-import stampit from 'stampit';
 import { propEq, none } from 'ramda';
 import { isUndefined } from 'ramda-adjunct';
 import {
@@ -16,6 +15,7 @@ import {
   Element,
   RefElement,
   BooleanElement,
+  Namespace,
 } from '@swagger-api/apidom-core';
 import { ApiDOMError } from '@swagger-api/apidom-error';
 import { evaluate as jsonPointerEvaluate, uriToPointer } from '@swagger-api/apidom-json-pointer';
@@ -43,11 +43,13 @@ import MaximumResolveDepthError from '../../../errors/MaximumResolveDepthError';
 import * as url from '../../../util/url';
 import parse from '../../../parse';
 import Reference from '../../../Reference';
+import ReferenceSet from '../../../ReferenceSet';
 import File from '../../../File';
 import Resolver from '../../../resolve/resolvers/Resolver';
 import { resolveSchema$refField, maybeRefractToSchemaElement } from './util';
 import { AncestorLineage } from '../../util';
 import EvaluationJsonSchemaUriError from '../../../errors/EvaluationJsonSchemaUriError';
+import type { ReferenceOptions } from '../../../options';
 
 // @ts-ignore
 const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
@@ -55,242 +57,452 @@ const visitAsync = visit[Symbol.for('nodejs.util.promisify.custom')];
 // initialize element identity manager
 const identityManager = new IdentityManager();
 
-const OpenApi3_1DereferenceVisitor = stampit({
-  props: {
-    indirections: null,
-    namespace: null,
-    reference: null,
-    options: null,
-    ancestors: null,
-    refractCache: null,
-  },
-  init({
-    indirections = [],
+export interface OpenAPI3_1DereferenceVisitorOptions {
+  readonly namespace: Namespace;
+  readonly reference: Reference;
+  readonly options: ReferenceOptions;
+  readonly indirections?: Element[];
+  readonly ancestors?: AncestorLineage<Element>;
+  readonly refractCache?: Map<string, Element>;
+}
+
+class OpenAPI3_1DereferenceVisitor {
+  protected readonly indirections: Element[];
+
+  protected readonly namespace: Namespace;
+
+  protected readonly reference: Reference;
+
+  protected readonly options: ReferenceOptions;
+
+  protected readonly ancestors: AncestorLineage<Element>;
+
+  protected readonly refractCache: Map<string, Element>;
+
+  constructor({
     reference,
     namespace,
     options,
+    indirections = [],
     ancestors = new AncestorLineage(),
     refractCache = new Map(),
-  }) {
+  }: OpenAPI3_1DereferenceVisitorOptions) {
     this.indirections = indirections;
     this.namespace = namespace;
     this.reference = reference;
     this.options = options;
     this.ancestors = new AncestorLineage(...ancestors);
     this.refractCache = refractCache;
-  },
-  methods: {
-    toBaseURI(uri: string): string {
-      return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
-    },
+  }
 
-    async toReference(uri: string): Promise<Reference> {
-      // detect maximum depth of resolution
-      if (this.reference.depth >= this.options.resolve.maxDepth) {
-        throw new MaximumResolveDepthError(
-          `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
-        );
-      }
+  protected toBaseURI(uri: string): string {
+    return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
+  }
 
-      const baseURI = this.toBaseURI(uri);
-      const { refSet } = this.reference;
+  protected async toReference(uri: string): Promise<Reference> {
+    // detect maximum depth of resolution
+    if (this.reference.depth >= this.options.resolve.maxDepth) {
+      throw new MaximumResolveDepthError(
+        `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
+      );
+    }
 
-      // we've already processed this Reference in past
-      if (refSet.has(baseURI)) {
-        return refSet.find(propEq(baseURI, 'uri'));
-      }
+    const baseURI = this.toBaseURI(uri);
+    const { refSet } = this.reference as { refSet: ReferenceSet };
 
-      const parseResult = await parse(url.unsanitize(baseURI), {
-        ...this.options,
-        parse: { ...this.options.parse, mediaType: 'text/plain' },
-      });
+    // we've already processed this Reference in past
+    if (refSet.has(baseURI)) {
+      return refSet.find(propEq(baseURI, 'uri'))!;
+    }
 
-      // register new mutable reference with a refSet
-      const mutableReference = new Reference({
-        uri: baseURI,
-        value: cloneDeep(parseResult),
+    const parseResult = await parse(url.unsanitize(baseURI), {
+      ...this.options,
+      parse: { ...this.options.parse, mediaType: 'text/plain' },
+    });
+
+    // register new mutable reference with a refSet
+    const mutableReference = new Reference({
+      uri: baseURI,
+      value: cloneDeep(parseResult),
+      depth: this.reference.depth + 1,
+    });
+    refSet.add(mutableReference);
+
+    if (this.options.dereference.immutable) {
+      // register new immutable reference with a refSet
+      const immutableReference = new Reference({
+        uri: `immutable://${baseURI}`,
+        value: parseResult,
         depth: this.reference.depth + 1,
       });
-      refSet.add(mutableReference);
+      refSet.add(immutableReference);
+    }
 
-      if (this.options.dereference.immutable) {
-        // register new immutable reference with a refSet
-        const immutableReference = new Reference({
-          uri: `immutable://${baseURI}`,
-          value: parseResult,
-          depth: this.reference.depth + 1,
-        });
-        refSet.add(immutableReference);
+    return mutableReference;
+  }
+
+  protected toAncestorLineage(
+    ancestors: (Element | Element[] | undefined)[],
+  ): [AncestorLineage<Element>, Set<Element>] {
+    /**
+     * Compute full ancestors lineage.
+     * Ancestors are flatten to unwrap all Element instances.
+     */
+    const directAncestors = new Set<Element>(ancestors.filter(isElement));
+    const ancestorsLineage = new AncestorLineage(...this.ancestors, directAncestors);
+
+    return [ancestorsLineage, directAncestors];
+  }
+
+  public async ReferenceElement(
+    referencingElement: ReferenceElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    // skip current referencing element as it's already been access
+    if (this.indirections.includes(referencingElement)) {
+      return false;
+    }
+
+    const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+
+    const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving internal Reference Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this reference element and all it's child elements
+      return false;
+    }
+    // ignore resolving external Reference Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this reference element and all it's child elements
+      return false;
+    }
+
+    const reference = await this.toReference(toValue(referencingElement.$ref));
+    const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+
+    this.indirections.push(referencingElement);
+
+    const jsonPointer = uriToPointer($refBaseURI);
+
+    // possibly non-semantic fragment
+    let referencedElement = jsonPointerEvaluate(jsonPointer, reference.value.result as Element);
+    referencedElement.id = identityManager.identify(referencedElement);
+
+    // applying semantics to a fragment
+    if (isPrimitiveElement(referencedElement)) {
+      const referencedElementType = toValue(referencingElement.meta.get('referenced-element'));
+      const cacheKey = `${referencedElementType}-${toValue(identityManager.identify(referencedElement))}`;
+
+      if (this.refractCache.has(cacheKey)) {
+        referencedElement = this.refractCache.get(cacheKey)!;
+      } else if (isReferenceLikeElement(referencedElement)) {
+        // handling indirect references
+        referencedElement = ReferenceElement.refract(referencedElement);
+        referencedElement.setMetaProperty('referenced-element', referencedElementType);
+        this.refractCache.set(cacheKey, referencedElement);
+      } else {
+        // handling direct references
+        const ElementClass = this.namespace.getElementClass(referencedElementType);
+        referencedElement = ElementClass.refract(referencedElement);
+        this.refractCache.set(cacheKey, referencedElement);
       }
+    }
 
-      return mutableReference;
-    },
+    // detect direct or indirect reference
+    if (referencingElement === referencedElement) {
+      throw new ApiDOMError('Recursive Reference Object detected');
+    }
 
-    toAncestorLineage(ancestors) {
-      /**
-       * Compute full ancestors lineage.
-       * Ancestors are flatten to unwrap all Element instances.
-       */
-      const directAncestors = new Set<Element>(ancestors.filter(isElement));
-      const ancestorsLineage = new AncestorLineage(...this.ancestors, directAncestors);
+    // detect maximum depth of dereferencing
+    if (this.indirections.length > this.options.dereference.maxDepth) {
+      throw new MaximumDereferenceDepthError(
+        `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
+      );
+    }
 
-      return [ancestorsLineage, directAncestors];
-    },
+    // detect second deep dive into the same fragment and avoid it
+    if (ancestorsLineage.includes(referencedElement)) {
+      reference.refSet!.circular = true;
 
-    async ReferenceElement(
-      referencingElement: ReferenceElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
+      if (this.options.dereference.circular === 'error') {
+        throw new ApiDOMError('Circular reference detected');
+      } else if (this.options.dereference.circular === 'replace') {
+        const refElement = new RefElement(referencedElement.id, {
+          type: 'reference',
+          uri: reference.uri,
+          $ref: toValue(referencingElement.$ref),
+        });
+        const replacer =
+          this.options.dereference.strategyOpts['openapi-3-1']?.circularReplacer ??
+          this.options.dereference.circularReplacer;
+        const replacement = replacer(refElement);
+
+        if (isMemberElement(parent)) {
+          parent.value = replacement; // eslint-disable-line no-param-reassign
+        } else if (Array.isArray(parent)) {
+          parent[key] = replacement; // eslint-disable-line no-param-reassign
+        }
+
+        return !parent ? replacement : false;
+      }
+    }
+
+    /**
+     * Dive deep into the fragment.
+     *
+     * Cases to consider:
+     *  1. We're crossing document boundary
+     *  2. Fragment is from non-root document
+     *  3. Fragment is a Reference Object. We need to follow it to get the eventual value
+     *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
+     */
+    const isNonRootDocument = url.stripHash(reference.refSet!.rootRef!.uri) !== reference.uri;
+    const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
+    if (
+      (isExternalReference ||
+        isNonRootDocument ||
+        isReferenceElement(referencedElement) ||
+        shouldDetectCircular) &&
+      !ancestorsLineage.includesCycle(referencedElement)
     ) {
-      // skip current referencing element as it's already been access
-      if (this.indirections.includes(referencingElement)) {
-        return false;
+      // append referencing reference to ancestors lineage
+      directAncestors.add(referencingElement);
+
+      const visitor = new OpenAPI3_1DereferenceVisitor({
+        reference,
+        namespace: this.namespace,
+        indirections: [...this.indirections],
+        options: this.options,
+        refractCache: this.refractCache,
+        ancestors: ancestorsLineage,
+      });
+      referencedElement = await visitAsync(referencedElement, visitor, {
+        keyMap,
+        nodeTypeGetter: getNodeType,
+      });
+
+      // remove referencing reference from ancestors lineage
+      directAncestors.delete(referencingElement);
+    }
+
+    this.indirections.pop();
+
+    /**
+     * Creating a new version of referenced element to avoid modifying the original one.
+     */
+    const mergedElement = cloneShallow(referencedElement);
+    // assign unique id to merged element
+    mergedElement.setMetaProperty('id', identityManager.generateId());
+    // annotate fragment with info about original Reference element
+    mergedElement.setMetaProperty('ref-fields', {
+      $ref: toValue(referencingElement.$ref),
+      // @ts-ignore
+      description: toValue(referencingElement.description),
+      // @ts-ignore
+      summary: toValue(referencingElement.summary),
+    });
+    // annotate fragment with info about origin
+    mergedElement.setMetaProperty('ref-origin', reference.uri);
+    // annotate fragment with info about referencing element
+    mergedElement.setMetaProperty(
+      'ref-referencing-element-id',
+      cloneDeep(identityManager.identify(referencingElement)),
+    );
+
+    // override description and summary (outer has higher priority then inner)
+    if (isObjectElement(referencedElement) && isObjectElement(mergedElement)) {
+      if (referencingElement.hasKey('description') && 'description' in referencedElement) {
+        mergedElement.remove('description');
+        mergedElement.set('description', referencingElement.get('description'));
       }
-
-      const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
-
-      const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
-      const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-      const isExternalReference = !isInternalReference;
-
-      // ignore resolving internal Reference Objects
-      if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this reference element and all it's child elements
-        return false;
+      if (referencingElement.hasKey('summary') && 'summary' in referencedElement) {
+        mergedElement.remove('summary');
+        mergedElement.set('summary', referencingElement.get('summary'));
       }
-      // ignore resolving external Reference Objects
-      if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this reference element and all it's child elements
-        return false;
+    }
+
+    /**
+     * Transclude referencing element with merged referenced element.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = mergedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = mergedElement; // eslint-disable-line no-param-reassign
+    }
+
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? mergedElement : false;
+  }
+
+  public async PathItemElement(
+    referencingElement: PathItemElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    // ignore PathItemElement without $ref field
+    if (!isStringElement(referencingElement.$ref)) {
+      return undefined;
+    }
+
+    // skip current referencing element as it's already been access
+    if (this.indirections.includes(referencingElement)) {
+      return false;
+    }
+
+    const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+
+    const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving external Path Item Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this Path Item element but traverse all it's child elements
+      return undefined;
+    }
+    // ignore resolving external Path Item Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this Path Item element but traverse all it's child elements
+      return undefined;
+    }
+
+    const reference = await this.toReference(toValue(referencingElement.$ref));
+    const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+
+    this.indirections.push(referencingElement);
+
+    const jsonPointer = uriToPointer($refBaseURI);
+
+    // possibly non-semantic referenced element
+    let referencedElement = jsonPointerEvaluate(jsonPointer, reference.value.result as Element);
+    referencedElement.id = identityManager.identify(referencedElement);
+
+    /**
+     * Applying semantics to a referenced element if semantics are missing.
+     */
+    if (isPrimitiveElement(referencedElement)) {
+      const cacheKey = `path-item-${toValue(identityManager.identify(referencedElement))}`;
+
+      if (this.refractCache.has(cacheKey)) {
+        referencedElement = this.refractCache.get(cacheKey)!;
+      } else {
+        referencedElement = PathItemElement.refract(referencedElement);
+        this.refractCache.set(cacheKey, referencedElement);
       }
+    }
 
-      const reference = await this.toReference(toValue(referencingElement.$ref));
-      const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+    // detect direct or indirect reference
+    if (referencingElement === referencedElement) {
+      throw new ApiDOMError('Recursive Path Item Object reference detected');
+    }
 
-      this.indirections.push(referencingElement);
+    // detect maximum depth of dereferencing
+    if (this.indirections.length > this.options.dereference.maxDepth) {
+      throw new MaximumDereferenceDepthError(
+        `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
+      );
+    }
 
-      const jsonPointer = uriToPointer($refBaseURI);
+    // detect second deep dive into the same fragment and avoid it
+    if (ancestorsLineage.includes(referencedElement)) {
+      reference.refSet!.circular = true;
 
-      // possibly non-semantic fragment
-      let referencedElement = jsonPointerEvaluate(jsonPointer, reference.value.result);
-      referencedElement.id = identityManager.identify(referencedElement);
-
-      // applying semantics to a fragment
-      if (isPrimitiveElement(referencedElement)) {
-        const referencedElementType = toValue(referencingElement.meta.get('referenced-element'));
-        const cacheKey = `${referencedElementType}-${toValue(identityManager.identify(referencedElement))}`;
-
-        if (this.refractCache.has(cacheKey)) {
-          referencedElement = this.refractCache.get(cacheKey);
-        } else if (isReferenceLikeElement(referencedElement)) {
-          // handling indirect references
-          referencedElement = ReferenceElement.refract(referencedElement);
-          referencedElement.setMetaProperty('referenced-element', referencedElementType);
-          this.refractCache.set(cacheKey, referencedElement);
-        } else {
-          // handling direct references
-          const ElementClass = this.namespace.getElementClass(referencedElementType);
-          referencedElement = ElementClass.refract(referencedElement);
-          this.refractCache.set(cacheKey, referencedElement);
-        }
-      }
-
-      // detect direct or indirect reference
-      if (referencingElement === referencedElement) {
-        throw new ApiDOMError('Recursive Reference Object detected');
-      }
-
-      // detect maximum depth of dereferencing
-      if (this.indirections.length > this.options.dereference.maxDepth) {
-        throw new MaximumDereferenceDepthError(
-          `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
-        );
-      }
-
-      // detect second deep dive into the same fragment and avoid it
-      if (ancestorsLineage.includes(referencedElement)) {
-        reference.refSet.circular = true;
-
-        if (this.options.dereference.circular === 'error') {
-          throw new ApiDOMError('Circular reference detected');
-        } else if (this.options.dereference.circular === 'replace') {
-          const refElement = new RefElement(referencedElement.id, {
-            type: 'reference',
-            uri: reference.uri,
-            $ref: toValue(referencingElement.$ref),
-          });
-          const replacer =
-            this.options.dereference.strategyOpts['openapi-3-1']?.circularReplacer ??
-            this.options.dereference.circularReplacer;
-          const replacement = replacer(refElement);
-
-          if (isMemberElement(parent)) {
-            parent.value = replacement; // eslint-disable-line no-param-reassign
-          } else if (Array.isArray(parent)) {
-            parent[key] = replacement; // eslint-disable-line no-param-reassign
-          }
-
-          return !parent ? replacement : false;
-        }
-      }
-
-      /**
-       * Dive deep into the fragment.
-       *
-       * Cases to consider:
-       *  1. We're crossing document boundary
-       *  2. Fragment is from non-root document
-       *  3. Fragment is a Reference Object. We need to follow it to get the eventual value
-       *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
-       */
-      const isNonRootDocument = url.stripHash(reference.refSet.rootRef.uri) !== reference.uri;
-      const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
-      if (
-        (isExternalReference ||
-          isNonRootDocument ||
-          isReferenceElement(referencedElement) ||
-          shouldDetectCircular) &&
-        !ancestorsLineage.includesCycle(referencedElement)
-      ) {
-        // append referencing reference to ancestors lineage
-        directAncestors.add(referencingElement);
-
-        const visitor = OpenApi3_1DereferenceVisitor({
-          reference,
-          namespace: this.namespace,
-          indirections: [...this.indirections],
-          options: this.options,
-          refractCache: this.refractCache,
-          ancestors: ancestorsLineage,
+      if (this.options.dereference.circular === 'error') {
+        throw new ApiDOMError('Circular reference detected');
+      } else if (this.options.dereference.circular === 'replace') {
+        const refElement = new RefElement(referencedElement.id, {
+          type: 'path-item',
+          uri: reference.uri,
+          $ref: toValue(referencingElement.$ref),
         });
-        referencedElement = await visitAsync(referencedElement, visitor, {
-          keyMap,
-          nodeTypeGetter: getNodeType,
-        });
+        const replacer =
+          this.options.dereference.strategyOpts['openapi-3-1']?.circularReplacer ??
+          this.options.dereference.circularReplacer;
+        const replacement = replacer(refElement);
 
-        // remove referencing reference from ancestors lineage
-        directAncestors.delete(referencingElement);
+        if (isMemberElement(parent)) {
+          parent.value = replacement; // eslint-disable-line no-param-reassign
+        } else if (Array.isArray(parent)) {
+          parent[key] = replacement; // eslint-disable-line no-param-reassign
+        }
+
+        return !parent ? replacement : false;
       }
+    }
 
-      this.indirections.pop();
+    /**
+     * Dive deep into the fragment.
+     *
+     * Cases to consider:
+     *  1. We're crossing document boundary
+     *  2. Fragment is from non-root document
+     *  3. Fragment is a Path Item Object with $ref field. We need to follow it to get the eventual value
+     *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
+     */
+    const isNonRootDocument = url.stripHash(reference.refSet!.rootRef!.uri) !== reference.uri;
+    const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
+    if (
+      (isExternalReference ||
+        isNonRootDocument ||
+        (isPathItemElement(referencedElement) && isStringElement(referencedElement.$ref)) ||
+        shouldDetectCircular) &&
+      !ancestorsLineage.includesCycle(referencedElement)
+    ) {
+      // append referencing reference to ancestors lineage
+      directAncestors.add(referencingElement);
 
-      /**
-       * Creating a new version of referenced element to avoid modifying the original one.
-       */
-      const mergedElement = cloneShallow(referencedElement);
+      const visitor = new OpenAPI3_1DereferenceVisitor({
+        reference,
+        namespace: this.namespace,
+        indirections: [...this.indirections],
+        options: this.options,
+        refractCache: this.refractCache,
+        ancestors: ancestorsLineage,
+      });
+      referencedElement = await visitAsync(referencedElement, visitor, {
+        keyMap,
+        nodeTypeGetter: getNodeType,
+      });
+
+      // remove referencing reference from ancestors lineage
+      directAncestors.delete(referencingElement);
+    }
+
+    this.indirections.pop();
+
+    /**
+     * Creating a new version of Path Item by merging fields from referenced Path Item with referencing one.
+     */
+    if (isPathItemElement(referencedElement)) {
+      const mergedElement = new PathItemElement(
+        [...referencedElement.content] as any,
+        cloneDeep(referencedElement.meta),
+        cloneDeep(referencedElement.attributes),
+      );
       // assign unique id to merged element
       mergedElement.setMetaProperty('id', identityManager.generateId());
-      // annotate fragment with info about original Reference element
+      // existing keywords from referencing PathItemElement overrides ones from referenced element
+      referencingElement.forEach((value: Element, keyElement: Element, item: Element) => {
+        mergedElement.remove(toValue(keyElement));
+        mergedElement.content.push(item);
+      });
+      mergedElement.remove('$ref');
+
+      // annotate referenced element with info about original referencing element
       mergedElement.setMetaProperty('ref-fields', {
         $ref: toValue(referencingElement.$ref),
-        // @ts-ignore
-        description: toValue(referencingElement.description),
-        // @ts-ignore
-        summary: toValue(referencingElement.summary),
       });
-      // annotate fragment with info about origin
+      // annotate referenced element with info about origin
       mergedElement.setMetaProperty('ref-origin', reference.uri);
       // annotate fragment with info about referencing element
       mergedElement.setMetaProperty(
@@ -298,424 +510,278 @@ const OpenApi3_1DereferenceVisitor = stampit({
         cloneDeep(identityManager.identify(referencingElement)),
       );
 
-      // override description and summary (outer has higher priority then inner)
-      if (isObjectElement(referencedElement) && isObjectElement(mergedElement)) {
-        if (referencingElement.hasKey('description') && 'description' in referencedElement) {
-          mergedElement.remove('description');
-          mergedElement.set('description', referencingElement.get('description'));
-        }
-        if (referencingElement.hasKey('summary') && 'summary' in referencedElement) {
-          mergedElement.remove('summary');
-          mergedElement.set('summary', referencingElement.get('summary'));
-        }
-      }
+      referencedElement = mergedElement;
+    }
 
-      /**
-       * Transclude referencing element with merged referenced element.
-       */
-      if (isMemberElement(parent)) {
-        parent.value = mergedElement; // eslint-disable-line no-param-reassign
-      } else if (Array.isArray(parent)) {
-        parent[key] = mergedElement; // eslint-disable-line no-param-reassign
-      }
+    /**
+     * Transclude referencing element with merged referenced element.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = referencedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = referencedElement; // eslint-disable-line no-param-reassign
+    }
 
-      /**
-       * We're at the root of the tree, so we're just replacing the entire tree.
-       */
-      return !parent ? mergedElement : false;
-    },
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? referencedElement : undefined;
+  }
 
-    async PathItemElement(
-      referencingElement: PathItemElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
-    ) {
-      // ignore PathItemElement without $ref field
-      if (!isStringElement(referencingElement.$ref)) {
-        return undefined;
-      }
+  public async LinkElement(
+    linkElement: LinkElement,
+    key: string | number,
+    parent: Element | undefined,
+  ) {
+    // ignore LinkElement without operationRef or operationId field
+    if (!isStringElement(linkElement.operationRef) && !isStringElement(linkElement.operationId)) {
+      return undefined;
+    }
 
-      // skip current referencing element as it's already been access
-      if (this.indirections.includes(referencingElement)) {
-        return false;
-      }
+    // operationRef and operationId fields are mutually exclusive
+    if (isStringElement(linkElement.operationRef) && isStringElement(linkElement.operationId)) {
+      throw new ApiDOMError(
+        'LinkElement operationRef and operationId fields are mutually exclusive.',
+      );
+    }
 
-      const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+    let operationElement: Element | undefined;
 
-      const retrievalURI = this.toBaseURI(toValue(referencingElement.$ref));
+    if (isStringElement(linkElement.operationRef)) {
+      // possibly non-semantic referenced element
+      const jsonPointer = uriToPointer(toValue(linkElement.operationRef));
+      const retrievalURI = this.toBaseURI(toValue(linkElement.operationRef));
       const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
       const isExternalReference = !isInternalReference;
 
-      // ignore resolving external Path Item Objects
+      // ignore resolving internal Operation Object reference
       if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this Path Item element but traverse all it's child elements
+        // skip traversing this Link element but traverse all it's child elements
         return undefined;
       }
-      // ignore resolving external Path Item Objects
+      // ignore resolving external Operation Object reference
       if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this Path Item element but traverse all it's child elements
+        // skip traversing this Link element but traverse all it's child elements
         return undefined;
       }
 
-      const reference = await this.toReference(toValue(referencingElement.$ref));
-      const $refBaseURI = url.resolve(retrievalURI, toValue(referencingElement.$ref));
+      const reference = await this.toReference(toValue(linkElement.operationRef));
 
-      this.indirections.push(referencingElement);
-
-      const jsonPointer = uriToPointer($refBaseURI);
-
-      // possibly non-semantic referenced element
-      let referencedElement = jsonPointerEvaluate(jsonPointer, reference.value.result);
-      referencedElement.id = identityManager.identify(referencedElement);
-
-      /**
-       * Applying semantics to a referenced element if semantics are missing.
-       */
-      if (isPrimitiveElement(referencedElement)) {
-        const cacheKey = `path-item-${toValue(identityManager.identify(referencedElement))}`;
+      operationElement = jsonPointerEvaluate(jsonPointer, reference.value.result as Element);
+      // applying semantics to a referenced element
+      if (isPrimitiveElement(operationElement)) {
+        const cacheKey = `operation-${toValue(identityManager.identify(operationElement))}`;
 
         if (this.refractCache.has(cacheKey)) {
-          referencedElement = this.refractCache.get(cacheKey);
+          operationElement = this.refractCache.get(cacheKey)!;
         } else {
-          referencedElement = PathItemElement.refract(referencedElement);
-          this.refractCache.set(cacheKey, referencedElement);
+          operationElement = OperationElement.refract(operationElement);
+          this.refractCache.set(cacheKey, operationElement);
         }
       }
-
-      // detect direct or indirect reference
-      if (referencingElement === referencedElement) {
-        throw new ApiDOMError('Recursive Path Item Object reference detected');
-      }
-
-      // detect maximum depth of dereferencing
-      if (this.indirections.length > this.options.dereference.maxDepth) {
-        throw new MaximumDereferenceDepthError(
-          `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
-        );
-      }
-
-      // detect second deep dive into the same fragment and avoid it
-      if (ancestorsLineage.includes(referencedElement)) {
-        reference.refSet.circular = true;
-
-        if (this.options.dereference.circular === 'error') {
-          throw new ApiDOMError('Circular reference detected');
-        } else if (this.options.dereference.circular === 'replace') {
-          const refElement = new RefElement(referencedElement.id, {
-            type: 'path-item',
-            uri: reference.uri,
-            $ref: toValue(referencingElement.$ref),
-          });
-          const replacer =
-            this.options.dereference.strategyOpts['openapi-3-1']?.circularReplacer ??
-            this.options.dereference.circularReplacer;
-          const replacement = replacer(refElement);
-
-          if (isMemberElement(parent)) {
-            parent.value = replacement; // eslint-disable-line no-param-reassign
-          } else if (Array.isArray(parent)) {
-            parent[key] = replacement; // eslint-disable-line no-param-reassign
-          }
-
-          return !parent ? replacement : false;
-        }
-      }
-
-      /**
-       * Dive deep into the fragment.
-       *
-       * Cases to consider:
-       *  1. We're crossing document boundary
-       *  2. Fragment is from non-root document
-       *  3. Fragment is a Path Item Object with $ref field. We need to follow it to get the eventual value
-       *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
-       */
-      const isNonRootDocument = url.stripHash(reference.refSet.rootRef.uri) !== reference.uri;
-      const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
-      if (
-        (isExternalReference ||
-          isNonRootDocument ||
-          (isPathItemElement(referencedElement) && isStringElement(referencedElement.$ref)) ||
-          shouldDetectCircular) &&
-        !ancestorsLineage.includesCycle(referencedElement)
-      ) {
-        // append referencing reference to ancestors lineage
-        directAncestors.add(referencingElement);
-
-        const visitor = OpenApi3_1DereferenceVisitor({
-          reference,
-          namespace: this.namespace,
-          indirections: [...this.indirections],
-          options: this.options,
-          refractCache: this.refractCache,
-          ancestors: ancestorsLineage,
-        });
-        referencedElement = await visitAsync(referencedElement, visitor, {
-          keyMap,
-          nodeTypeGetter: getNodeType,
-        });
-
-        // remove referencing reference from ancestors lineage
-        directAncestors.delete(referencingElement);
-      }
-
-      this.indirections.pop();
-
-      /**
-       * Creating a new version of Path Item by merging fields from referenced Path Item with referencing one.
-       */
-      if (isPathItemElement(referencedElement)) {
-        const mergedElement = new PathItemElement(
-          [...referencedElement.content] as any,
-          cloneDeep(referencedElement.meta),
-          cloneDeep(referencedElement.attributes),
-        );
-        // assign unique id to merged element
-        mergedElement.setMetaProperty('id', identityManager.generateId());
-        // existing keywords from referencing PathItemElement overrides ones from referenced element
-        referencingElement.forEach((value: Element, keyElement: Element, item: Element) => {
-          mergedElement.remove(toValue(keyElement));
-          mergedElement.content.push(item);
-        });
-        mergedElement.remove('$ref');
-
-        // annotate referenced element with info about original referencing element
-        mergedElement.setMetaProperty('ref-fields', {
-          $ref: toValue(referencingElement.$ref),
-        });
-        // annotate referenced element with info about origin
-        mergedElement.setMetaProperty('ref-origin', reference.uri);
-        // annotate fragment with info about referencing element
-        mergedElement.setMetaProperty(
-          'ref-referencing-element-id',
-          cloneDeep(identityManager.identify(referencingElement)),
-        );
-
-        referencedElement = mergedElement;
-      }
-
-      /**
-       * Transclude referencing element with merged referenced element.
-       */
-      if (isMemberElement(parent)) {
-        parent.value = referencedElement; // eslint-disable-line no-param-reassign
-      } else if (Array.isArray(parent)) {
-        parent[key] = referencedElement; // eslint-disable-line no-param-reassign
-      }
-
-      /**
-       * We're at the root of the tree, so we're just replacing the entire tree.
-       */
-      return !parent ? referencedElement : undefined;
-    },
-
-    async LinkElement(linkElement: LinkElement, key: string | number, parent: Element | undefined) {
-      // ignore LinkElement without operationRef or operationId field
-      if (!isStringElement(linkElement.operationRef) && !isStringElement(linkElement.operationId)) {
-        return undefined;
-      }
-
-      // operationRef and operationId fields are mutually exclusive
-      if (isStringElement(linkElement.operationRef) && isStringElement(linkElement.operationId)) {
-        throw new ApiDOMError(
-          'LinkElement operationRef and operationId fields are mutually exclusive.',
-        );
-      }
-
-      let operationElement: any;
-
-      if (isStringElement(linkElement.operationRef)) {
-        // possibly non-semantic referenced element
-        const jsonPointer = uriToPointer(toValue(linkElement.operationRef));
-        const retrievalURI = this.toBaseURI(toValue(linkElement.operationRef));
-        const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-        const isExternalReference = !isInternalReference;
-
-        // ignore resolving internal Operation Object reference
-        if (!this.options.resolve.internal && isInternalReference) {
-          // skip traversing this Link element but traverse all it's child elements
-          return undefined;
-        }
-        // ignore resolving external Operation Object reference
-        if (!this.options.resolve.external && isExternalReference) {
-          // skip traversing this Link element but traverse all it's child elements
-          return undefined;
-        }
-
-        const reference = await this.toReference(toValue(linkElement.operationRef));
-
-        operationElement = jsonPointerEvaluate(jsonPointer, reference.value.result);
-        // applying semantics to a referenced element
-        if (isPrimitiveElement(operationElement)) {
-          const cacheKey = `operation-${toValue(identityManager.identify(operationElement))}`;
-
-          if (this.refractCache.has(cacheKey)) {
-            operationElement = this.refractCache.get(cacheKey);
-          } else {
-            operationElement = OperationElement.refract(operationElement);
-            this.refractCache.set(cacheKey, operationElement);
-          }
-        }
-        // create shallow clone to be able to annotate with metadata
-        operationElement = cloneShallow(operationElement);
-        // annotate operation element with info about origin
-        operationElement.setMetaProperty('ref-origin', reference.uri);
-
-        const linkElementCopy = cloneShallow(linkElement);
-        linkElementCopy.operationRef?.meta.set('operation', operationElement);
-
-        /**
-         * Transclude Link Object containing Operation Object in its meta.
-         */
-        if (isMemberElement(parent)) {
-          parent.value = linkElementCopy; // eslint-disable-line no-param-reassign
-        } else if (Array.isArray(parent)) {
-          parent[key] = linkElementCopy; // eslint-disable-line no-param-reassign
-        }
-
-        /**
-         * We're at the root of the tree, so we're just replacing the entire tree.
-         */
-        return !parent ? linkElementCopy : undefined;
-      }
-
-      if (isStringElement(linkElement.operationId)) {
-        const operationId = toValue(linkElement.operationId);
-        const reference = await this.toReference(url.unsanitize(this.reference.uri));
-        operationElement = find(
-          (e) =>
-            isOperationElement(e) && isElement(e.operationId) && e.operationId.equals(operationId),
-          reference.value.result,
-        );
-        // OperationElement not found by its operationId
-        if (isUndefined(operationElement)) {
-          throw new ApiDOMError(`OperationElement(operationId=${operationId}) not found.`);
-        }
-
-        const linkElementCopy = cloneShallow(linkElement);
-        linkElementCopy.operationId?.meta.set('operation', operationElement);
-
-        /**
-         * Transclude Link Object containing Operation Object in its meta.
-         */
-        if (isMemberElement(parent)) {
-          parent.value = linkElementCopy; // eslint-disable-line no-param-reassign
-        } else if (Array.isArray(parent)) {
-          parent[key] = linkElementCopy; // eslint-disable-line no-param-reassign
-        }
-
-        /**
-         * We're at the root of the tree, so we're just replacing the entire tree.
-         */
-        return !parent ? linkElementCopy : undefined;
-      }
-
-      return undefined;
-    },
-
-    async ExampleElement(
-      exampleElement: ExampleElement,
-      key: string | number,
-      parent: Element | undefined,
-    ) {
-      // ignore ExampleElement without externalValue field
-      if (!isStringElement(exampleElement.externalValue)) {
-        return undefined;
-      }
-
-      // value and externalValue fields are mutually exclusive
-      if (exampleElement.hasKey('value') && isStringElement(exampleElement.externalValue)) {
-        throw new ApiDOMError(
-          'ExampleElement value and externalValue fields are mutually exclusive.',
-        );
-      }
-
-      const retrievalURI = this.toBaseURI(toValue(exampleElement.externalValue));
-      const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-      const isExternalReference = !isInternalReference;
-
-      // ignore resolving internal Example Objects
-      if (!this.options.resolve.internal && isInternalReference) {
-        // skip traversing this Example element but traverse all it's child elements
-        return undefined;
-      }
-      // ignore resolving external Example Objects
-      if (!this.options.resolve.external && isExternalReference) {
-        // skip traversing this Example element but traverse all it's child elements
-        return undefined;
-      }
-
-      const reference = await this.toReference(toValue(exampleElement.externalValue));
-
-      // shallow clone of the referenced element
-      const valueElement = cloneShallow(reference.value.result);
+      // create shallow clone to be able to annotate with metadata
+      operationElement = cloneShallow(operationElement);
       // annotate operation element with info about origin
-      valueElement.setMetaProperty('ref-origin', reference.uri);
+      operationElement.setMetaProperty('ref-origin', reference.uri);
 
-      const exampleElementCopy = cloneShallow(exampleElement);
-      exampleElementCopy.value = valueElement;
+      const linkElementCopy = cloneShallow(linkElement);
+      linkElementCopy.operationRef?.meta.set('operation', operationElement);
 
       /**
-       * Transclude Example Object containing external value.
+       * Transclude Link Object containing Operation Object in its meta.
        */
       if (isMemberElement(parent)) {
-        parent.value = exampleElementCopy; // eslint-disable-line no-param-reassign
+        parent.value = linkElementCopy; // eslint-disable-line no-param-reassign
       } else if (Array.isArray(parent)) {
-        parent[key] = exampleElementCopy; // eslint-disable-line no-param-reassign
+        parent[key] = linkElementCopy; // eslint-disable-line no-param-reassign
       }
 
       /**
        * We're at the root of the tree, so we're just replacing the entire tree.
        */
-      return !parent ? exampleElementCopy : undefined;
-    },
+      return !parent ? linkElementCopy : undefined;
+    }
 
-    async SchemaElement(
-      referencingElement: SchemaElement,
-      key: string | number,
-      parent: Element | undefined,
-      path: (string | number)[],
-      ancestors: [Element | Element[]],
-    ) {
-      // skip current referencing schema as $ref keyword was not defined
-      if (!isStringElement(referencingElement.$ref)) {
-        return undefined;
+    if (isStringElement(linkElement.operationId)) {
+      const operationId = toValue(linkElement.operationId);
+      const reference = await this.toReference(url.unsanitize(this.reference.uri));
+      operationElement = find(
+        (e) =>
+          isOperationElement(e) && isElement(e.operationId) && e.operationId.equals(operationId),
+        reference.value.result as Element,
+      );
+      // OperationElement not found by its operationId
+      if (isUndefined(operationElement)) {
+        throw new ApiDOMError(`OperationElement(operationId=${operationId}) not found.`);
       }
 
-      // skip current referencing element as it's already been access
-      if (this.indirections.includes(referencingElement)) {
-        return false;
+      const linkElementCopy = cloneShallow(linkElement);
+      linkElementCopy.operationId?.meta.set('operation', operationElement);
+
+      /**
+       * Transclude Link Object containing Operation Object in its meta.
+       */
+      if (isMemberElement(parent)) {
+        parent.value = linkElementCopy; // eslint-disable-line no-param-reassign
+      } else if (Array.isArray(parent)) {
+        parent[key] = linkElementCopy; // eslint-disable-line no-param-reassign
       }
 
-      const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+      /**
+       * We're at the root of the tree, so we're just replacing the entire tree.
+       */
+      return !parent ? linkElementCopy : undefined;
+    }
 
-      // compute baseURI using rules around $id and $ref keywords
-      let reference = await this.toReference(url.unsanitize(this.reference.uri));
-      let { uri: retrievalURI } = reference;
-      const $refBaseURI = resolveSchema$refField(retrievalURI, referencingElement)!;
-      const $refBaseURIStrippedHash = url.stripHash($refBaseURI);
-      const file = new File({ uri: $refBaseURIStrippedHash });
-      const isUnknownURI = none((r: Resolver) => r.canRead(file), this.options.resolve.resolvers);
-      const isURL = !isUnknownURI;
-      let isInternalReference = url.stripHash(this.reference.uri) === $refBaseURI;
-      let isExternalReference = !isInternalReference;
+    return undefined;
+  }
 
-      this.indirections.push(referencingElement);
+  public async ExampleElement(
+    exampleElement: ExampleElement,
+    key: string | number,
+    parent: Element | undefined,
+  ) {
+    // ignore ExampleElement without externalValue field
+    if (!isStringElement(exampleElement.externalValue)) {
+      return undefined;
+    }
 
-      // determining reference, proper evaluation and selection mechanism
-      let referencedElement: any;
+    // value and externalValue fields are mutually exclusive
+    if (exampleElement.hasKey('value') && isStringElement(exampleElement.externalValue)) {
+      throw new ApiDOMError(
+        'ExampleElement value and externalValue fields are mutually exclusive.',
+      );
+    }
 
-      try {
-        if (isUnknownURI || isURL) {
-          // we're dealing with canonical URI or URL with possible fragment
-          retrievalURI = this.toBaseURI($refBaseURI);
-          const selector = $refBaseURI;
-          const referenceAsSchema = maybeRefractToSchemaElement(reference.value.result);
-          referencedElement = uriEvaluate(selector, referenceAsSchema);
-          referencedElement = maybeRefractToSchemaElement(referencedElement);
-          referencedElement.id = identityManager.identify(referencedElement);
+    const retrievalURI = this.toBaseURI(toValue(exampleElement.externalValue));
+    const isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+    const isExternalReference = !isInternalReference;
+
+    // ignore resolving internal Example Objects
+    if (!this.options.resolve.internal && isInternalReference) {
+      // skip traversing this Example element but traverse all it's child elements
+      return undefined;
+    }
+    // ignore resolving external Example Objects
+    if (!this.options.resolve.external && isExternalReference) {
+      // skip traversing this Example element but traverse all it's child elements
+      return undefined;
+    }
+
+    const reference = await this.toReference(toValue(exampleElement.externalValue));
+
+    // shallow clone of the referenced element
+    const valueElement = cloneShallow(reference.value.result as Element);
+    // annotate operation element with info about origin
+    valueElement.setMetaProperty('ref-origin', reference.uri);
+
+    const exampleElementCopy = cloneShallow(exampleElement);
+    exampleElementCopy.value = valueElement;
+
+    /**
+     * Transclude Example Object containing external value.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = exampleElementCopy; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = exampleElementCopy; // eslint-disable-line no-param-reassign
+    }
+
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? exampleElementCopy : undefined;
+  }
+
+  public async SchemaElement(
+    referencingElement: SchemaElement,
+    key: string | number,
+    parent: Element | undefined,
+    path: (string | number)[],
+    ancestors: [Element | Element[]],
+  ) {
+    // skip current referencing schema as $ref keyword was not defined
+    if (!isStringElement(referencingElement.$ref)) {
+      return undefined;
+    }
+
+    // skip current referencing element as it's already been access
+    if (this.indirections.includes(referencingElement)) {
+      return false;
+    }
+
+    const [ancestorsLineage, directAncestors] = this.toAncestorLineage([...ancestors, parent]);
+
+    // compute baseURI using rules around $id and $ref keywords
+    let reference = await this.toReference(url.unsanitize(this.reference.uri));
+    let { uri: retrievalURI } = reference;
+    const $refBaseURI = resolveSchema$refField(retrievalURI, referencingElement)!;
+    const $refBaseURIStrippedHash = url.stripHash($refBaseURI);
+    const file = new File({ uri: $refBaseURIStrippedHash });
+    const isUnknownURI = none((r: Resolver) => r.canRead(file), this.options.resolve.resolvers);
+    const isURL = !isUnknownURI;
+    let isInternalReference = url.stripHash(this.reference.uri) === $refBaseURI;
+    let isExternalReference = !isInternalReference;
+
+    this.indirections.push(referencingElement);
+
+    // determining reference, proper evaluation and selection mechanism
+    let referencedElement: Element;
+
+    try {
+      if (isUnknownURI || isURL) {
+        // we're dealing with canonical URI or URL with possible fragment
+        retrievalURI = this.toBaseURI($refBaseURI);
+        const selector = $refBaseURI;
+        const referenceAsSchema = maybeRefractToSchemaElement(reference.value.result as Element);
+        referencedElement = uriEvaluate(selector, referenceAsSchema)!;
+        referencedElement = maybeRefractToSchemaElement(referencedElement);
+        referencedElement.id = identityManager.identify(referencedElement);
+
+        // ignore resolving internal Schema Objects
+        if (!this.options.resolve.internal && isInternalReference) {
+          // skip traversing this schema element but traverse all it's child elements
+          return undefined;
+        }
+        // ignore resolving external Schema Objects
+        if (!this.options.resolve.external && isExternalReference) {
+          // skip traversing this schema element but traverse all it's child elements
+          return undefined;
+        }
+      } else {
+        // we're assuming here that we're dealing with JSON Pointer here
+        retrievalURI = this.toBaseURI($refBaseURI);
+        isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+        isExternalReference = !isInternalReference;
+
+        // ignore resolving internal Schema Objects
+        if (!this.options.resolve.internal && isInternalReference) {
+          // skip traversing this schema element but traverse all it's child elements
+          return undefined;
+        }
+        // ignore resolving external Schema Objects
+        if (!this.options.resolve.external && isExternalReference) {
+          // skip traversing this schema element but traverse all it's child elements
+          return undefined;
+        }
+
+        reference = await this.toReference(url.unsanitize($refBaseURI));
+        const selector = uriToPointer($refBaseURI);
+        const referenceAsSchema = maybeRefractToSchemaElement(reference.value.result as Element);
+        referencedElement = jsonPointerEvaluate(selector, referenceAsSchema);
+        referencedElement = maybeRefractToSchemaElement(referencedElement);
+        referencedElement.id = identityManager.identify(referencedElement);
+      }
+    } catch (error) {
+      /**
+       * No SchemaElement($id=URL) was not found, so we're going to try to resolve
+       * the URL and assume the returned response is a JSON Schema.
+       */
+      if (isURL && error instanceof EvaluationJsonSchemaUriError) {
+        if (isAnchor(uriToAnchor($refBaseURI))) {
+          // we're dealing with JSON Schema $anchor here
+          isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
+          isExternalReference = !isInternalReference;
 
           // ignore resolving internal Schema Objects
           if (!this.options.resolve.internal && isInternalReference) {
@@ -727,6 +793,13 @@ const OpenApi3_1DereferenceVisitor = stampit({
             // skip traversing this schema element but traverse all it's child elements
             return undefined;
           }
+
+          reference = await this.toReference(url.unsanitize($refBaseURI));
+          const selector = uriToAnchor($refBaseURI);
+          const referenceAsSchema = maybeRefractToSchemaElement(reference.value.result as Element);
+          referencedElement = $anchorEvaluate(selector, referenceAsSchema)!;
+          referencedElement = maybeRefractToSchemaElement(referencedElement);
+          referencedElement.id = identityManager.identify(referencedElement);
         } else {
           // we're assuming here that we're dealing with JSON Pointer here
           retrievalURI = this.toBaseURI($refBaseURI);
@@ -746,219 +819,166 @@ const OpenApi3_1DereferenceVisitor = stampit({
 
           reference = await this.toReference(url.unsanitize($refBaseURI));
           const selector = uriToPointer($refBaseURI);
-          const referenceAsSchema = maybeRefractToSchemaElement(reference.value.result);
+          const referenceAsSchema = maybeRefractToSchemaElement(reference.value.result as Element);
           referencedElement = jsonPointerEvaluate(selector, referenceAsSchema);
           referencedElement = maybeRefractToSchemaElement(referencedElement);
           referencedElement.id = identityManager.identify(referencedElement);
         }
-      } catch (error) {
-        /**
-         * No SchemaElement($id=URL) was not found, so we're going to try to resolve
-         * the URL and assume the returned response is a JSON Schema.
-         */
-        if (isURL && error instanceof EvaluationJsonSchemaUriError) {
-          if (isAnchor(uriToAnchor($refBaseURI))) {
-            // we're dealing with JSON Schema $anchor here
-            isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-            isExternalReference = !isInternalReference;
-
-            // ignore resolving internal Schema Objects
-            if (!this.options.resolve.internal && isInternalReference) {
-              // skip traversing this schema element but traverse all it's child elements
-              return undefined;
-            }
-            // ignore resolving external Schema Objects
-            if (!this.options.resolve.external && isExternalReference) {
-              // skip traversing this schema element but traverse all it's child elements
-              return undefined;
-            }
-
-            reference = await this.toReference(url.unsanitize($refBaseURI));
-            const selector = uriToAnchor($refBaseURI);
-            const referenceAsSchema = maybeRefractToSchemaElement(reference.value.result);
-            referencedElement = $anchorEvaluate(selector, referenceAsSchema);
-            referencedElement = maybeRefractToSchemaElement(referencedElement);
-            referencedElement.id = identityManager.identify(referencedElement);
-          } else {
-            // we're assuming here that we're dealing with JSON Pointer here
-            retrievalURI = this.toBaseURI($refBaseURI);
-            isInternalReference = url.stripHash(this.reference.uri) === retrievalURI;
-            isExternalReference = !isInternalReference;
-
-            // ignore resolving internal Schema Objects
-            if (!this.options.resolve.internal && isInternalReference) {
-              // skip traversing this schema element but traverse all it's child elements
-              return undefined;
-            }
-            // ignore resolving external Schema Objects
-            if (!this.options.resolve.external && isExternalReference) {
-              // skip traversing this schema element but traverse all it's child elements
-              return undefined;
-            }
-
-            reference = await this.toReference(url.unsanitize($refBaseURI));
-            const selector = uriToPointer($refBaseURI);
-            const referenceAsSchema = maybeRefractToSchemaElement(reference.value.result);
-            referencedElement = jsonPointerEvaluate(selector, referenceAsSchema);
-            referencedElement = maybeRefractToSchemaElement(referencedElement);
-            referencedElement.id = identityManager.identify(referencedElement);
-          }
-        } else {
-          throw error;
-        }
+      } else {
+        throw error;
       }
+    }
 
-      // detect direct or indirect reference
-      if (referencingElement === referencedElement) {
-        throw new ApiDOMError('Recursive Schema Object reference detected');
-      }
+    // detect direct or indirect reference
+    if (referencingElement === referencedElement) {
+      throw new ApiDOMError('Recursive Schema Object reference detected');
+    }
 
-      // detect maximum depth of dereferencing
-      if (this.indirections.length > this.options.dereference.maxDepth) {
-        throw new MaximumDereferenceDepthError(
-          `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
-        );
-      }
+    // detect maximum depth of dereferencing
+    if (this.indirections.length > this.options.dereference.maxDepth) {
+      throw new MaximumDereferenceDepthError(
+        `Maximum dereference depth of "${this.options.dereference.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
+      );
+    }
 
-      // detect second deep dive into the same fragment and avoid it
-      if (ancestorsLineage.includes(referencedElement)) {
-        reference.refSet.circular = true;
+    // detect second deep dive into the same fragment and avoid it
+    if (ancestorsLineage.includes(referencedElement)) {
+      reference.refSet!.circular = true;
 
-        if (this.options.dereference.circular === 'error') {
-          throw new ApiDOMError('Circular reference detected');
-        } else if (this.options.dereference.circular === 'replace') {
-          const refElement = new RefElement(referencedElement.id, {
-            type: 'json-schema',
-            uri: reference.uri,
-            $ref: toValue(referencingElement.$ref),
-          });
-          const replacer =
-            this.options.dereference.strategyOpts['openapi-3-1']?.circularReplacer ??
-            this.options.dereference.circularReplacer;
-          const replacement = replacer(refElement);
-
-          if (isMemberElement(parent)) {
-            parent.value = replacement; // eslint-disable-line no-param-reassign
-          } else if (Array.isArray(parent)) {
-            parent[key] = replacement; // eslint-disable-line no-param-reassign
-          }
-
-          return !parent ? replacement : false;
-        }
-      }
-
-      /**
-       * Dive deep into the fragment.
-       *
-       * Cases to consider:
-       *  1. We're crossing document boundary
-       *  2. Fragment is from non-root document
-       *  3. Fragment is a Schema Object with $ref field. We need to follow it to get the eventual value
-       *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
-       */
-      const isNonRootDocument = url.stripHash(reference.refSet.rootRef.uri) !== reference.uri;
-      const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
-      if (
-        (isExternalReference ||
-          isNonRootDocument ||
-          (isSchemaElement(referencedElement) && isStringElement(referencedElement.$ref)) ||
-          shouldDetectCircular) &&
-        !ancestorsLineage.includesCycle(referencedElement)
-      ) {
-        // append referencing reference to ancestors lineage
-        directAncestors.add(referencingElement);
-
-        const visitor = OpenApi3_1DereferenceVisitor({
-          reference,
-          namespace: this.namespace,
-          indirections: [...this.indirections],
-          options: this.options,
-          refractCache: this.refractCache,
-          ancestors: ancestorsLineage,
-        });
-        referencedElement = await visitAsync(referencedElement, visitor, {
-          keyMap,
-          nodeTypeGetter: getNodeType,
-        });
-
-        // remove referencing reference from ancestors lineage
-        directAncestors.delete(referencingElement);
-      }
-
-      this.indirections.pop();
-
-      // Boolean JSON Schemas
-      if (isBooleanJsonSchemaElement(referencedElement as unknown)) {
-        const booleanJsonSchemaElement: BooleanElement = cloneDeep(referencedElement);
-        // assign unique id to merged element
-        booleanJsonSchemaElement.setMetaProperty('id', identityManager.generateId());
-        // annotate referenced element with info about original referencing element
-        booleanJsonSchemaElement.setMetaProperty('ref-fields', {
+      if (this.options.dereference.circular === 'error') {
+        throw new ApiDOMError('Circular reference detected');
+      } else if (this.options.dereference.circular === 'replace') {
+        const refElement = new RefElement(referencedElement.id, {
+          type: 'json-schema',
+          uri: reference.uri,
           $ref: toValue(referencingElement.$ref),
         });
-        // annotate referenced element with info about origin
-        booleanJsonSchemaElement.setMetaProperty('ref-origin', reference.uri);
-        // annotate fragment with info about referencing element
-        booleanJsonSchemaElement.setMetaProperty(
-          'ref-referencing-element-id',
-          cloneDeep(identityManager.identify(referencingElement)),
-        );
+        const replacer =
+          this.options.dereference.strategyOpts['openapi-3-1']?.circularReplacer ??
+          this.options.dereference.circularReplacer;
+        const replacement = replacer(refElement);
 
         if (isMemberElement(parent)) {
-          parent.value = booleanJsonSchemaElement; // eslint-disable-line no-param-reassign
+          parent.value = replacement; // eslint-disable-line no-param-reassign
         } else if (Array.isArray(parent)) {
-          parent[key] = booleanJsonSchemaElement; // eslint-disable-line no-param-reassign
+          parent[key] = replacement; // eslint-disable-line no-param-reassign
         }
 
-        return !parent ? booleanJsonSchemaElement : false;
+        return !parent ? replacement : false;
       }
+    }
 
-      /**
-       * Creating a new version of Schema Object by merging fields from referenced Schema Object with referencing one.
-       */
-      if (isSchemaElement(referencedElement)) {
-        const mergedElement = new SchemaElement(
-          [...referencedElement.content] as any,
-          cloneDeep(referencedElement.meta),
-          cloneDeep(referencedElement.attributes),
-        );
-        // assign unique id to merged element
-        mergedElement.setMetaProperty('id', identityManager.generateId());
-        // existing keywords from referencing schema overrides ones from referenced schema
-        referencingElement.forEach((value: Element, keyElement: Element, item: Element) => {
-          mergedElement.remove(toValue(keyElement));
-          mergedElement.content.push(item);
-        });
-        mergedElement.remove('$ref');
-        // annotate referenced element with info about original referencing element
-        mergedElement.setMetaProperty('ref-fields', {
-          $ref: toValue(referencingElement.$ref),
-        });
-        // annotate fragment with info about origin
-        mergedElement.setMetaProperty('ref-origin', reference.uri);
-        // annotate fragment with info about referencing element
-        mergedElement.setMetaProperty(
-          'ref-referencing-element-id',
-          cloneDeep(identityManager.identify(referencingElement)),
-        );
+    /**
+     * Dive deep into the fragment.
+     *
+     * Cases to consider:
+     *  1. We're crossing document boundary
+     *  2. Fragment is from non-root document
+     *  3. Fragment is a Schema Object with $ref field. We need to follow it to get the eventual value
+     *  4. We are dereferencing the fragment lazily/eagerly depending on circular mode
+     */
+    const isNonRootDocument = url.stripHash(reference.refSet!.rootRef!.uri) !== reference.uri;
+    const shouldDetectCircular = ['error', 'replace'].includes(this.options.dereference.circular);
+    if (
+      (isExternalReference ||
+        isNonRootDocument ||
+        (isSchemaElement(referencedElement) && isStringElement(referencedElement.$ref)) ||
+        shouldDetectCircular) &&
+      !ancestorsLineage.includesCycle(referencedElement)
+    ) {
+      // append referencing reference to ancestors lineage
+      directAncestors.add(referencingElement);
 
-        referencedElement = mergedElement;
-      }
-      /**
-       * Transclude referencing element with merged referenced element.
-       */
+      const visitor = new OpenAPI3_1DereferenceVisitor({
+        reference,
+        namespace: this.namespace,
+        indirections: [...this.indirections],
+        options: this.options,
+        refractCache: this.refractCache,
+        ancestors: ancestorsLineage,
+      });
+      referencedElement = await visitAsync(referencedElement, visitor, {
+        keyMap,
+        nodeTypeGetter: getNodeType,
+      });
+
+      // remove referencing reference from ancestors lineage
+      directAncestors.delete(referencingElement);
+    }
+
+    this.indirections.pop();
+
+    // Boolean JSON Schemas
+    if (isBooleanJsonSchemaElement(referencedElement as unknown)) {
+      const booleanJsonSchemaElement: BooleanElement = cloneDeep(referencedElement);
+      // assign unique id to merged element
+      booleanJsonSchemaElement.setMetaProperty('id', identityManager.generateId());
+      // annotate referenced element with info about original referencing element
+      booleanJsonSchemaElement.setMetaProperty('ref-fields', {
+        $ref: toValue(referencingElement.$ref),
+      });
+      // annotate referenced element with info about origin
+      booleanJsonSchemaElement.setMetaProperty('ref-origin', reference.uri);
+      // annotate fragment with info about referencing element
+      booleanJsonSchemaElement.setMetaProperty(
+        'ref-referencing-element-id',
+        cloneDeep(identityManager.identify(referencingElement)),
+      );
+
       if (isMemberElement(parent)) {
-        parent.value = referencedElement; // eslint-disable-line no-param-reassign
+        parent.value = booleanJsonSchemaElement; // eslint-disable-line no-param-reassign
       } else if (Array.isArray(parent)) {
-        parent[key] = referencedElement; // eslint-disable-line no-param-reassign
+        parent[key] = booleanJsonSchemaElement; // eslint-disable-line no-param-reassign
       }
 
-      /**
-       * We're at the root of the tree, so we're just replacing the entire tree.
-       */
-      return !parent ? referencedElement : undefined;
-    },
-  },
-});
+      return !parent ? booleanJsonSchemaElement : false;
+    }
 
-export default OpenApi3_1DereferenceVisitor;
+    /**
+     * Creating a new version of Schema Object by merging fields from referenced Schema Object with referencing one.
+     */
+    if (isSchemaElement(referencedElement)) {
+      const mergedElement = new SchemaElement(
+        [...referencedElement.content] as any,
+        cloneDeep(referencedElement.meta),
+        cloneDeep(referencedElement.attributes),
+      );
+      // assign unique id to merged element
+      mergedElement.setMetaProperty('id', identityManager.generateId());
+      // existing keywords from referencing schema overrides ones from referenced schema
+      referencingElement.forEach((value: Element, keyElement: Element, item: Element) => {
+        mergedElement.remove(toValue(keyElement));
+        mergedElement.content.push(item);
+      });
+      mergedElement.remove('$ref');
+      // annotate referenced element with info about original referencing element
+      mergedElement.setMetaProperty('ref-fields', {
+        $ref: toValue(referencingElement.$ref),
+      });
+      // annotate fragment with info about origin
+      mergedElement.setMetaProperty('ref-origin', reference.uri);
+      // annotate fragment with info about referencing element
+      mergedElement.setMetaProperty(
+        'ref-referencing-element-id',
+        cloneDeep(identityManager.identify(referencingElement)),
+      );
+
+      referencedElement = mergedElement;
+    }
+    /**
+     * Transclude referencing element with merged referenced element.
+     */
+    if (isMemberElement(parent)) {
+      parent.value = referencedElement; // eslint-disable-line no-param-reassign
+    } else if (Array.isArray(parent)) {
+      parent[key] = referencedElement; // eslint-disable-line no-param-reassign
+    }
+
+    /**
+     * We're at the root of the tree, so we're just replacing the entire tree.
+     */
+    return !parent ? referencedElement : undefined;
+  }
+}
+
+export default OpenAPI3_1DereferenceVisitor;


### PR DESCRIPTION
Refs #3481

BREAKING CHANGE: all visitors from apidom-reference package became a class and requires to be instantiated with new operator.
