### PR TITLE
fix(ns-asyncapi-3): implement SpecificationExtensionVisitor

### DIFF
--- a/packages/apidom-ns-asyncapi-3/src/refractor/specification.ts
+++ b/packages/apidom-ns-asyncapi-3/src/refractor/specification.ts
@@ -22,6 +22,7 @@ import DefaultContentTypeVisitor from './visitors/async-api-3/DefaultContentType
 import ExternalDocumentationOrReferenceVisitor from './visitors/async-api-3/external-documentation-object/ExternalDocumentationOrReferenceVisitor.ts';
 import ExternalDocumentationVisitor from './visitors/async-api-3/external-documentation-object/index.ts';
 import FallbackVisitor from './visitors/FallbackVisitor.ts';
+import SpecificationExtensionVisitor from './visitors/SpecificationExtensionVisitor.ts';
 import IdentifierVisitor from './visitors/async-api-3/IdentifierVisitor.ts';
 import InfoVisitor from './visitors/async-api-3/info/info.ts';
 import LicenseVisitor from './visitors/async-api-3/license/index.ts';
@@ -1459,6 +1460,9 @@ const specification = {
             },
           },
         },
+      },
+      extension: {
+        $visitor: SpecificationExtensionVisitor,
       },
     },
   },

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/AsyncApi3/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/AsyncApi3/__snapshots__/index.ts.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refractor elements AsyncApi3Element given specification extensions should refract x- extension properties 1`] = `
+(AsyncApi3Element
+  (MemberElement
+    (StringElement)
+    (AsyncApiVersionElement))
+  (MemberElement
+    (StringElement)
+    (InfoElement
+      (MemberElement
+        (StringElement)
+        (StringElement))
+      (MemberElement
+        (StringElement)
+        (StringElement))))
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (ObjectElement
+      (MemberElement
+        (StringElement)
+        (StringElement)))))
+`;
+
 exports[`refractor elements AsyncApi3Element should refract to semantic ApiDOM tree 1`] = `
 (AsyncApi3Element
   (MemberElement

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/AsyncApi3/index.ts
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/AsyncApi3/index.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { sexprs, includesClasses, ObjectElement } from '@swagger-api/apidom-core';
 
 import { AsyncApi3Element } from '../../../../src/index.ts';
 
@@ -19,6 +19,38 @@ describe('refractor', function () {
         });
 
         expect(sexprs(asyncApiElement)).toMatchSnapshot();
+      });
+
+      context('given specification extensions', function () {
+        specify('should refract x- extension properties', function () {
+          const asyncApiElement = AsyncApi3Element.refract({
+            asyncapi: '3.0.0',
+            info: {
+              title: 'Test API',
+              version: '1.0.0',
+            },
+            'x-custom-extension': 'custom value',
+            'x-another-extension': {
+              nested: 'property',
+            },
+          });
+
+          expect(sexprs(asyncApiElement)).toMatchSnapshot();
+        });
+
+        specify('should mark x- extensions with specification-extension class', function () {
+          const asyncApiElement = AsyncApi3Element.refract({
+            asyncapi: '3.0.0',
+            info: {
+              title: 'Test API',
+              version: '1.0.0',
+            },
+            'x-custom-extension': 'custom value',
+          }) as ObjectElement;
+
+          const extensionMember = asyncApiElement.getMember('x-custom-extension');
+          expect(includesClasses(['specification-extension'], extensionMember)).to.be.true;
+        });
       });
     });
   });

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Channel/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Channel/__snapshots__/index.ts.snap
@@ -80,6 +80,16 @@ exports[`refractor elements ChannelElement given parameters field contains field
             (StringElement)))))))
 `;
 
+exports[`refractor elements ChannelElement given specification extensions should refract x- extension properties 1`] = `
+(ChannelElement
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement)))
+`;
+
 exports[`refractor elements ChannelElement given tags field contains list of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (ChannelElement
   (MemberElement

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Channel/index.ts
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Channel/index.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { sexprs, includesClasses, ObjectElement } from '@swagger-api/apidom-core';
 
 import { ChannelElement } from '../../../../src/index.ts';
 
@@ -135,6 +135,27 @@ describe('refractor', function () {
           });
 
           expect(sexprs(channelElement)).toMatchSnapshot();
+        });
+      });
+
+      context('given specification extensions', function () {
+        specify('should refract x- extension properties', function () {
+          const channelElement = ChannelElement.refract({
+            address: '/user/signedup',
+            'x-internal-name': 'user-signup-channel',
+          });
+
+          expect(sexprs(channelElement)).toMatchSnapshot();
+        });
+
+        specify('should mark x- extensions with specification-extension class', function () {
+          const channelElement = ChannelElement.refract({
+            address: '/user/signedup',
+            'x-internal-name': 'user-signup-channel',
+          }) as ObjectElement;
+
+          const extensionMember = channelElement.getMember('x-internal-name');
+          expect(includesClasses(['specification-extension'], extensionMember)).to.be.true;
         });
       });
     });

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Components/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Components/__snapshots__/index.ts.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refractor elements ComponentsElement given specification extensions should refract x- extension properties 1`] = `
+(ComponentsElement
+  (MemberElement
+    (StringElement)
+    (ObjectElement))
+  (MemberElement
+    (StringElement)
+    (BooleanElement)))
+`;
+
 exports[`refractor elements ComponentsElement should refract to semantic ApiDOM tree 1`] = `
 (ComponentsElement
   (MemberElement

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Components/index.ts
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Components/index.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { sexprs, includesClasses, ObjectElement } from '@swagger-api/apidom-core';
 
 import { ComponentsElement } from '../../../../src/index.ts';
 
@@ -132,6 +132,27 @@ describe('refractor', function () {
         });
 
         expect(sexprs(componentsElement)).toMatchSnapshot();
+      });
+
+      context('given specification extensions', function () {
+        specify('should refract x- extension properties', function () {
+          const componentsElement = ComponentsElement.refract({
+            schemas: {},
+            'x-internal-components': true,
+          });
+
+          expect(sexprs(componentsElement)).toMatchSnapshot();
+        });
+
+        specify('should mark x- extensions with specification-extension class', function () {
+          const componentsElement = ComponentsElement.refract({
+            schemas: {},
+            'x-internal-components': true,
+          }) as ObjectElement;
+
+          const extensionMember = componentsElement.getMember('x-internal-components');
+          expect(includesClasses(['specification-extension'], extensionMember)).to.be.true;
+        });
       });
     });
   });

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Contact/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Contact/__snapshots__/index.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refractor elements ContactElement given specification extensions should refract x- extension properties 1`] = `
+(ContactElement
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement)))
+`;
+
 exports[`refractor elements ContactElement should refract to semantic ApiDOM tree 1`] = `
 (ContactElement
   (MemberElement

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Contact/index.ts
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Contact/index.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { sexprs, includesClasses, ObjectElement } from '@swagger-api/apidom-core';
 
 import { ContactElement } from '../../../../src/index.ts';
 
@@ -14,6 +14,29 @@ describe('refractor', function () {
         });
 
         expect(sexprs(contactElement)).toMatchSnapshot();
+      });
+
+      context('given specification extensions', function () {
+        specify('should refract x- extension properties', function () {
+          const contactElement = ContactElement.refract({
+            name: 'API Support',
+            email: 'support@example.com',
+            'x-slack-channel': '#api-support',
+          });
+
+          expect(sexprs(contactElement)).toMatchSnapshot();
+        });
+
+        specify('should mark x- extensions with specification-extension class', function () {
+          const contactElement = ContactElement.refract({
+            name: 'API Support',
+            email: 'support@example.com',
+            'x-slack-channel': '#api-support',
+          }) as ObjectElement;
+
+          const extensionMember = contactElement.getMember('x-slack-channel');
+          expect(includesClasses(['specification-extension'], extensionMember)).to.be.true;
+        });
       });
     });
   });

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Info/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Info/__snapshots__/index.ts.snap
@@ -17,6 +17,25 @@ exports[`refractor elements InfoElement given externalDocs field of type Referen
         (StringElement)))))
 `;
 
+exports[`refractor elements InfoElement given specification extensions should refract x- extension properties 1`] = `
+(InfoElement
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (ObjectElement
+      (MemberElement
+        (StringElement)
+        (StringElement)))))
+`;
+
 exports[`refractor elements InfoElement given tags field contains list of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (InfoElement
   (MemberElement

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Info/index.ts
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Info/index.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { sexprs, includesClasses, ObjectElement } from '@swagger-api/apidom-core';
 
 import { InfoElement } from '../../../../src/index.ts';
 
@@ -69,6 +69,52 @@ describe('refractor', function () {
           });
 
           expect(sexprs(infoElement)).toMatchSnapshot();
+        });
+      });
+
+      context('given specification extensions', function () {
+        specify('should refract x- extension properties', function () {
+          const infoElement = InfoElement.refract({
+            title: 'Test API',
+            version: '1.0.0',
+            'x-api-id': 'unique-id',
+            'x-metadata': {
+              owner: 'team-a',
+            },
+          });
+
+          expect(sexprs(infoElement)).toMatchSnapshot();
+        });
+
+        specify('should mark x- extensions with specification-extension class', function () {
+          const infoElement = InfoElement.refract({
+            title: 'Test API',
+            version: '1.0.0',
+            'x-api-id': 'unique-id',
+          }) as ObjectElement;
+
+          const extensionMember = infoElement.getMember('x-api-id');
+          expect(includesClasses(['specification-extension'], extensionMember)).to.be.true;
+        });
+
+        specify('should handle multiple x- extensions', function () {
+          const infoElement = InfoElement.refract({
+            title: 'Test API',
+            version: '1.0.0',
+            'x-api-id': 'unique-id',
+            'x-owner': 'team-a',
+            'x-metadata': {
+              created: '2023-01-01',
+            },
+          }) as ObjectElement;
+
+          const apiIdMember = infoElement.getMember('x-api-id');
+          const ownerMember = infoElement.getMember('x-owner');
+          const metadataMember = infoElement.getMember('x-metadata');
+
+          expect(includesClasses(['specification-extension'], apiIdMember)).to.be.true;
+          expect(includesClasses(['specification-extension'], ownerMember)).to.be.true;
+          expect(includesClasses(['specification-extension'], metadataMember)).to.be.true;
         });
       });
     });

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/License/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/License/__snapshots__/index.ts.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refractor elements LicenseElement given specification extensions should refract x- extension properties 1`] = `
+(LicenseElement
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement)))
+`;
+
 exports[`refractor elements LicenseElement should refract to semantic ApiDOM tree 1`] = `
 (LicenseElement
   (MemberElement

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/License/index.ts
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/License/index.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { sexprs, includesClasses, ObjectElement } from '@swagger-api/apidom-core';
 
 import { LicenseElement } from '../../../../src/index.ts';
 
@@ -13,6 +13,27 @@ describe('refractor', function () {
         });
 
         expect(sexprs(licenseElement)).toMatchSnapshot();
+      });
+
+      context('given specification extensions', function () {
+        specify('should refract x- extension properties', function () {
+          const licenseElement = LicenseElement.refract({
+            name: 'Apache 2.0',
+            'x-internal-id': 'license-123',
+          });
+
+          expect(sexprs(licenseElement)).toMatchSnapshot();
+        });
+
+        specify('should mark x- extensions with specification-extension class', function () {
+          const licenseElement = LicenseElement.refract({
+            name: 'Apache 2.0',
+            'x-internal-id': 'license-123',
+          }) as ObjectElement;
+
+          const extensionMember = licenseElement.getMember('x-internal-id');
+          expect(includesClasses(['specification-extension'], extensionMember)).to.be.true;
+        });
       });
     });
   });

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Message/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Message/__snapshots__/index.ts.snap
@@ -146,6 +146,16 @@ exports[`refractor elements given payload field of type SchemaElement should ref
     (SchemaElement)))
 `;
 
+exports[`refractor elements given specification extensions should refract x- extension properties 1`] = `
+(MessageElement
+  (MemberElement
+    (StringElement)
+    (SchemaElement))
+  (MemberElement
+    (StringElement)
+    (StringElement)))
+`;
+
 exports[`refractor elements given tags field contains list of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (MessageElement
   (MemberElement

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Message/index.ts
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Message/index.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { sexprs, includesClasses, ObjectElement } from '@swagger-api/apidom-core';
 
 import { MessageElement } from '../../../../src/index.ts';
 
@@ -208,6 +208,27 @@ describe('refractor', function () {
         });
 
         expect(sexprs(messageElement)).toMatchSnapshot();
+      });
+    });
+
+    context('given specification extensions', function () {
+      specify('should refract x- extension properties', function () {
+        const messageElement = MessageElement.refract({
+          payload: {},
+          'x-message-type': 'event',
+        });
+
+        expect(sexprs(messageElement)).toMatchSnapshot();
+      });
+
+      specify('should mark x- extensions with specification-extension class', function () {
+        const messageElement = MessageElement.refract({
+          payload: {},
+          'x-message-type': 'event',
+        }) as ObjectElement;
+
+        const extensionMember = messageElement.getMember('x-message-type');
+        expect(includesClasses(['specification-extension'], extensionMember)).to.be.true;
       });
     });
   });

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Operation/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Operation/__snapshots__/index.ts.snap
@@ -73,6 +73,22 @@ exports[`refractor elements OperationElement given security field contains list 
           (ArrayElement))))))
 `;
 
+exports[`refractor elements OperationElement given specification extensions should refract x- extension properties 1`] = `
+(OperationElement
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (ReferenceElement
+      (MemberElement
+        (StringElement)
+        (StringElement))))
+  (MemberElement
+    (StringElement)
+    (NumberElement)))
+`;
+
 exports[`refractor elements OperationElement given tags field contains list of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (OperationElement
   (MemberElement

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Operation/index.ts
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Operation/index.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { sexprs, includesClasses, ObjectElement } from '@swagger-api/apidom-core';
 
 import { OperationElement } from '../../../../src/index.ts';
 
@@ -154,6 +154,29 @@ describe('refractor', function () {
           });
 
           expect(sexprs(operationElement)).toMatchSnapshot();
+        });
+      });
+
+      context('given specification extensions', function () {
+        specify('should refract x- extension properties', function () {
+          const operationElement = OperationElement.refract({
+            action: 'send',
+            channel: { $ref: '#/channels/userSignup' },
+            'x-rate-limit': 100,
+          });
+
+          expect(sexprs(operationElement)).toMatchSnapshot();
+        });
+
+        specify('should mark x- extensions with specification-extension class', function () {
+          const operationElement = OperationElement.refract({
+            action: 'send',
+            channel: { $ref: '#/channels/userSignup' },
+            'x-rate-limit': 100,
+          }) as ObjectElement;
+
+          const extensionMember = operationElement.getMember('x-rate-limit');
+          expect(includesClasses(['specification-extension'], extensionMember)).to.be.true;
         });
       });
     });

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Server/__snapshots__/index.ts.snap
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Server/__snapshots__/index.ts.snap
@@ -53,6 +53,22 @@ exports[`refractor elements ServerElement given security field values contain Se
       (SecuritySchemeElement))))
 `;
 
+exports[`refractor elements ServerElement given specification extensions should refract x- extension properties 1`] = `
+(ServerElement
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement))
+  (MemberElement
+    (StringElement)
+    (StringElement)))
+`;
+
 exports[`refractor elements ServerElement given tags field contains list of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (ServerElement
   (MemberElement

--- a/packages/apidom-ns-asyncapi-3/test/refractor/elements/Server/index.ts
+++ b/packages/apidom-ns-asyncapi-3/test/refractor/elements/Server/index.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { sexprs } from '@swagger-api/apidom-core';
+import { sexprs, includesClasses, ObjectElement } from '@swagger-api/apidom-core';
 
 import { ServerElement } from '../../../../src/index.ts';
 
@@ -126,6 +126,30 @@ describe('refractor', function () {
           });
 
           expect(sexprs(serverElement)).toMatchSnapshot();
+        });
+      });
+
+      context('given specification extensions', function () {
+        specify('should refract x- extension properties', function () {
+          const serverElement = ServerElement.refract({
+            host: 'api.example.com',
+            protocol: 'mqtt',
+            'x-region': 'us-east-1',
+            'x-environment': 'production',
+          });
+
+          expect(sexprs(serverElement)).toMatchSnapshot();
+        });
+
+        specify('should mark x- extensions with specification-extension class', function () {
+          const serverElement = ServerElement.refract({
+            host: 'api.example.com',
+            protocol: 'mqtt',
+            'x-region': 'us-east-1',
+          }) as ObjectElement;
+
+          const extensionMember = serverElement.getMember('x-region');
+          expect(includesClasses(['specification-extension'], extensionMember)).to.be.true;
         });
       });
     });


### PR DESCRIPTION
Register SpecificationExtensionVisitor in the refractor specification to handle x- prefixed extension properties. This enables proper refraction of specification extensions across all AsyncAPI 3 elements, marking them with the 'specification-extension' class for identification.