### PR TITLE
fix(reference): skip transcluded Example value in mutual-exclusion check

### DIFF
--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
@@ -895,6 +895,11 @@ class OpenAPI3_0DereferenceVisitor {
       return undefined;
     }
 
+    // ignore already dereferenced ExampleElement; value field was transcluded from externalValue field
+    if (exampleElement.value?.meta.hasKey('ref-origin')) {
+      return undefined;
+    }
+
     // value and externalValue fields are mutually exclusive
     if (exampleElement.hasKey('value') && isStringElement(exampleElement.externalValue)) {
       const error = new ApiDOMError(

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
@@ -972,6 +972,11 @@ class OpenAPI3_1DereferenceVisitor {
       return undefined;
     }
 
+    // ignore already dereferenced ExampleElement; value field was transcluded from externalValue field
+    if (exampleElement.value?.meta.hasKey('ref-origin')) {
+      return undefined;
+    }
+
     // value and externalValue fields are mutually exclusive
     if (exampleElement.hasKey('value') && isStringElement(exampleElement.externalValue)) {
       const error = new ApiDOMError(

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-2/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-2/visitor.ts
@@ -1095,6 +1095,11 @@ class OpenAPI3_2DereferenceVisitor {
       return undefined;
     }
 
+    // ignore already dereferenced ExampleElement; value field was transcluded from externalValue field
+    if (exampleElement.value?.meta.hasKey('ref-origin')) {
+      return undefined;
+    }
+
     // value and externalValue fields are mutually exclusive
     if (exampleElement.hasKey('value') && isStringElement(exampleElement.externalValue)) {
       const error = new ApiDOMError(

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/example-object/fixtures/external-value-path-item-ref/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/example-object/fixtures/external-value-path-item-ref/dereferenced.json
@@ -1,0 +1,30 @@
+[
+  {
+    "openapi": "3.0.4",
+    "paths": {
+      "/path1": {
+        "post": {
+          "responses": {
+            "200": {
+              "description": "200 response",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "example1": {
+                      "description": "example1 description",
+                      "externalValue": "./ex.json",
+                      "value": {
+                        "prop1": "value1",
+                        "prop2": "value2"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/example-object/fixtures/external-value-path-item-ref/entry.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/example-object/fixtures/external-value-path-item-ref/entry.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.4",
+  "paths": {
+    "/path1": {
+      "$ref": "./path-item.json"
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/example-object/fixtures/external-value-path-item-ref/ex.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/example-object/fixtures/external-value-path-item-ref/ex.json
@@ -1,0 +1,4 @@
+{
+  "prop1": "value1",
+  "prop2": "value2"
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/example-object/fixtures/external-value-path-item-ref/path-item.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/example-object/fixtures/external-value-path-item-ref/path-item.json
@@ -1,0 +1,19 @@
+{
+  "post": {
+    "responses": {
+      "200": {
+        "description": "200 response",
+        "content": {
+          "application/json": {
+            "examples": {
+              "example1": {
+                "description": "example1 description",
+                "externalValue": "./ex.json"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-0/example-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-0/example-object/index.ts
@@ -160,6 +160,23 @@ describe('dereference', function () {
             });
           });
 
+          context(
+            'given Example Object is inside externally referenced Path Item Object',
+            function () {
+              const fixturePath = path.join(entryFixturePath, 'external-value-path-item-ref');
+
+              specify('should dereference', async function () {
+                const entryFilePath = path.join(fixturePath, 'entry.json');
+                const actual = await dereference(entryFilePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const expected = loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+                assert.deepEqual(toValue(actual), expected);
+              });
+            },
+          );
+
           context('given both value and externalValue fields are defined', function () {
             const fixturePath = path.join(entryFixturePath, 'external-value-value-both-defined');
 

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/example-object/fixtures/external-value-path-item-ref/dereferenced.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/example-object/fixtures/external-value-path-item-ref/dereferenced.json
@@ -1,0 +1,30 @@
+[
+  {
+    "openapi": "3.1.0",
+    "paths": {
+      "/path1": {
+        "post": {
+          "responses": {
+            "200": {
+              "description": "200 response",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "example1": {
+                      "description": "example1 description",
+                      "externalValue": "./ex.json",
+                      "value": {
+                        "prop1": "value1",
+                        "prop2": "value2"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/example-object/fixtures/external-value-path-item-ref/ex.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/example-object/fixtures/external-value-path-item-ref/ex.json
@@ -1,0 +1,4 @@
+{
+  "prop1": "value1",
+  "prop2": "value2"
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/example-object/fixtures/external-value-path-item-ref/path-item.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/example-object/fixtures/external-value-path-item-ref/path-item.json
@@ -1,0 +1,19 @@
+{
+  "post": {
+    "responses": {
+      "200": {
+        "description": "200 response",
+        "content": {
+          "application/json": {
+            "examples": {
+              "example1": {
+                "description": "example1 description",
+                "externalValue": "./ex.json"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/example-object/fixtures/external-value-path-item-ref/root.json
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/example-object/fixtures/external-value-path-item-ref/root.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.1.0",
+  "paths": {
+    "/path1": {
+      "$ref": "./path-item.json"
+    }
+  }
+}

--- a/packages/apidom-reference/test/dereference/strategies/openapi-3-1/example-object/index.ts
+++ b/packages/apidom-reference/test/dereference/strategies/openapi-3-1/example-object/index.ts
@@ -160,6 +160,23 @@ describe('dereference', function () {
             });
           });
 
+          context(
+            'given Example Object is inside externally referenced Path Item Object',
+            function () {
+              const fixturePath = path.join(rootFixturePath, 'external-value-path-item-ref');
+
+              specify('should dereference', async function () {
+                const rootFilePath = path.join(fixturePath, 'root.json');
+                const actual = await dereference(rootFilePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                });
+                const expected = loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+                assert.deepEqual(toValue(actual), expected);
+              });
+            },
+          );
+
           context('given both value and externalValue fields are defined', function () {
             const fixturePath = path.join(rootFixturePath, 'external-value-value-both-defined');
 


### PR DESCRIPTION
Fixes #5190. Also the root cause of swagger-api/swagger-ui#10418 (and the motivation behind the now-closed swagger-api/swagger-ui#10822, per @glowcloud's review there).

## Problem

When an Example Object with only `externalValue` sits inside an **externally referenced Path Item Object**, dereferencing fails with:

> ExampleElement value and externalValue fields are mutually exclusive.

The `PathItemElement` handler dereferences the external fragment with a nested visitor, then `link.replaceWith`s the merged Path Item — and the outer visitor descends into the already-dereferenced subtree. The nested pass has by then transcluded `externalValue` into `value` (annotating `value` with `ref-origin` meta) while intentionally keeping `externalValue`, so the outer pass re-visits an Example that now has both fields and trips the mutual-exclusion guard. Without the path-level `$ref` there is only one traversal, hence no error.

## Fix

In the `ExampleElement` handlers of the 3.0, 3.1, and 3.2 dereference strategies, skip elements whose `value` carries the `ref-origin` meta (i.e. the value was already transcluded by a previous pass) before applying the mutual-exclusion check. A genuine violation (both `value` and `externalValue` in source) still errors as before.

## Verification

- Reproduced the failure with the fixture from swagger-ui#10418 against `@swagger-api/apidom-reference@1.11.3`; with this guard applied the repro dereferences cleanly and the output is identical to the inline (no-`$ref`) equivalent.
- Added regression fixtures/tests `external-value-path-item-ref` to the example-object dereference suites for the 3.0 and 3.1 strategies.
- The full monorepo suite was not run locally (Windows machine constraints) — relying on CI for end-to-end validation.