### PR TITLE
fix: Remove unnecessary dependency entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26484,6 +26484,7 @@
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
         "@swagger-api/apidom-core": "^1.0.0-beta.31",
+        "@swagger-api/apidom-error": "^1.0.0-beta.31",
         "@types/ramda": "~0.30.0",
         "axios": "^1.8.2",
         "minimatch": "^7.4.3",
@@ -26492,7 +26493,6 @@
         "ramda-adjunct": "^5.0.0"
       },
       "devDependencies": {
-        "@swagger-api/apidom-error": "*",
         "@swagger-api/apidom-json-pointer": "*",
         "@swagger-api/apidom-ns-arazzo-1": "*",
         "@swagger-api/apidom-ns-asyncapi-2": "*",
@@ -26516,7 +26516,6 @@
         "axios-mock-adapter": "^2.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-error": "^1.0.0-beta.3 <1.0.0-rc.0",
         "@swagger-api/apidom-json-pointer": "^1.0.0-beta.3 <1.0.0-rc.0",
         "@swagger-api/apidom-ns-arazzo-1": "^1.0.0-beta.3 <1.0.0-rc.0",
         "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.3 <1.0.0-rc.0",

--- a/packages/apidom-reference/package.json
+++ b/packages/apidom-reference/package.json
@@ -268,7 +268,6 @@
     "ramda-adjunct": "^5.0.0"
   },
   "optionalDependencies": {
-    "@swagger-api/apidom-error": "^1.0.0-beta.3 <1.0.0-rc.0",
     "@swagger-api/apidom-json-pointer": "^1.0.0-beta.3 <1.0.0-rc.0",
     "@swagger-api/apidom-ns-arazzo-1": "^1.0.0-beta.3 <1.0.0-rc.0",
     "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.3 <1.0.0-rc.0",
@@ -291,7 +290,6 @@
     "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.3 <1.0.0-rc.0"
   },
   "devDependencies": {
-    "@swagger-api/apidom-error": "*",
     "@swagger-api/apidom-json-pointer": "*",
     "@swagger-api/apidom-ns-arazzo-1": "*",
     "@swagger-api/apidom-ns-asyncapi-2": "*",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

In https://github.com/swagger-api/apidom/pull/4154 `apidom-error` was added as a direct dependency, but wasn't removed as an optional or dev dependency. Given it is now required directly, let's just drop it from the optional and the dev lists.

﻿### Motivation and Context

Some internal tooling had problems with it, as yarn@1 lockfiles end up in a weird state when a dependency is both required and optional

### How Has This Been Tested?

🤷 

### Screenshots (if appropriate):

N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains...
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
