### PR TITLE
chore(deps): bump jsonpath-plus from 7.2.0 to 10.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4310,6 +4310,28 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
+      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
+      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -19866,6 +19888,14 @@
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true
     },
+    "node_modules/jsep": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
+      "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -19984,11 +20014,20 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.0.6.tgz",
+      "integrity": "sha512-Q0KCash90S0WQnPnE/W0uVXQSww4NkO34COfs+gbq0fk+Kv03FYpZ+uU2I7soLLaS4d/ywsm9PxplZsTMmfBmg==",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "jsep": "^1.3.9"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonpointer": {
@@ -31622,7 +31661,7 @@
         "@swagger-api/apidom-core": "^1.0.0-alpha.9",
         "@swagger-api/apidom-error": "^1.0.0-alpha.9",
         "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.9",
-        "jsonpath-plus": "^7.2.0"
+        "jsonpath-plus": "^10.0.6"
       }
     },
     "packages/apidom-json-pointer": {

--- a/packages/apidom-json-path/package.json
+++ b/packages/apidom-json-path/package.json
@@ -41,7 +41,7 @@
     "@swagger-api/apidom-core": "^1.0.0-alpha.9",
     "@swagger-api/apidom-error": "^1.0.0-alpha.9",
     "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.9",
-    "jsonpath-plus": "^7.2.0"
+    "jsonpath-plus": "^10.0.6"
   },
   "files": [
     "cjs/",

--- a/packages/apidom-json-path/src/index.ts
+++ b/packages/apidom-json-path/src/index.ts
@@ -1,3 +1,5 @@
+import './polyfills';
+
 export { default as EvaluationJsonPathError } from './errors/EvaluationJsonPathError';
 export type { EvaluationJsonPathErrorOptions } from './errors/EvaluationJsonPathError';
 export { default as MultiEvaluationJsonPathError } from './errors/MultiEvaluationJsonPathError';

--- a/packages/apidom-json-path/src/polyfills.ts
+++ b/packages/apidom-json-path/src/polyfills.ts
@@ -1,0 +1,18 @@
+// @ts-ignore
+import hasOwnPonyfill from 'core-js-pure/actual/object/has-own';
+// @ts-ignore
+import replaceAllPonyfill from 'core-js-pure/actual/string/replace-all';
+
+/**
+ * These polyfills do maintain compatibility with Node.js >= 12.20.0
+ */
+
+if (!Object.hasOwn) {
+  Object.hasOwn = hasOwnPonyfill;
+}
+if (!String.prototype.replaceAll) {
+  // eslint-disable-next-line no-extend-native
+  String.prototype.replaceAll = function replaceAll(search, replacement) {
+    return replaceAllPonyfill(this, search, replacement);
+  };
+}


### PR DESCRIPTION
Closes #4379

---

In order to update jsonpath-plus, eliminate security issues around it and keep the minimum supported Node.js version to Node.js 12.20.0, polyfills needed to be introduced.