### PR TITLE
fix(release): auto-fix package-lock.json after release

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     }
   },
   "scripts": {
+    "version": "npm install",
     "prebuild": "cd ./node_modules/tree-sitter && node-gyp rebuild && cd ../tree-sitter-json && tree-sitter generate ./grammar.js && tree-sitter build --wasm && node-gyp rebuild && cd ../@tree-sitter-grammars/tree-sitter-yaml && tree-sitter generate ./grammar.js && tree-sitter build --wasm && node-gyp rebuild",
     "build": "lerna run build",
     "build:es": "lerna run build:es",


### PR DESCRIPTION
root level `version` npm script is run updater dependency update
and before the release commit is created. This gives us chance to
fix the corrupted package-lock.json before commiting the changes.