### PR TITLE
fix(ls): fix validation of writeOnly and readOnly properties

### DIFF
--- a/packages/apidom-ls/src/services/validation/linter-functions.ts
+++ b/packages/apidom-ls/src/services/validation/linter-functions.ts
@@ -356,9 +356,10 @@ export const standardLinterfunctions: FunctionItem[] = [
 
       const fields = keys.map((key) => element.get(key)).filter(Boolean);
 
-      if (fields.length === 0) {
+      if (fields.length !== keys.length) {
         return true;
       }
+
       return !fields.every((field) => {
         const elValue = toValue(field);
 

--- a/packages/apidom-ls/test/fixtures/validation/oas/schema-read-only-write-only.yaml
+++ b/packages/apidom-ls/test/fixtures/validation/oas/schema-read-only-write-only.yaml
@@ -16,6 +16,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PropertyToTest'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/PropertyToTestNoError'
 components:
   schemas:
     PropertyToTest:
@@ -30,6 +33,22 @@ components:
           format: uuid
           readOnly: true
           writeOnly: true
+        fieldname:
+          type: string
+        fieldDate:
+          type: string
+          format: date-time
+    PropertyToTestNoError:
+      type: object
+      required:
+        - id
+        - fieldname
+        - fieldDate
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
         fieldname:
           type: string
         fieldDate:

--- a/packages/apidom-ls/test/validate.ts
+++ b/packages/apidom-ls/test/validate.ts
@@ -5187,11 +5187,11 @@ describe('apidom-ls-validate', function () {
         range: {
           end: {
             character: 10,
-            line: 27,
+            line: 30,
           },
           start: {
             character: 8,
-            line: 27,
+            line: 30,
           },
         },
         severity: 1,


### PR DESCRIPTION
Fixes validation rule applying when only `writeOnly` or `readOnly` was present and set to `true`.

Before:
<img width="862" height="351" alt="Screenshot 2025-11-21 at 12 15 52" src="https://github.com/user-attachments/assets/8f8ef09f-cdde-4469-bd81-f37e8fc50400" />

After:
<img width="824" height="187" alt="Screenshot 2025-11-21 at 12 15 28" src="https://github.com/user-attachments/assets/ddab589e-45a1-498e-acae-c7ecd06fd20a" />
