### PR TITLE
build(ns-json-schema-draft-7): use nodenext for TypeScript modules

### DIFF
--- a/packages/apidom-ns-json-schema-draft-7/.eslintrc
+++ b/packages/apidom-ns-json-schema-draft-7/.eslintrc
@@ -1,0 +1,22 @@
+{
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "project": ["./tsconfig.json"]
+      }
+    }
+  },
+  "rules": {
+    "import/extensions": [
+      "error",
+      "always",
+      {
+        "ts": "always",
+        "tsx": "always",
+        "js": "always",
+        "jsx": "never",
+        "ignorePackages": true
+      }
+    ]
+  }
+}

--- a/packages/apidom-ns-json-schema-draft-7/package.json
+++ b/packages/apidom-ns-json-schema-draft-7/package.json
@@ -29,8 +29,8 @@
     "clean": "rimraf --glob 'src/**/*.mjs' 'src/**/*.cjs' 'test/**/*.mjs' ./dist ./types",
     "test": "npm run build:es && cross-env BABEL_ENV=es babel test --out-dir test --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward' && cross-env NODE_ENV=test mocha",
     "test:update-snapshots": "cross-env UPDATE_SNAPSHOT=1 mocha",
-    "typescript:check-types": "tsc --noEmit",
-    "typescript:declaration": "tsc -p declaration.tsconfig.json && rollup -c config/rollup/types.dist.js",
+    "typescript:check-types": "tsc --noEmit && tsc -p ./test/tsconfig.json --noEmit",
+    "typescript:declaration": "tsc -p tsconfig.declaration.json && rollup -c config/rollup/types.dist.js",
     "prepack": "copyfiles -u 3 ../../LICENSES/* LICENSES && copyfiles -u 2 ../../NOTICE .",
     "postpack": "rimraf NOTICE LICENSES"
   },

--- a/packages/apidom-ns-json-schema-draft-7/src/index.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/index.ts
@@ -11,21 +11,21 @@ export {
   isStringElement,
 } from '@swagger-api/apidom-core';
 
-export { default as mediaTypes, JSONSchemaDraft7MediaTypes } from './media-types';
+export { default as mediaTypes, JSONSchemaDraft7MediaTypes } from './media-types.ts';
 
 // eslint-disable-next-line no-restricted-exports
-export { default } from './namespace';
+export { default } from './namespace.ts';
 
-export { default as refractorPluginReplaceEmptyElement } from './refractor/plugins/replace-empty-element';
+export { default as refractorPluginReplaceEmptyElement } from './refractor/plugins/replace-empty-element.ts';
 
-export { default as refract, createRefractor } from './refractor';
-export { default as specificationObj } from './refractor/specification';
+export { default as refract, createRefractor } from './refractor/index.ts';
+export { default as specificationObj } from './refractor/specification.ts';
 
 export {
   isJSONReferenceElement,
   isJSONSchemaElement,
   isLinkDescriptionElement,
-} from './predicates';
+} from './predicates.ts';
 
 export {
   isJSONReferenceLikeElement,
@@ -62,16 +62,16 @@ export type {
 export type {
   default as JSONSchemaVisitor,
   JSONSchemaVisitorOptions,
-} from './refractor/visitors/json-schema';
+} from './refractor/visitors/json-schema/index.ts';
 export type {
   default as LinkDescriptionVisitor,
   LinkDescriptionVisitorOptions,
-} from './refractor/visitors/json-schema/link-description';
+} from './refractor/visitors/json-schema/link-description/index.ts';
 
-export { keyMap, getNodeType } from './traversal/visitor';
+export { keyMap, getNodeType } from './traversal/visitor.ts';
 
 /**
  * JSON Schema Draft 7 specification elements.
  */
-export { JSONSchemaElement, LinkDescriptionElement } from './refractor/registration';
+export { JSONSchemaElement, LinkDescriptionElement } from './refractor/registration.ts';
 export { JSONReferenceElement } from '@swagger-api/apidom-ns-json-schema-draft-6';

--- a/packages/apidom-ns-json-schema-draft-7/src/namespace.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/namespace.ts
@@ -1,8 +1,8 @@
 import { NamespacePluginOptions } from '@swagger-api/apidom-core';
 import { JSONReferenceElement } from '@swagger-api/apidom-ns-json-schema-draft-6';
 
-import JSONSchemaElement from './elements/JSONSchema';
-import LinkDescriptionElement from './elements/LinkDescription';
+import JSONSchemaElement from './elements/JSONSchema.ts';
+import LinkDescriptionElement from './elements/LinkDescription.ts';
 
 const jsonSchemaDraft7 = {
   namespace: (options: NamespacePluginOptions) => {

--- a/packages/apidom-ns-json-schema-draft-7/src/predicates.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/predicates.ts
@@ -1,7 +1,7 @@
 import { createPredicate } from '@swagger-api/apidom-core';
 
-import JSONSchemaElement from './elements/JSONSchema';
-import LinkDescriptionElement from './elements/LinkDescription';
+import JSONSchemaElement from './elements/JSONSchema.ts';
+import LinkDescriptionElement from './elements/LinkDescription.ts';
 
 export { isJSONReferenceElement } from '@swagger-api/apidom-ns-json-schema-draft-6';
 

--- a/packages/apidom-ns-json-schema-draft-7/src/refractor/index.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/refractor/index.ts
@@ -8,9 +8,9 @@ import {
 } from '@swagger-api/apidom-core';
 import type { Visitor as VisitorClass } from '@swagger-api/apidom-ns-json-schema-draft-6';
 
-import specification from './specification';
-import { keyMap, getNodeType } from '../traversal/visitor';
-import createToolbox from './toolbox';
+import specification from './specification.ts';
+import { keyMap, getNodeType } from '../traversal/visitor.ts';
+import createToolbox from './toolbox.ts';
 
 const refract = <T extends Element>(
   value: unknown,

--- a/packages/apidom-ns-json-schema-draft-7/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/refractor/plugins/replace-empty-element.ts
@@ -14,9 +14,9 @@ import {
  * JSON Schema Draft 7 specification elements.
  */
 
-import JSONSchemaElement from '../../elements/JSONSchema';
-import LinkDescriptionElement from '../../elements/LinkDescription';
-import { getNodeType } from '../../traversal/visitor';
+import JSONSchemaElement from '../../elements/JSONSchema.ts';
+import LinkDescriptionElement from '../../elements/LinkDescription.ts';
+import { getNodeType } from '../../traversal/visitor.ts';
 
 /**
  * This plugin is specific to YAML 1.2 format, which allows defining key-value pairs

--- a/packages/apidom-ns-json-schema-draft-7/src/refractor/registration.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/refractor/registration.ts
@@ -1,6 +1,6 @@
-import JSONSchemaElement from '../elements/JSONSchema';
-import LinkDescriptionElement from '../elements/LinkDescription';
-import { createRefractor } from './index';
+import JSONSchemaElement from '../elements/JSONSchema.ts';
+import LinkDescriptionElement from '../elements/LinkDescription.ts';
+import { createRefractor } from './index.ts';
 
 // register refractors specific to element types
 

--- a/packages/apidom-ns-json-schema-draft-7/src/refractor/specification.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/refractor/specification.ts
@@ -1,8 +1,8 @@
 import { pipe, assocPath, dissocPath } from 'ramda';
 import { specificationObj } from '@swagger-api/apidom-ns-json-schema-draft-6';
 
-import JSONSchemaVisitor from './visitors/json-schema';
-import LinkDescriptionVisitor from './visitors/json-schema/link-description';
+import JSONSchemaVisitor from './visitors/json-schema/index.ts';
+import LinkDescriptionVisitor from './visitors/json-schema/link-description/index.ts';
 
 const specification = pipe(
   // JSON Schema object modifications

--- a/packages/apidom-ns-json-schema-draft-7/src/refractor/toolbox.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/refractor/toolbox.ts
@@ -1,7 +1,7 @@
 import { createNamespace, isStringElement } from '@swagger-api/apidom-core';
 
-import * as jsonSchemaDraft7Predicates from '../predicates';
-import jsonSchemaDraft7Namespace from '../namespace';
+import * as jsonSchemaDraft7Predicates from '../predicates.ts';
+import jsonSchemaDraft7Namespace from '../namespace.ts';
 
 const createToolbox = () => {
   const namespace = createNamespace(jsonSchemaDraft7Namespace);

--- a/packages/apidom-ns-json-schema-draft-7/src/refractor/visitors/json-schema/index.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/refractor/visitors/json-schema/index.ts
@@ -9,7 +9,7 @@ import {
   SpecPath,
 } from '@swagger-api/apidom-ns-json-schema-draft-6';
 
-import JSONSchemaElement from '../../../elements/JSONSchema';
+import JSONSchemaElement from '../../../elements/JSONSchema.ts';
 
 export interface JSONSchemaVisitorOptions
   extends FixedFieldsVisitorOptions,

--- a/packages/apidom-ns-json-schema-draft-7/src/refractor/visitors/json-schema/link-description/index.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/refractor/visitors/json-schema/link-description/index.ts
@@ -8,7 +8,7 @@ import {
   SpecPath,
 } from '@swagger-api/apidom-ns-json-schema-draft-6';
 
-import LinkDescriptionElement from '../../../../elements/LinkDescription';
+import LinkDescriptionElement from '../../../../elements/LinkDescription.ts';
 
 export interface LinkDescriptionVisitorOptions
   extends FixedFieldsVisitorOptions,

--- a/packages/apidom-ns-json-schema-draft-7/test/mocha-bootstrap.ts
+++ b/packages/apidom-ns-json-schema-draft-7/test/mocha-bootstrap.ts
@@ -2,9 +2,9 @@ import * as chai from 'chai';
 import { jestSnapshotPlugin, addSerializer } from 'mocha-chai-jest-snapshot';
 
 // @ts-ignore
-import * as jestApiDOMSerializer from '../../../scripts/jest-serializer-apidom';
+import * as jestApiDOMSerializer from '../../../scripts/jest-serializer-apidom.mjs';
 // @ts-ignore
-import * as jestStringSerializer from '../../../scripts/jest-serializer-string';
+import * as jestStringSerializer from '../../../scripts/jest-serializer-string.mjs';
 
 chai.use(jestSnapshotPlugin());
 addSerializer(jestApiDOMSerializer);

--- a/packages/apidom-ns-json-schema-draft-7/test/predicates.ts
+++ b/packages/apidom-ns-json-schema-draft-7/test/predicates.ts
@@ -7,7 +7,7 @@ import {
   JSONSchemaElement,
   JSONReferenceElement,
   LinkDescriptionElement,
-} from '../src';
+} from '../src/index.ts';
 
 describe('predicates', function () {
   context('isJSONSchemaElement', function () {

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONReference/index.ts
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONReference/index.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { sexprs } from '@swagger-api/apidom-core';
 
-import { JSONReferenceElement } from '../../../../src';
+import { JSONReferenceElement } from '../../../../src/index.ts';
 
 describe('refractor', function () {
   context('elements', function () {

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONSchema/index.ts
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONSchema/index.ts
@@ -1,7 +1,7 @@
 import { assert, expect } from 'chai';
 import { ObjectElement, sexprs, toValue } from '@swagger-api/apidom-core';
 
-import { JSONSchemaElement } from '../../../../src';
+import { JSONSchemaElement } from '../../../../src/index.ts';
 
 describe('refractor', function () {
   context('elements', function () {

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/LinkDescription/index.ts
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/LinkDescription/index.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { sexprs } from '@swagger-api/apidom-core';
 
-import { LinkDescriptionElement } from '../../../../src';
+import { LinkDescriptionElement } from '../../../../src/index.ts';
 
 describe('refractor', function () {
   context('elements', function () {

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/index.ts
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/index.ts
@@ -5,8 +5,12 @@ import { assert, expect } from 'chai';
 import sinon from 'sinon';
 import { ObjectElement, toValue, Namespace } from '@swagger-api/apidom-core';
 
-import { JSONSchemaElement, LinkDescriptionElement, isLinkDescriptionElement } from '../../src';
-import * as predicates from '../../src/predicates';
+import {
+  JSONSchemaElement,
+  LinkDescriptionElement,
+  isLinkDescriptionElement,
+} from '../../src/index.ts';
+import * as predicates from '../../src/predicates.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/plugins/replace-empty-element/mappings.ts
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/plugins/replace-empty-element/mappings.ts
@@ -3,7 +3,7 @@ import dedent from 'dedent';
 import { sexprs, SourceMapElement } from '@swagger-api/apidom-core';
 import { parse } from '@swagger-api/apidom-parser-adapter-yaml-1-2';
 
-import { refractorPluginReplaceEmptyElement, JSONSchemaElement } from '../../../../src';
+import { refractorPluginReplaceEmptyElement, JSONSchemaElement } from '../../../../src/index.ts';
 
 describe('given empty value for field additionalItems', function () {
   it('should replace empty value with semantic element', async function () {

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/plugins/replace-empty-element/sequences.ts
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/plugins/replace-empty-element/sequences.ts
@@ -3,7 +3,7 @@ import dedent from 'dedent';
 import { sexprs, SourceMapElement } from '@swagger-api/apidom-core';
 import { parse } from '@swagger-api/apidom-parser-adapter-yaml-1-2';
 
-import { refractorPluginReplaceEmptyElement, JSONSchemaElement } from '../../../../src';
+import { refractorPluginReplaceEmptyElement, JSONSchemaElement } from '../../../../src/index.ts';
 
 describe('given empty value for field allOf', function () {
   it('should replace empty value with semantic element', async function () {

--- a/packages/apidom-ns-json-schema-draft-7/test/tsconfig.json
+++ b/packages/apidom-ns-json-schema-draft-7/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": [
+    "."
+  ]
+}

--- a/packages/apidom-ns-json-schema-draft-7/tsconfig.declaration.json
+++ b/packages/apidom-ns-json-schema-draft-7/tsconfig.declaration.json
@@ -1,8 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": [
-    "test/**/*"
-  ],
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "types",

--- a/packages/apidom-ns-json-schema-draft-7/tsconfig.json
+++ b/packages/apidom-ns-json-schema-draft-7/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": true
+  },
   "include": [
-    "src/**/*",
-    "test/**/*"
+    "src/**/*"
   ]
 }


### PR DESCRIPTION
Refs #4385

**NOTE:** the errors should be gone once [`apidom-ns-json-schema-draft-6`](https://github.com/swagger-api/apidom/pull/4460) is transformed.