### PR TITLE
feat: add missing lint rule for allowed fields for AsyncAPI3 (swg-16802)

### DIFF
--- a/packages/apidom-ls/src/config/asyncapi/asyncapi3/lint/allowed-fields.ts
+++ b/packages/apidom-ls/src/config/asyncapi/asyncapi3/lint/allowed-fields.ts
@@ -1,4 +1,30 @@
-import { LinterMeta } from '../../../../apidom-language-types.ts';
+import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
-const allowedFieldsLint: LinterMeta = {};
+import ApilintCodes from '../../../codes.ts';
+import { LinterMeta } from '../../../../apidom-language-types.ts';
+import { AsyncAPI3 } from '../../target-specs.ts';
+
+const allowedFieldsLint: LinterMeta = {
+	code: ApilintCodes.NOT_ALLOWED_FIELDS,
+	source: 'apilint',
+	message: 'Object includes not allowed fields',
+	severity: DiagnosticSeverity.Error,
+	linterFunction: 'allowedFields',
+	linterParams: [
+		[
+			'asyncapi',
+			'id',
+			'info',
+			'servers',
+			'defaultContentType',
+			'channels',
+			'operations',
+			'components',
+		],
+		'x-',
+	],
+	marker: 'key',
+	targetSpecs: AsyncAPI3,
+};
+
 export default allowedFieldsLint;

--- a/packages/apidom-ls/src/config/asyncapi/asyncapi3/lint/allowed-fields.ts
+++ b/packages/apidom-ls/src/config/asyncapi/asyncapi3/lint/allowed-fields.ts
@@ -5,26 +5,26 @@ import { LinterMeta } from '../../../../apidom-language-types.ts';
 import { AsyncAPI3 } from '../../target-specs.ts';
 
 const allowedFieldsLint: LinterMeta = {
-	code: ApilintCodes.NOT_ALLOWED_FIELDS,
-	source: 'apilint',
-	message: 'Object includes not allowed fields',
-	severity: DiagnosticSeverity.Error,
-	linterFunction: 'allowedFields',
-	linterParams: [
-		[
-			'asyncapi',
-			'id',
-			'info',
-			'servers',
-			'defaultContentType',
-			'channels',
-			'operations',
-			'components',
-		],
-		'x-',
-	],
-	marker: 'key',
-	targetSpecs: AsyncAPI3,
+  code: ApilintCodes.NOT_ALLOWED_FIELDS,
+  source: 'apilint',
+  message: 'Object includes not allowed fields',
+  severity: DiagnosticSeverity.Error,
+  linterFunction: 'allowedFields',
+  linterParams: [
+    [
+      'asyncapi',
+      'id',
+      'info',
+      'servers',
+      'defaultContentType',
+      'channels',
+      'operations',
+      'components',
+    ],
+    'x-',
+  ],
+  marker: 'key',
+  targetSpecs: AsyncAPI3,
 };
 
 export default allowedFieldsLint;


### PR DESCRIPTION
This PR adds missing linting rule for allowed fileds for AsyncAPI3

### Description
<!--- Describe your changes in detail -->



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Closes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains...
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
