### PR TITLE
ci(release): add id-token write permission to GPR release workflow

### DIFF
--- a/.github/workflows/release-to-GPR.yml
+++ b/.github/workflows/release-to-GPR.yml
@@ -16,6 +16,9 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     name: Release to GitHub Package Registry
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
       HUSKY: 0 # disabled husky and lint staged; https://typicode.github.io/husky/#/?id=with-env-variables
 


### PR DESCRIPTION
## Summary

- Adds `id-token: write` permission to the `release-to-GPR.yml` workflow
- Also adds `contents: read` (minimum required; no git push in this workflow)
- Without `id-token: write`, lerna publish fails with `EUSAGE Provenance generation in GitHub Actions requires "write" access to the "id-token" permission` when `publishConfig.provenance: true` is set (introduced in #5228)
