### PR TITLE
build(parser-adapter-openapi-yaml-3-0): use nodenext for TypeScript modules

### DIFF
--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/.eslintrc
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/.eslintrc
@@ -1,0 +1,22 @@
+{
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "project": ["./tsconfig.json"]
+      }
+    }
+  },
+  "rules": {
+    "import/extensions": [
+      "error",
+      "always",
+      {
+        "ts": "always",
+        "tsx": "always",
+        "js": "always",
+        "jsx": "never",
+        "ignorePackages": true
+      }
+    ]
+  }
+}

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/check-types-test.tsconfig.json
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/check-types-test.tsconfig.json
@@ -1,12 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "allowImportingTsExtensions": true
   },
   "include": [
-    "src/**/*",
     "test/**/*"
   ]
 }

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/check-types.tsconfig.json
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/check-types.tsconfig.json
@@ -6,7 +6,6 @@
     "allowImportingTsExtensions": true
   },
   "include": [
-    "src/**/*",
-    "test/**/*"
+    "src/**/*"
   ]
 }

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/package.json
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint ./",
     "lint:fix": "eslint ./ --fix",
     "clean": "rimraf --glob 'src/**/*.mjs' 'src/**/*.cjs' 'test/**/*.mjs' ./dist ./types",
-    "typescript:check-types": "tsc --noEmit",
+    "typescript:check-types": "tsc -p check-types.tsconfig.json --noEmit && tsc -p check-types-test.tsconfig.json --noEmit",
     "typescript:declaration": "tsc -p declaration.tsconfig.json && rollup -c config/rollup/types.dist.js",
     "test": "npm run build:es && cross-env BABEL_ENV=es babel test --out-dir test --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward' && cross-env NODE_ENV=test mocha",
     "prepack": "copyfiles -u 3 ../../LICENSES/* LICENSES && copyfiles -u 2 ../../NOTICE .",

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/src/adapter.ts
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/src/adapter.ts
@@ -7,7 +7,7 @@ import {
 } from '@swagger-api/apidom-parser-adapter-yaml-1-2';
 import openApiNamespace, { OpenApi3_0Element } from '@swagger-api/apidom-ns-openapi-3-0';
 
-export { default as mediaTypes } from './media-types';
+export { default as mediaTypes } from './media-types.ts';
 
 export const detectionRegExp =
   /(?<YAML>^(["']?)openapi\2\s*:\s*(["']?)(?<version_yaml>3\.0\.[0123](?:-rc[012])?)\3(?:\s+|$))|(?<JSON>"openapi"\s*:\s*"(?<version_json>3\.0\.[0123](?:-rc[012])?)")/m;

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/test/adapter.ts
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/test/adapter.ts
@@ -6,7 +6,7 @@ import dedent from 'dedent';
 import { isParseResultElement, SourceMapElement, sexprs } from '@swagger-api/apidom-core';
 import { isOpenApi3_0Element } from '@swagger-api/apidom-ns-openapi-3-0';
 
-import * as adapter from '../src/adapter';
+import * as adapter from '../src/adapter.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const jsonSpec = fs.readFileSync(path.join(__dirname, 'fixtures', 'sample-api.json')).toString();

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/test/media-types.ts
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/test/media-types.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import ApiDOMParser from '@swagger-api/apidom-parser';
 
-import * as openApiYAMLAdapter from '../src/adapter';
+import * as openApiYAMLAdapter from '../src/adapter.ts';
 
 describe('given adapter is used in parser', function () {
   const parser = new ApiDOMParser().use(openApiYAMLAdapter);

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/test/mocha-bootstrap.ts
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/test/mocha-bootstrap.ts
@@ -2,9 +2,9 @@ import * as chai from 'chai';
 import { jestSnapshotPlugin, addSerializer } from 'mocha-chai-jest-snapshot';
 
 // @ts-ignore
-import * as jestApiDOMSerializer from '../../../scripts/jest-serializer-apidom';
+import * as jestApiDOMSerializer from '../../../scripts/jest-serializer-apidom.mjs';
 // @ts-ignore
-import * as jestStringSerializer from '../../../scripts/jest-serializer-string';
+import * as jestStringSerializer from '../../../scripts/jest-serializer-string.mjs';
 
 chai.use(jestSnapshotPlugin());
 addSerializer(jestApiDOMSerializer);


### PR DESCRIPTION
Refs #4385

**NOTE:** the errors should be gone once [`apidom-ns-openapi-3-0`](https://github.com/swagger-api/apidom/pull/4449) is transformed.