### PR TITLE
fix(apidom-parser-adapter-openapi-json-3-0): remove rc version support

### DIFF
--- a/packages/apidom-parser-adapter-openapi-json-3-0/src/adapter.ts
+++ b/packages/apidom-parser-adapter-openapi-json-3-0/src/adapter.ts
@@ -6,7 +6,7 @@ import openApiNamespace, { OpenApi3_0Element } from '@swagger-api/apidom-ns-open
 
 export { default as mediaTypes } from './media-types';
 
-export const detectionRegExp = /"openapi"\s*:\s*"(?<version_json>3\.0\.([0123])(?:-rc[012])?)"/;
+export const detectionRegExp = /"openapi"\s*:\s*"(?<version_json>3\.0\.([0123]))"/;
 
 export const detect = async (source: string): Promise<boolean> =>
   detectionRegExp.test(source) && (await detectJSON(source));

--- a/packages/apidom-parser-adapter-openapi-json-3-0/test/adapter.ts
+++ b/packages/apidom-parser-adapter-openapi-json-3-0/test/adapter.ts
@@ -79,6 +79,7 @@ describe('adapter', function () {
       assert.isFalse(adapter.detectionRegExp.test('"openapi": "3.1.0"'));
       assert.isFalse(adapter.detectionRegExp.test('"openapi": "3.01.0"'));
       assert.isFalse(adapter.detectionRegExp.test('"openapi": "3.0.01"'));
+      assert.isFalse(adapter.detectionRegExp.test('"openapi": "3.0.1-rc1"'));
     });
   });
 });


### PR DESCRIPTION
This PR removes rc version support from `apidom-parser-adapter-openapi-json-3-0` package.

### Description

This PR does the following:

- modifies version detection RegExp
- adds one additional test to ensure that rc releases are not recognized anymore



### Motivation and Context

Closes https://github.com/swagger-api/apidom/issues/2265



### How Has This Been Tested?

It has been tested by adding new unit tests in the package folder.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains...
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
