### PR TITLE
fix(parser-apadter-ads): include files needed by main entry point

### DIFF
--- a/packages/apidom-logging/package.json
+++ b/packages/apidom-logging/package.json
@@ -42,9 +42,9 @@
     "@swagger-api/apidom-error": "*"
   },
   "files": [
-    "cjs/",
+    "src/**/*.mjs",
+    "src/**/*.cjs",
     "dist/",
-    "es/",
     "types/apidom-logging.d.ts",
     "LICENSES",
     "NOTICE",

--- a/packages/apidom-parser-adapter-api-design-systems-json/package.json
+++ b/packages/apidom-parser-adapter-api-design-systems-json/package.json
@@ -46,9 +46,9 @@
     "ramda-adjunct": "^5.0.0"
   },
   "files": [
-    "cjs/",
+    "src/**/*.mjs",
+    "src/**/*.cjs",
     "dist/",
-    "es/",
     "types/apidom-parser-adapter-api-design-systems-json.d.ts",
     "LICENSES",
     "NOTICE",


### PR DESCRIPTION
Some packages were missing inclusion of `*.mjs` or `*.cjs` artifacts into npm dist package.

Refs #4539