### PR TITLE
ci(release): automatically release to GitHub Package Registry

### DIFF
--- a/.github/workflows/release-to-GPR.yml
+++ b/.github/workflows/release-to-GPR.yml
@@ -1,14 +1,17 @@
 name: Release monorepo packages to GitHub Package Registry
 on:
-  workflow_dispatch:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Release monorepo packages"]
+    types:
+      - completed
+    branches: [main]
 
 env:
   CPU_CORES: 2
 
 jobs:
   release:
+    if: github.event.workflow_run.conclusion == 'success'
     name: Release to GitHub Package Registry
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
We want to automatically release ApiDOM npm packages to GitHub Package Registry along with npmj.com.