### PR TITLE
ci(release): add temporary workflow_dispatch trigger to GPR release workflow

### DIFF
--- a/.github/workflows/release-to-GPR.yml
+++ b/.github/workflows/release-to-GPR.yml
@@ -1,8 +1,6 @@
 name: Release monorepo packages to GitHub Package Registry
 on:
   workflow_dispatch:
-    branches:
-      - main
   workflow_run:
     workflows: ["Release monorepo packages"]
     types:
@@ -16,7 +14,7 @@ env:
 
 jobs:
   release:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Release to GitHub Package Registry
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-to-GPR.yml
+++ b/.github/workflows/release-to-GPR.yml
@@ -1,5 +1,8 @@
 name: Release monorepo packages to GitHub Package Registry
 on:
+  workflow_dispatch:
+    branches:
+      - main
   workflow_run:
     workflows: ["Release monorepo packages"]
     types:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the GPR release workflow
