### PR TITLE
build(parser-adapter-workflows-yaml-1): use nodenext for TypeScript modules

### DIFF
--- a/packages/apidom-parser-adapter-workflows-yaml-1/.eslintrc
+++ b/packages/apidom-parser-adapter-workflows-yaml-1/.eslintrc
@@ -1,0 +1,22 @@
+{
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "project": ["./tsconfig.json"]
+      }
+    }
+  },
+  "rules": {
+    "import/extensions": [
+      "error",
+      "always",
+      {
+        "ts": "always",
+        "tsx": "always",
+        "js": "always",
+        "jsx": "never",
+        "ignorePackages": true
+      }
+    ]
+  }
+}

--- a/packages/apidom-parser-adapter-workflows-yaml-1/package.json
+++ b/packages/apidom-parser-adapter-workflows-yaml-1/package.json
@@ -24,8 +24,8 @@
     "lint": "eslint ./",
     "lint:fix": "eslint ./ --fix",
     "clean": "rimraf --glob 'src/**/*.mjs' 'src/**/*.cjs' 'test/**/*.mjs' ./dist ./types",
-    "typescript:check-types": "tsc --noEmit",
-    "typescript:declaration": "tsc -p declaration.tsconfig.json && rollup -c config/rollup/types.dist.js",
+    "typescript:check-types": "tsc --noEmit && tsc -p ./test/tsconfig.json --noEmit",
+    "typescript:declaration": "tsc -p tsconfig.declaration.json && rollup -c config/rollup/types.dist.js",
     "test": "npm run build:es && cross-env BABEL_ENV=es babel test --out-dir test --extensions '.ts' --out-file-extension '.mjs' --root-mode 'upward' && cross-env NODE_ENV=test mocha",
     "prepack": "copyfiles -u 3 ../../LICENSES/* LICENSES && copyfiles -u 2 ../../NOTICE .",
     "postpack": "rimraf NOTICE LICENSES"

--- a/packages/apidom-parser-adapter-workflows-yaml-1/src/adapter.ts
+++ b/packages/apidom-parser-adapter-workflows-yaml-1/src/adapter.ts
@@ -9,7 +9,7 @@ import workflowsNamespace, {
   WorkflowsSpecification1Element,
 } from '@swagger-api/apidom-ns-workflows-1';
 
-export { default as mediaTypes } from './media-types';
+export { default as mediaTypes } from './media-types.ts';
 
 export const detectionRegExp =
   /(?<YAML>^(["']?)workflowsSpec\2\s*:\s*(["']?)(?<version_yaml>1\.(?:[1-9]\d*|0)\.(?:[1-9]\d*|0))\3(?:\s+|$))|(?<JSON>"workflowsSpec"\s*:\s*"(?<version_json>1\.(?:[1-9]\d*|0)\.(?:[1-9]\d*|0))")/m;

--- a/packages/apidom-parser-adapter-workflows-yaml-1/test/adapter.ts
+++ b/packages/apidom-parser-adapter-workflows-yaml-1/test/adapter.ts
@@ -6,7 +6,7 @@ import dedent from 'dedent';
 import { isParseResultElement, SourceMapElement, sexprs } from '@swagger-api/apidom-core';
 import { isWorkflowsSpecification1Element } from '@swagger-api/apidom-ns-workflows-1';
 
-import * as adapter from '../src/adapter';
+import * as adapter from '../src/adapter.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const jsonSpec = fs

--- a/packages/apidom-parser-adapter-workflows-yaml-1/test/media-types.ts
+++ b/packages/apidom-parser-adapter-workflows-yaml-1/test/media-types.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import ApiDOMParser from '@swagger-api/apidom-parser';
 
-import * as workflowsYamlAdapter from '../src/adapter';
+import * as workflowsYamlAdapter from '../src/adapter.ts';
 
 describe('given adapter is used in parser', function () {
   const parser = new ApiDOMParser().use(workflowsYamlAdapter);

--- a/packages/apidom-parser-adapter-workflows-yaml-1/test/mocha-bootstrap.ts
+++ b/packages/apidom-parser-adapter-workflows-yaml-1/test/mocha-bootstrap.ts
@@ -2,9 +2,9 @@ import * as chai from 'chai';
 import { jestSnapshotPlugin, addSerializer } from 'mocha-chai-jest-snapshot';
 
 // @ts-ignore
-import * as jestApiDOMSerializer from '../../../scripts/jest-serializer-apidom';
+import * as jestApiDOMSerializer from '../../../scripts/jest-serializer-apidom.mjs';
 // @ts-ignore
-import * as jestStringSerializer from '../../../scripts/jest-serializer-string';
+import * as jestStringSerializer from '../../../scripts/jest-serializer-string.mjs';
 
 chai.use(jestSnapshotPlugin());
 addSerializer(jestApiDOMSerializer);

--- a/packages/apidom-parser-adapter-workflows-yaml-1/test/tsconfig.json
+++ b/packages/apidom-parser-adapter-workflows-yaml-1/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": [
+    "."
+  ]
+}

--- a/packages/apidom-parser-adapter-workflows-yaml-1/tsconfig.declaration.json
+++ b/packages/apidom-parser-adapter-workflows-yaml-1/tsconfig.declaration.json
@@ -1,8 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": [
-    "test/**/*"
-  ],
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "types",

--- a/packages/apidom-parser-adapter-workflows-yaml-1/tsconfig.json
+++ b/packages/apidom-parser-adapter-workflows-yaml-1/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": true
+  },
   "include": [
-    "src/**/*",
-    "test/**/*"
+    "src/**/*"
   ]
 }


### PR DESCRIPTION
Refs #4385
