### PR TITLE
Revert "ci(release): add temporary workflow_dispatch trigger to GPR release workflow"

### DIFF
--- a/.github/workflows/release-to-GPR.yml
+++ b/.github/workflows/release-to-GPR.yml
@@ -1,6 +1,5 @@
 name: Release monorepo packages to GitHub Package Registry
 on:
-  workflow_dispatch:
   workflow_run:
     workflows: ["Release monorepo packages"]
     types:
@@ -14,7 +13,7 @@ env:
 
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     name: Release to GitHub Package Registry
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Reverts swagger-api/apidom#5231

release succeeded no need for manual dispatch anymore
ref: https://github.com/swagger-api/apidom/actions/runs/34229688370